### PR TITLE
[Fix] 검증 실행 상태전이 및 CAP 스냅샷 무결성 보강

### DIFF
--- a/src/main/java/com/susukkang/fgc/cap/dto/CapCheckDetailLine.java
+++ b/src/main/java/com/susukkang/fgc/cap/dto/CapCheckDetailLine.java
@@ -6,6 +6,10 @@ import java.math.BigDecimal;
  * cap_check_detail 1건에 대응하는 산입·제외 근거 라인
  * classification 은 cap_rule_item.inclusion_status 와 같은 값(INCLUDED/EXCLUDED/REVIEW_REQUIRED)을 사용
  * IF-API-31(계산근거 팝업)이 항목명·근거자료를 그대로 노출해야 해서 itemName/evidenceRef 도 담는다.
+ *
+ * contractMonthNo 가 Integer 인 이유 — 예상 스케줄에서 온 상세행에만 회차가 있다.
+ * 귀속행(실제 지급건) 출처의 상세행에는 회차 개념이 없어 NULL 이 정당하다
+ * (ck_cap_detail_source · ck_cap_detail_month_snapshot). primitive 로 두면 언박싱에서 터진다.
  */
 public record CapCheckDetailLine(
         int detailSeq,
@@ -13,7 +17,7 @@ public record CapCheckDetailLine(
         String itemCode,
         String itemName,
         Long scheduleLineId,
-        int contractMonthNo,
+        Integer contractMonthNo,
         String classification,
         BigDecimal amount,
         String decisionReason,

--- a/src/main/resources/db/migration/V6__integrity_hardening.sql
+++ b/src/main/resources/db/migration/V6__integrity_hardening.sql
@@ -1,0 +1,577 @@
+-- ============================================================================
+-- FGC 무결성 보강 마이그레이션 v2.1.5 → v2.1.6
+-- 대상 DBMS: PostgreSQL 17
+-- 작성 기준일: 2026-08-05
+-- 결정 근거: SRC-027 FGC 정합성 설계결정서 §3-2 (D-01·D-04)
+--
+-- ── 왜 V1~V5 를 고치지 않고 V6 를 만드나 ──────────────────────────────────
+--   V1·V2·V2.1·V3·V4 는 이미 팀원 DB에 적용돼 있습니다.
+--   적용된 마이그레이션 파일을 한 글자라도 고치면 Flyway 가 체크섬 오류를 내고
+--   그 사람 앱이 아예 안 뜹니다. 그래서 전부 이 파일로 덧붙여 고칩니다.
+--
+--   ★ 이 파일은 db/migration 에 둡니다. db/demo 가 아닙니다.
+--     운영은 classpath:db/migration 만 읽고, 로컬만 db/demo 를 더 읽습니다.
+--     따라서 V6 은 V3·V4 시드가 있다고 가정하면 안 됩니다.
+--     빈 운영 DB에도, 시드가 다 들어간 로컬 DB에도 똑같이 적용돼야 합니다.
+--
+-- ── 고치는 것 5가지 ───────────────────────────────────────────────────────
+--   1) P0-1 contract_status_event.processed_at 이 원리적으로 갱신 불가능한 문제
+--          → 처리이력 전용 테이블을 새로 만든다
+--   2) P0-2 잔여 : 정책 생명주기를 INSERT 로 우회할 수 있는 문제
+--          → INSERT 가드 + 작성자·승인자 분리 CHECK
+--   3) P1-3 검증·대사 실행의 상태전이가 아무 데서나 점프되는 문제
+--          → 두 테이블이 함께 쓰는 상태전이 가드 1개
+--   4) D-01 acquisition_cost_check 에 사용률을 담을 자리가 없는 문제
+--          → 검증유형별 상세행 테이블 (2차 기능용 물리 선반영, D-03)
+--   5) P0-4 트리거 함수가 실행시점 search_path 에 의존하는 문제
+--          → fgc 스키마 함수 전체에 search_path 를 못 박는다 (맨 마지막에 실행)
+--
+-- ── 데이터 영향 ───────────────────────────────────────────────────────────
+--   기존 행을 지우거나 값을 바꾸지 않습니다.
+--   테이블 2개·함수 2개·트리거 5개·제약 1개(NOT VALID)를 추가하고,
+--   기존 함수 1개를 확장합니다.
+-- ============================================================================
+
+SET search_path TO fgc, public;
+
+
+-- ============================================================================
+-- 1. P0-1 : 계약상태 사건의 "처리했다" 기록을 담을 자리
+--
+--    무엇이 문제였나
+--      V1 은 contract_status_event 에 processed_at 컬럼을 두고(V1:662),
+--      같은 테이블에 append-only 트리거(UPDATE·DELETE 전면 금지)를 붙였습니다(V1:677).
+--      그래서 사건이 들어온 뒤에 배치가 processed_at 을 채우는 것이 불가능합니다.
+--      그런데 V2 의 적용후확인 주석(V2:243-247)은 WHERE processed_at IS NULL 로
+--      미처리 사건을 고르라고 안내합니다. 서로 모순입니다.
+--
+--    왜 컬럼을 UPDATE 가능하게 푸는 대신 표를 새로 만드나
+--      ① append-only 를 푸는 순간 "사건 원본은 절대 안 바뀐다"는 규제 근거가 무너집니다.
+--         사건 원본과 우리 처리기록은 성격이 다른 사실이므로 표를 나누는 게 맞습니다.
+--      ② 한 사건을 여러 Job 이 봅니다. DailyChangedContractJob 도, MonthlyValidationJob 도.
+--         컬럼 하나로는 "어느 Job 이 처리했나"를 구분할 수 없습니다.
+--      ③ 실패도 증거입니다. 실패 → 재시도 → 성공의 전 과정이 남아야 합니다.
+--
+--    ★ 멱등성 설계 (V2 헤더가 "UNIQUE 제약이 중복을 막아 준다"고 명시한 그 성질)
+--      PK 는 대리키로 둡니다. 자연키를 PK 로 두면 실패 이력을 못 쌓습니다.
+--      대신 부분 UNIQUE 인덱스로 "사건 × Job 당 SUCCEEDED 는 최대 1행"을 강제합니다.
+--        - 실패(FAILED)는 몇 번이든 쌓인다        → 증거 보존
+--        - 성공(SUCCEEDED)은 Job 당 딱 한 번      → 배치 재실행해도 중복 없음
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS fgc.contract_status_event_processing (
+    contract_status_event_processing_id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    contract_status_event_id bigint       NOT NULL
+                             REFERENCES fgc.contract_status_event(contract_status_event_id),
+    processing_job           varchar(100) NOT NULL,
+    processing_status        varchar(20)  NOT NULL
+                             CHECK (processing_status IN ('SUCCEEDED','FAILED')),
+    validation_run_id        bigint REFERENCES fgc.validation_run(validation_run_id),
+    processed_at             timestamptz  NOT NULL DEFAULT clock_timestamp(),
+    failure_reason           varchar(2000),
+    created_at               timestamptz  NOT NULL DEFAULT clock_timestamp(),
+    CONSTRAINT ck_cse_processing_failure
+      CHECK ((processing_status = 'FAILED') = (failure_reason IS NOT NULL))
+);
+
+-- 사건 × Job 당 성공기록은 하나뿐. 실패기록은 제한 없음.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_cse_processing_succeeded
+  ON fgc.contract_status_event_processing (contract_status_event_id, processing_job)
+  WHERE processing_status = 'SUCCEEDED';
+
+-- 사건 하나의 처리 전말(실패 포함)을 시간순으로 뽑는 경로. 이 표의 주 용도입니다.
+CREATE INDEX IF NOT EXISTS ix_cse_processing_event
+  ON fgc.contract_status_event_processing (contract_status_event_id, processed_at);
+
+COMMENT ON TABLE fgc.contract_status_event_processing IS
+  '계약상태 사건을 어느 배치가 언제 처리했는지의 기록. 사건 원본(append-only)과 분리한다. '
+  '미처리 사건 조회는 NOT EXISTS 를 쓴다(V2:243-247 의 processed_at IS NULL 을 대체). '
+  '★ 뷰를 만들지 않은 이유 — 올바른 쿼리는 반드시 processing_job = :jobName 을 포함해야 하는데 '
+  '뷰는 파라미터를 못 받아, Daily 가 처리한 사건을 Monthly 가 처리됨으로 오인하는 함정이 된다.';
+COMMENT ON COLUMN fgc.contract_status_event_processing.processing_job IS
+  'Spring Batch Job 이름. 예) DailyChangedContractJob, MonthlyValidationJob. '
+  'CHECK 를 걸지 않는다 — Job 이 늘 때마다 마이그레이션을 새로 만들어야 하기 때문(COR-004)';
+COMMENT ON COLUMN fgc.contract_status_event_processing.processing_status IS
+  'SUCCEEDED = 해당 Job 기준 처리 완료. FAILED = 실패, failure_reason 필수';
+COMMENT ON COLUMN fgc.contract_status_event_processing.validation_run_id IS
+  '그때 만들어진 validation_run. 일일 보정처럼 run 없이 도는 처리는 NULL';
+COMMENT ON COLUMN fgc.contract_status_event_processing.processed_at IS
+  '처리를 마친 시각. ★ 사건의 received_at 이후여야 한다는 규칙은 DB가 강제하지 못한다 '
+  '(부모 테이블 컬럼이라 CHECK 로 표현 불가). 애플리케이션이 지킨다';
+
+-- 처리기록도 사건 원본과 같이 고쳐 쓸 수 없게 한다.
+-- 실패와 성공이 각각 "다른 행"이므로 UPDATE 할 일이 원래 없다.
+-- 고쳐 쓸 수 있는 처리기록은 그것이 설명하는 사건보다 증거력이 약해진다.
+DROP TRIGGER IF EXISTS trg_cse_processing_append_only ON fgc.contract_status_event_processing;
+CREATE TRIGGER trg_cse_processing_append_only
+BEFORE UPDATE OR DELETE ON fgc.contract_status_event_processing
+FOR EACH ROW EXECUTE FUNCTION fgc.reject_update_delete();
+
+-- ── contract_status_event.processed_at 은 어떻게 하나 : 남긴다 ──────────────
+--   지우면 다음을 잃습니다.
+--     ① 팀원 DB·운영 DB에 이미 들어 있는 실제 값. append-only 로 지키던 감사 데이터를
+--        마이그레이션이 스스로 파괴하는 셈이고, 되돌릴 방법이 없습니다.
+--     ② V3 §15 가 "effective_at / received_at / processed_at 세 날짜를 구분하라"고
+--        가르치는 시드 시나리오가 통째로 깨집니다.
+--   지워서 얻는 것은 NULL 비트 한 자리뿐입니다. 남기고 주석으로 폐기 표시합니다.
+--   (ck_contract_status_processed CHECK(V1:674)는 그대로 유효하며 아무것도 막지 않습니다)
+COMMENT ON COLUMN fgc.contract_status_event.processed_at IS
+  '【DEPRECATED v2.1.6】신규 코드에서 읽지도 쓰지도 마세요. '
+  'append-only 트리거 때문에 INSERT 시점에만 넣을 수 있고 나중에 갱신할 수 없습니다. '
+  '처리 여부는 fgc.contract_status_event_processing 을 보세요. '
+  '컬럼을 지우지 않는 이유 — 기존 DB에 들어 있는 값은 되살릴 수 없는 감사 데이터입니다.';
+
+
+-- ============================================================================
+-- 2. P0-2 잔여 : 정책 생명주기를 INSERT 로 우회하는 문제
+--
+--    무엇이 문제였나
+--      guard_policy_version_lifecycle 은 BEFORE UPDATE OR DELETE 입니다(V1:534-536).
+--      그래서 INSERT ... status='ACTIVE' 는 그냥 통과합니다.
+--      ck_policy_approval(V1:327-329)도 approved_at 만 요구해서
+--      created_by·approved_by 가 NULL 이어도 ACTIVE 정책이 만들어집니다.
+--      실제로 V2 가 그 경로로 STATUS-MONTH-RULE-2026 v1 을 넣었습니다(V2:182-203).
+--      데이터는 V3 이 폐기·재발행으로 수습했지만, 강제장치는 그대로 뚫려 있습니다.
+-- ============================================================================
+
+-- ── 2-1. 작성자·승인자 분리 강제 (REG-22) ─────────────────────────────────
+--
+--   ★ 왜 NOT VALID 인가 — 반드시 읽어야 합니다
+--     V2 가 넣은 STATUS-MONTH-RULE-2026 v1 은 DB마다 상태가 다릅니다.
+--       · 로컬(V3 적용됨) : status='RETIRED', created_by=NULL, approved_by=NULL
+--       · 운영(V3 미적용) : status='ACTIVE',  created_by=NULL, approved_by=NULL
+--     즉 운영 DB에는 지금도 작성자 없는 ACTIVE 정책이 살아 있을 수 있습니다.
+--     그냥 ADD CONSTRAINT 하면 그 DB에 V6 적용이 실패합니다.
+--
+--   ★ 왜 값을 채워 넣지(backfill) 않았나
+--     운영 DB의 app_user 는 비어 있습니다(사용자 시드는 V3 = demo 전용).
+--     작성자를 넣으려면 가짜 시스템 계정을 만들어야 하는데,
+--     없는 승인자를 있는 것처럼 적는 것은 없는 것보다 나쁜 증거입니다.
+--     사실대로 "이 한 행은 절차 이전의 유산"으로 남기고 예외임을 명시합니다.
+--
+--   ★ 왜 RETIRED 를 대상에서 뺐나
+--     ① V6 이후로는 RETIRED 에 도달하려면 반드시 APPROVED 나 ACTIVE 를 거치는데
+--        그 두 상태는 이 CHECK 가 검사합니다. 신규 RETIRED 행은 이미 검증된 것입니다.
+--     ② 운영 DB의 유산 행을 나중에 정상적으로 폐기할 길을 열어 둡니다.
+--        RETIRED 까지 검사하면 그 UPDATE 가 CHECK 에 걸려(NOT VALID 라도 UPDATE 는 검사됨)
+--        유산 행이 영영 폐기 불가능해집니다. 고치라고 만든 제약이 고치는 걸 막는 셈입니다.
+--
+--   ★ VALIDATE 는 언제 하나
+--     유산 행을 RETIRED 로 폐기하고 v2 를 절차대로 발행한 다음,
+--     별도 마이그레이션에서 아래 한 줄을 돌립니다. 지금 하면 안 됩니다.
+--       ALTER TABLE fgc.policy_version VALIDATE CONSTRAINT ck_policy_authorship;
+ALTER TABLE fgc.policy_version DROP CONSTRAINT IF EXISTS ck_policy_authorship;
+ALTER TABLE fgc.policy_version ADD CONSTRAINT ck_policy_authorship CHECK (
+    status NOT IN ('APPROVED','ACTIVE')
+    OR (created_by   IS NOT NULL
+    AND approved_by  IS NOT NULL
+    AND approved_at  IS NOT NULL
+    AND created_by  <> approved_by)
+) NOT VALID;
+
+COMMENT ON CONSTRAINT ck_policy_authorship ON fgc.policy_version IS
+  '승인·활성 정책은 작성자와 승인자가 모두 있어야 하고 서로 달라야 한다(REG-22, SRC-027). '
+  'NOT VALID 인 이유 — V2 가 절차를 건너뛰고 만든 STATUS-MONTH-RULE-2026 v1 이 '
+  'V3(demo)를 적용하지 않은 DB에는 아직 ACTIVE 로 남아 있다. 그 행을 폐기한 뒤 VALIDATE 한다. '
+  'RETIRED 를 제외한 이유 — 유산 행의 폐기 경로를 막지 않기 위해서다.';
+
+-- ── 2-2. INSERT 도 생명주기 가드에 태운다 ─────────────────────────────────
+--
+--   V1 본체를 그대로 두고 맨 앞에 INSERT 분기만 얹습니다.
+--   나머지(삭제 제한·불변 컬럼·상태전이표)는 V1:494-536 과 한 글자도 다르지 않습니다.
+--
+--   V3·V4 를 깨뜨리지 않는가 — 확인했습니다.
+--     V3 §1-1②(V3:98) 와 §7(V3:303-306) 은 둘 다 'DRAFT' 로 INSERT 합니다.
+--     V4 에는 policy_version INSERT 자체가 없습니다.
+--     V2 의 ACTIVE INSERT 는 V6 보다 먼저 끝났으므로 영향받지 않습니다.
+CREATE OR REPLACE FUNCTION fgc.guard_policy_version_lifecycle()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- v2.1.6 신규 : INSERT 우회 차단
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.status <> 'DRAFT' THEN
+      RAISE EXCEPTION
+        'policy_version must be inserted as DRAFT (got %); promote with DRAFT -> APPROVED -> ACTIVE updates',
+        NEW.status;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.status <> 'DRAFT' THEN
+      RAISE EXCEPTION 'Only DRAFT policy versions may be deleted; create a new version instead';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF OLD.status IN ('APPROVED','ACTIVE','RETIRED') THEN
+    IF ROW(NEW.policy_code, NEW.policy_name, NEW.policy_type, NEW.version_no,
+           NEW.source_class, NEW.effective_from, NEW.effective_to, NEW.fee_regime_code,
+           NEW.basic_document_version, NEW.regulation_refs, NEW.source_refs,
+           NEW.approval_evidence_ref, NEW.approved_by, NEW.approved_at, NEW.created_by)
+       IS DISTINCT FROM
+       ROW(OLD.policy_code, OLD.policy_name, OLD.policy_type, OLD.version_no,
+           OLD.source_class, OLD.effective_from, OLD.effective_to, OLD.fee_regime_code,
+           OLD.basic_document_version, OLD.regulation_refs, OLD.source_refs,
+           OLD.approval_evidence_ref, OLD.approved_by, OLD.approved_at, OLD.created_by) THEN
+      RAISE EXCEPTION 'APPROVED/ACTIVE/RETIRED policy version is immutable; create a new version';
+    END IF;
+  END IF;
+
+  IF NEW.status IS DISTINCT FROM OLD.status THEN
+    IF NOT (
+      (OLD.status = 'DRAFT'    AND NEW.status IN ('REVIEW','APPROVED')) OR
+      (OLD.status = 'REVIEW'   AND NEW.status IN ('DRAFT','APPROVED')) OR
+      (OLD.status = 'APPROVED' AND NEW.status IN ('ACTIVE','RETIRED')) OR
+      (OLD.status = 'ACTIVE'   AND NEW.status = 'RETIRED')
+    ) THEN
+      RAISE EXCEPTION 'Invalid policy status transition: % -> %', OLD.status, NEW.status;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_policy_version_lifecycle ON fgc.policy_version;
+CREATE TRIGGER trg_policy_version_lifecycle
+BEFORE INSERT OR UPDATE OR DELETE ON fgc.policy_version
+FOR EACH ROW EXECUTE FUNCTION fgc.guard_policy_version_lifecycle();
+
+
+-- ============================================================================
+-- 3. P1-3 : 실행(run) 상태전이가 아무 데서나 점프되는 문제
+--
+--    무엇이 문제였나
+--      guard_validation_run_finalized(V1:1633-1649) 와
+--      guard_reconciliation_run_finalized(V1:1715-1728) 는
+--      "FINALIZED 가 된 뒤" 만 잠급니다. 그 전에는 무엇이든 됩니다.
+--      CREATED → FINALIZED 직행도, FAILED → FINALIZED 도 통과합니다.
+--      돌지도 않은 검증이 확정되면 그 확정에는 근거가 없습니다.
+--
+--    두 테이블은 상태 어휘가 같고(CREATED/RUNNING/COMPLETED/FAILED/FINALIZED)
+--    PK 컬럼 이름만 다릅니다. 그래서 함수는 하나만 만들고
+--    PK 컬럼명을 TG_ARGV[0] 으로 넘겨 오류 메시지에만 씁니다.
+--    (to_jsonb 는 실패 분기 안에서만 부릅니다. 정상 UPDATE 에는 비용이 없습니다)
+--
+--    ★ 기존 FINALIZED 가드는 건드리지 않고 트리거를 나란히 둡니다.
+--      ① 이미 검증된 불변성 로직을 다시 쓰다가 후퇴시킬 위험이 없습니다.
+--      ② PostgreSQL 은 같은 시점 트리거를 이름 알파벳순으로 실행합니다.
+--         trg_*_finalized < trg_*_lifecycle 이므로
+--         FINALIZED 행은 전이 검사에 도달하기도 전에 먼저 거부됩니다.
+--         (그래서 아래 전이표에 FINALIZED 출발 항목이 없어도 안전합니다)
+--
+--    시드 영향 — 확인했습니다.
+--      V3·V4 어디에도 validation_run / reconciliation_run INSERT 가 없습니다.
+--      따라서 새 DB에서 V3·V4 를 다시 돌려도 이 트리거에 걸릴 일이 없습니다.
+-- ============================================================================
+CREATE OR REPLACE FUNCTION fgc.guard_run_lifecycle()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.status IS DISTINCT FROM OLD.status THEN
+    IF NOT (
+      (OLD.status = 'CREATED'   AND NEW.status = 'RUNNING') OR
+      (OLD.status = 'RUNNING'   AND NEW.status IN ('COMPLETED','FAILED')) OR
+      (OLD.status = 'COMPLETED' AND NEW.status = 'FINALIZED') OR
+      (OLD.status = 'FAILED'    AND NEW.status = 'RUNNING')
+    ) THEN
+      RAISE EXCEPTION 'Invalid % status transition: % -> % (run %)',
+        TG_TABLE_NAME, OLD.status, NEW.status, to_jsonb(OLD) ->> TG_ARGV[0];
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION fgc.guard_run_lifecycle() IS
+  'validation_run·reconciliation_run 공용 상태전이 가드(SRC-027 P1-3). '
+  '허용 : CREATED→RUNNING, RUNNING→COMPLETED, RUNNING→FAILED, COMPLETED→FINALIZED, FAILED→RUNNING. '
+  '트리거 인자로 PK 컬럼명을 넘긴다(오류 메시지 전용). '
+  'FINALIZED 이후 불변성은 기존 guard_*_run_finalized 트리거가 담당한다(중복 구현 금지)';
+
+DROP TRIGGER IF EXISTS trg_validation_run_lifecycle ON fgc.validation_run;
+CREATE TRIGGER trg_validation_run_lifecycle
+BEFORE UPDATE ON fgc.validation_run
+FOR EACH ROW EXECUTE FUNCTION fgc.guard_run_lifecycle('validation_run_id');
+
+DROP TRIGGER IF EXISTS trg_reconciliation_run_lifecycle ON fgc.reconciliation_run;
+CREATE TRIGGER trg_reconciliation_run_lifecycle
+BEFORE UPDATE ON fgc.reconciliation_run
+FOR EACH ROW EXECUTE FUNCTION fgc.guard_run_lifecycle('reconciliation_run_id');
+
+
+-- ============================================================================
+-- 4. D-01 : 계약체결비용 검증의 사용률 4개를 담을 자리
+--
+--    무엇이 문제였나
+--      운영정책서 제45조(:924-929)는 사용률 4개를 각각 저장하라고 정합니다.
+--        선지급 총액   ÷ 계약체결비용
+--        유지관리 월액 ÷ (계약체결비용 × 월 상한율)
+--        유지관리 총액 ÷ 계약체결비용
+--        장기유지 월액 ÷ (계약체결비용 × 0.4%)
+--      그런데 acquisition_cost_check(V1:1859-1873)에는 사용률 컬럼이 하나도 없습니다.
+--      금액 쌍만 있습니다.
+--
+--    왜 컬럼을 4개 더 붙이지 않고 상세행 테이블인가
+--      월액 두 유형(유지관리 월액·장기유지 월액)은 해당 월마다 값이 다릅니다.
+--      컬럼으로는 한 달치밖에 못 담습니다. 검증유형 × 대상월 = 1행이어야 합니다.
+--
+--    ★ 이 표는 2차 기능용 물리 선반영입니다 (SRC-027 D-03).
+--      표가 있다는 것이 계약체결비용 검증의 1차 제공을 뜻하지 않습니다.
+--      1차에는 비활성이며 ACQC-W01 화면과 함께 2차에 켭니다.
+--
+--    ★ 초년도 1,200% 는 여기 넣지 않습니다 (SRC-027 D-01).
+--      근거 조문(REG-08)도, 판정 기준금액(월납환산 초회보험료 × 12)도,
+--      저장 테이블(cap_check)도 다른 별개의 규제검증입니다.
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS fgc.acquisition_cost_check_detail (
+    acquisition_cost_check_detail_id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    acquisition_cost_check_id bigint       NOT NULL
+                              REFERENCES fgc.acquisition_cost_check(acquisition_cost_check_id),
+    check_type                varchar(30)  NOT NULL CHECK (check_type IN (
+                                'UPFRONT_TOTAL',        -- 선지급 총액   (REG-02)
+                                'MAINTENANCE_MONTHLY',  -- 유지관리 월액 (REG-03)
+                                'MAINTENANCE_TOTAL',    -- 유지관리 총액 (REG-03 제4호)
+                                'LONG_TERM_MONTHLY'     -- 장기유지 월액 (REG-05)
+                              )),
+    target_month              date CHECK (target_month IS NULL OR fgc.is_first_day_of_month(target_month)),
+    actual_amount             numeric(15,2) NOT NULL CHECK (actual_amount >= 0),
+    limit_amount              numeric(15,2) NOT NULL CHECK (limit_amount >= 0),
+    usage_pct                 numeric(12,6),
+    result_status             varchar(20)  NOT NULL
+                              CHECK (result_status IN ('NORMAL','WARNING','VIOLATION','REVIEW_REQUIRED')),
+    decision_reason           varchar(1000) NOT NULL,
+    calculation_snapshot      jsonb        NOT NULL DEFAULT '{}'::jsonb,
+    created_at                timestamptz  NOT NULL DEFAULT clock_timestamp(),
+    -- 월액 유형은 대상월이 반드시 있고, 총액 유형은 반드시 없다.
+    CONSTRAINT ck_acqd_target_month CHECK (
+      (check_type IN ('MAINTENANCE_MONTHLY','LONG_TERM_MONTHLY')) = (target_month IS NOT NULL)
+    )
+);
+
+-- 총액 유형은 검증당 1행. 월액 유형은 대상월당 1행.
+-- COALESCE 로 NULL 을 무한과거로 치환해 총액 유형도 같은 인덱스로 막는다.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_acquisition_cost_check_detail
+  ON fgc.acquisition_cost_check_detail (
+    acquisition_cost_check_id, check_type, COALESCE(target_month, '-infinity'::date)
+  );
+
+COMMENT ON TABLE fgc.acquisition_cost_check_detail IS
+  '계약체결비용 검증의 유형별 사용률 상세(운영정책서 제45조, SRC-027 D-01). '
+  '네 한도는 서로 차감하지 않는다. 하나라도 100%를 넘으면 부모가 VIOLATION 이다. '
+  '★ 2차 기능용 물리 선반영 — 표의 존재가 1차 제공을 뜻하지 않는다(SRC-027 D-03). '
+  '★ 초년도 1,200%(REG-08)는 여기 넣지 않는다. cap_check 가 담당하는 별개 검증이다.';
+COMMENT ON COLUMN fgc.acquisition_cost_check_detail.check_type IS
+  'UPFRONT_TOTAL=선지급 총액(REG-02) / MAINTENANCE_MONTHLY=유지관리 월액(REG-03) / '
+  'MAINTENANCE_TOTAL=유지관리 총액(REG-03 제4호) / LONG_TERM_MONTHLY=장기유지 월액(REG-05)';
+COMMENT ON COLUMN fgc.acquisition_cost_check_detail.target_month IS
+  '월액 유형의 대상 정산월(1일). 총액 유형은 NULL. ck_acqd_target_month 가 강제한다';
+COMMENT ON COLUMN fgc.acquisition_cost_check_detail.usage_pct IS
+  'actual_amount ÷ limit_amount × 100. 사용률 정밀도는 소수점 6자리(cap_check.usage_pct 와 동일)';
+
+-- ── 부모와 동일하게 FINALIZED 실행의 결과를 잠근다 ─────────────────────────
+--   guard_finalized_validation_result 는 CASE ... ELSE RAISE EXCEPTION 으로 끝나서
+--   목록에 없는 테이블에 붙이면 'Unsupported validation result table' 예외가 납니다.
+--   그래서 cap_check_detail 분기와 똑같은 모양으로 한 갈래를 더한 판으로 교체합니다.
+--   (V2_1 이 guard_policy_child_mutation 에 policy_parameter 를 더한 것과 같은 방식)
+--   나머지 로직은 V1:1570-1618 과 한 글자도 다르지 않습니다.
+CREATE OR REPLACE FUNCTION fgc.guard_finalized_validation_result()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_old_run_id bigint;
+  v_new_run_id bigint;
+  v_parent_id bigint;
+  v_run_id bigint;
+  v_status varchar(20);
+BEGIN
+  IF TG_TABLE_NAME IN ('validation_target','cap_check','arbitrage_check','acquisition_cost_check','maintenance_check') THEN
+    IF TG_OP <> 'INSERT' THEN v_old_run_id := OLD.validation_run_id; END IF;
+    IF TG_OP <> 'DELETE' THEN v_new_run_id := NEW.validation_run_id; END IF;
+  ELSIF TG_TABLE_NAME = 'cap_check_detail' THEN
+    IF TG_OP <> 'INSERT' THEN
+      v_parent_id := OLD.cap_check_id;
+      SELECT validation_run_id INTO v_old_run_id
+        FROM cap_check WHERE cap_check_id = v_parent_id
+        FOR SHARE;
+    END IF;
+    IF TG_OP <> 'DELETE' THEN
+      v_parent_id := NEW.cap_check_id;
+      SELECT validation_run_id INTO v_new_run_id
+        FROM cap_check WHERE cap_check_id = v_parent_id
+        FOR SHARE;
+    END IF;
+  -- v2.1.6 신규 : acquisition_cost_check_detail (부모를 거쳐 run 을 찾는다)
+  ELSIF TG_TABLE_NAME = 'acquisition_cost_check_detail' THEN
+    IF TG_OP <> 'INSERT' THEN
+      v_parent_id := OLD.acquisition_cost_check_id;
+      SELECT validation_run_id INTO v_old_run_id
+        FROM acquisition_cost_check WHERE acquisition_cost_check_id = v_parent_id
+        FOR SHARE;
+    END IF;
+    IF TG_OP <> 'DELETE' THEN
+      v_parent_id := NEW.acquisition_cost_check_id;
+      SELECT validation_run_id INTO v_new_run_id
+        FROM acquisition_cost_check WHERE acquisition_cost_check_id = v_parent_id
+        FOR SHARE;
+    END IF;
+  ELSE
+    RAISE EXCEPTION 'Unsupported validation result table: %', TG_TABLE_NAME;
+  END IF;
+
+  -- 결과행 변경과 validation_run FINALIZED 전환을 직렬화한다.
+  FOR v_run_id, v_status IN
+    SELECT validation_run_id, status
+      FROM validation_run
+     WHERE validation_run_id = ANY (
+       array_remove(ARRAY[v_old_run_id, v_new_run_id]::bigint[], NULL)
+     )
+     ORDER BY validation_run_id
+     FOR SHARE
+  LOOP
+    IF v_status = 'FINALIZED' THEN
+      RAISE EXCEPTION 'Results of finalized validation run % are immutable', v_run_id;
+    END IF;
+  END LOOP;
+
+  IF TG_OP='DELETE' THEN RETURN OLD; END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_acquisition_cost_check_detail_immutable
+  ON fgc.acquisition_cost_check_detail;
+CREATE TRIGGER trg_acquisition_cost_check_detail_immutable
+BEFORE INSERT OR UPDATE OR DELETE ON fgc.acquisition_cost_check_detail
+FOR EACH ROW EXECUTE FUNCTION fgc.guard_finalized_validation_result();
+
+
+-- ============================================================================
+-- 5. P0-4 : 함수가 실행시점 search_path 에 의존하는 문제  ★ 반드시 맨 마지막
+--
+--    무엇이 문제였나
+--      V1 의 함수 다수가 테이블을 스키마 없이 씁니다.
+--        FROM policy_version / FROM validation_run / FROM commission_transaction ...
+--      이 이름은 함수를 만들 때가 아니라 "부를 때"의 search_path 로 풀립니다.
+--      커넥션풀 설정이 바뀌거나, 누가 fgc 앞에 다른 스키마를 끼워 넣거나,
+--      psql 에서 search_path 를 바꾸고 UPDATE 하면
+--      가드가 엉뚱한 테이블을 보고 조용히 통과합니다. 막으라고 만든 가드가요.
+--
+--    ★ 왜 함수 본문을 고치지 않고 ALTER FUNCTION ... SET 인가
+--      본문 수정은 23개 함수를 전부 다시 써야 하고 그 과정에서 로직이 바뀔 위험이 있습니다.
+--      ALTER 는 로직을 한 글자도 건드리지 않고 이름 해석만 고정합니다.
+--
+--    ★ 왜 개별 ALTER 나열 대신 DO 루프인가 (둘 다 검토했습니다)
+--      나열하면 23줄 + 인자 시그니처를 손으로 맞춰야 합니다.
+--      is_within_first_year(date,date) 같은 걸 하나만 틀려도 마이그레이션 전체가 실패합니다.
+--      루프는 pg_get_function_identity_arguments 로 카탈로그에서 정확한 시그니처를
+--      직접 읽으므로 틀릴 수가 없고, 앞으로 함수가 늘어도 이 파일을 안 고쳐도 됩니다.
+--
+--    ★ IMMUTABLE 함수는 왜 뺐나 (여기가 유일한 예외입니다)
+--      is_first_day_of_month / round_krw_half_up / is_within_first_year 3개입니다.
+--      셋 다 테이블을 전혀 참조하지 않아 search_path 와 무관합니다.
+--      반면 SET 절이 붙은 SQL 함수는 플래너가 인라인 전개를 못 합니다.
+--      is_first_day_of_month 는 statement_batch·commission_transaction·
+--      transaction_attribution·validation_run·reconciliation_run 의
+--      CHECK 제약에서 행마다 호출됩니다. 얻는 것 0, 잃는 것만 있는 거래라 뺍니다.
+--
+--    ★ 실행 순서 — 이 절이 파일 맨 뒤에 있는 이유
+--      위에서 새로 만든 guard_run_lifecycle 과 교체한
+--      guard_policy_version_lifecycle·guard_finalized_validation_result 까지
+--      한 번에 덮기 위해서입니다.
+-- ============================================================================
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT p.proname,
+           pg_get_function_identity_arguments(p.oid) AS args
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'fgc'
+       AND p.prokind = 'f'
+       AND p.provolatile <> 'i'      -- IMMUTABLE 순수함수는 인라인 유지를 위해 제외
+     ORDER BY p.proname
+  LOOP
+    EXECUTE format('ALTER FUNCTION fgc.%I(%s) SET search_path = fgc, pg_temp',
+                   r.proname, r.args);
+    RAISE NOTICE 'search_path 고정: fgc.%(%)', r.proname, r.args;
+  END LOOP;
+END;
+$$;
+
+
+-- ============================================================================
+-- 적용 후 확인
+-- ============================================================================
+-- ① search_path 가 안 박힌 함수가 남았는가 (IMMUTABLE 3개만 나와야 정상)
+--    SELECT p.proname, p.provolatile, p.proconfig
+--      FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--     WHERE n.nspname='fgc' AND p.prokind='f' AND p.proconfig IS NULL
+--     ORDER BY 1;
+--    → is_first_day_of_month / is_within_first_year / round_krw_half_up
+--
+-- ② 정책 INSERT 우회가 막혔는가 (아래가 실패해야 정상)
+--    INSERT INTO fgc.policy_version
+--      (policy_code,policy_name,policy_type,source_class,version_no,
+--       effective_from,status,approved_at)
+--    VALUES ('TEST-BYPASS','우회시도','CAP_1200','GA_POLICY',1,
+--            current_date,'ACTIVE',now());
+--    → ERROR: policy_version must be inserted as DRAFT (got ACTIVE)
+--
+-- ③ 승인자 = 작성자 인 승격이 막혔는가 (두 번째 UPDATE 가 실패해야 정상)
+--    INSERT INTO fgc.policy_version
+--      (policy_code,policy_name,policy_type,source_class,version_no,
+--       effective_from,status,created_by)
+--    VALUES ('TEST-SELFAPPROVE','자가승인','CAP_1200','GA_POLICY',1,
+--            current_date,'DRAFT',(SELECT user_id FROM fgc.app_user LIMIT 1));
+--    UPDATE fgc.policy_version SET status='APPROVED', approved_at=now(),
+--           approved_by=created_by
+--     WHERE policy_code='TEST-SELFAPPROVE';
+--    → ERROR: ... violates check constraint "ck_policy_authorship"
+--    (정리) DELETE FROM fgc.policy_version WHERE policy_code LIKE 'TEST-%';
+--
+-- ④ 실행 상태 점프가 막혔는가 (두 번째가 실패, 세 번째는 성공해야 정상)
+--    INSERT INTO fgc.validation_run(validation_month, run_no)
+--    VALUES (date_trunc('month', current_date)::date, 999);
+--    UPDATE fgc.validation_run SET status='FINALIZED', finalized_at=now()
+--     WHERE run_no=999;
+--    → ERROR: Invalid validation_run status transition: CREATED -> FINALIZED (run N)
+--    UPDATE fgc.validation_run SET status='RUNNING', started_at=now() WHERE run_no=999;
+--    → 성공
+--    (정리) DELETE FROM fgc.validation_run WHERE run_no=999;
+--
+-- ⑤ 미처리 계약상태 사건 조회 (V2:243-247 의 processed_at IS NULL 을 대체)
+--    SELECT e.contract_status_event_id, e.contract_id, e.effective_at, e.received_at
+--      FROM fgc.contract_status_event e
+--     WHERE NOT EXISTS (
+--             SELECT 1 FROM fgc.contract_status_event_processing p
+--              WHERE p.contract_status_event_id = e.contract_status_event_id
+--                AND p.processing_job    = 'DailyChangedContractJob'
+--                AND p.processing_status = 'SUCCEEDED')
+--     ORDER BY e.effective_at;   -- 수신 순서가 아니라 효력일 순서로 재구성한다
+--
+-- ⑥ 처리기록 멱등성 (같은 문장을 두 번 돌려도 1행이어야 정상)
+--    INSERT INTO fgc.contract_status_event_processing
+--      (contract_status_event_id, processing_job, processing_status)
+--    SELECT contract_status_event_id, 'DailyChangedContractJob', 'SUCCEEDED'
+--      FROM fgc.contract_status_event ORDER BY contract_status_event_id LIMIT 1
+--    ON CONFLICT (contract_status_event_id, processing_job)
+--         WHERE processing_status = 'SUCCEEDED' DO NOTHING;
+--    → 2회차 0 rows
+--
+-- ⑦ 처리기록 append-only (아래가 실패해야 정상)
+--    UPDATE fgc.contract_status_event_processing SET processing_job='X';
+--    → ERROR: contract_status_event_processing is append-only
+--
+-- ⑧ 작성자 없는 유산 정책 확인 (★ 운영 DB에서 반드시 먼저 돌릴 것)
+--    SELECT policy_code, version_no, status, created_by, approved_by, approved_at
+--      FROM fgc.policy_version
+--     WHERE created_by IS NULL OR approved_by IS NULL;
+--    → 로컬(V3 적용) : STATUS-MONTH-RULE-2026 v1 (RETIRED) 1행
+--    → V3 미적용 DB  : STATUS-MONTH-RULE-2026 v1 (ACTIVE)  1행  ← 폐기 대상
+-- ============================================================================

--- a/src/main/resources/db/migration/V7__run_progress_and_snapshot_locks.sql
+++ b/src/main/resources/db/migration/V7__run_progress_and_snapshot_locks.sql
@@ -1,0 +1,545 @@
+-- ============================================================================
+-- FGC 무결성 보강 마이그레이션 v2.1.6 → v2.1.7
+-- 대상 DBMS: PostgreSQL 17
+-- 작성 기준일: 2026-08-06
+-- 결정 근거: SRC-027 FGC 정합성 설계결정서 · VRUN 10단계 정합성 감사
+--
+-- ── 왜 V1~V6 를 고치지 않고 V7 을 만드나 ──────────────────────────────────
+--   앞의 마이그레이션은 이미 팀원 DB에 적용돼 있습니다.
+--   적용된 파일을 한 글자라도 고치면 Flyway 가 체크섬 오류를 내고 그 사람 앱이 안 뜹니다.
+--
+--   ★ 이 파일은 db/migration 에 둡니다. db/demo 가 아닙니다.
+--     운영은 classpath:db/migration 만 읽고, 로컬만 db/demo 를 더 읽습니다.
+--     따라서 V7 은 V3·V4 시드가 있다고 가정하면 안 됩니다.
+--
+-- ── 고치는 것 3가지 ───────────────────────────────────────────────────────
+--   1) 월 통합검증 10단계 진행률을 저장할 자리가 없는 문제
+--          → validation_run.current_step 신설
+--   2) 실행(run)을 처음부터 FINALIZED 로 INSERT 할 수 있는 문제  ★ V6 누락 보완
+--          → guard_run_lifecycle 에 INSERT 분기 추가
+--   3) V5 가 만든 스냅샷 컬럼이 NULL 을 허용해 목적을 우회할 수 있는 문제
+--          → NOT NULL + 조건부 CHECK
+--
+-- ── 데이터 영향 ───────────────────────────────────────────────────────────
+--   컬럼 1개·제약 3개를 추가하고 함수 1개를 확장합니다.
+--   기존 행을 지우지 않습니다. 값 보정(백필)은 아래 두 곳뿐이며 모두 멱등입니다.
+-- ============================================================================
+
+SET search_path TO fgc, public;
+
+
+-- ============================================================================
+-- 1. 월 통합검증 10단계 진행률을 담을 자리
+--
+--    무엇이 문제였나
+--      운영정책서 제43조는 월 통합검증을 10단계로 정합니다.
+--        1 실행생성 2 대상선별 3 스케줄 4 1,200% 5 차익거래
+--        6 원장기표·균형 7 양방향대사 8 예외생성 | 9 담당자검토 10 확정
+--      1~8 은 Spring Batch(MonthlyValidationJob), 9~10 은 사람이 합니다.
+--
+--      그런데 이 10단계를 저장할 컬럼이 어디에도 없었습니다.
+--      VRUN-W02 스텝퍼, VRUN-W01·DASH-W01 진행률 바(step/10*100),
+--      확정조건 1번(step >= 8)이 전부 없는 값을 읽고 있었고,
+--      MVP 는 localStorage 로 위장하고 있었습니다.
+--
+--    ★ status 5개와 10단계는 서로 다른 축입니다. 그 자체는 정상 설계입니다.
+--        status      = 실행의 거친 생명주기 (CREATED→RUNNING→COMPLETED→FINALIZED)
+--        current_step = RUNNING 안에서의 진행 위치
+--      문제는 두 번째 축을 저장하지 않았다는 것이었습니다.
+--
+--    ★ 왜 Spring Batch 메타테이블(batch_step_execution)에서 읽지 않나
+--      ① V2 헤더(36-39행)가 "배치 메타테이블을 업무 로직이 읽는 구조"를
+--         이미 명시적으로 거부했습니다. 업무용 값은 업무 스키마에 둡니다.
+--      ② 배치 Step 8개가 정책 10단계와 1:1이 아닙니다.
+--         6단계 = Step 2개(journalPostingStep→imbalanceCheckStep),
+--         4단계 = 파티션 2개, 7단계 = 2회 실행.
+--      ③ 9·10단계는 사람이 합니다. Spring Batch 에 Step 자체가 없어
+--         구조적으로 표현할 수 없습니다.
+--      ④ validation_run 에 job_execution_id 가 없어 조인할 키도 없습니다.
+--
+--    ★ 왜 단계별 테이블이 아니라 컬럼 1개인가
+--      화면이 실제로 쓰는 것은 스칼라 하나입니다.
+--      스텝퍼는 s.no <= current_step 으로 색만 칠하고,
+--      진행률 바는 current_step/10*100 을 씁니다.
+--      IF-API-49 가 약속한 readCount·writeCount 는 쓰는 화면이 없습니다.
+--      (인터페이스정의서 스펙을 이 현실에 맞춰 축소합니다)
+--
+--    ★ 9단계에 별도 값을 두지 않는 이유
+--      status='COMPLETED' AND current_step=8 이 곧 "배치 끝, 사람 검토 대기"입니다.
+--      스텝퍼가 1~8 초록 / 9·10 회색으로 그려지고, 그것이 정확히 그 뜻입니다.
+--      MVP 도 8 에서 10 으로 건너뜁니다. 값을 하나 더 만들면 누가 9로 올리는지
+--      정하는 규칙이 필요해지는데, 그 규칙에 해당하는 사용자 행동이 화면에 없습니다.
+--
+--    reconciliation_run 에는 넣지 않습니다.
+--    10단계는 월 통합검증 고유 개념이고 대사 실행에는 스텝퍼 화면이 없습니다.
+-- ============================================================================
+ALTER TABLE fgc.validation_run
+  ADD COLUMN IF NOT EXISTS current_step smallint NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN fgc.validation_run.current_step IS
+  '월 통합검증 10단계 중 현재 위치(운영정책서 제43조). 0=시작 전, 1~8=배치, 9~10=사람. '
+  '진행률 = current_step / 10 * 100. status=FAILED 이면 이 값이 실패한 단계다. '
+  '★ 9단계(담당자 검토)에 별도 값을 두지 않는다 — status=COMPLETED + current_step=8 이 '
+  '"배치 끝, 사람 검토 대기"를 뜻한다. 단계 이름은 DB가 아니라 화면 상수가 갖는다.';
+
+-- ── 기존 행 보정 ──────────────────────────────────────────────────────────
+--   live 는 0행이지만 이미 실행이 쌓인 팀원 DB·운영 DB를 위해 둡니다.
+--   제약을 붙이기 "전에" 돌려야 합니다. 순서를 바꾸면 COMPLETED 행에서 적용이 실패합니다.
+--
+--   ★★ 왜 한 문장이 아니라 두 갈래인가 — 반드시 읽으세요
+--     trg_validation_run_finalized(V1:1647)는 BEFORE UPDATE OR DELETE 이고
+--     OLD.status='FINALIZED' 이면 무엇을 바꾸든 조건 없이 RAISE 합니다(V1:1640).
+--     그래서 COMPLETED 와 FINALIZED 를 한 UPDATE 로 묶으면
+--     "확정된 실행이 하나라도 있는 DB"에서 이 마이그레이션이 그냥 실패합니다.
+--     ☞ 이 파일의 초판이 실제로 그랬습니다. dev DB가 0행이라 적용 테스트가 못 잡았습니다.
+--       0행은 검증이 아닙니다.
+--
+--   COMPLETED 는 가드 대상이 아닙니다. 평범한 UPDATE 로 끝냅니다.
+UPDATE fgc.validation_run
+   SET current_step = 8
+ WHERE current_step = 0
+   AND status = 'COMPLETED';
+
+-- ── FINALIZED 행 보정 : 불변 가드를 같은 트랜잭션 안에서만 잠시 내립니다 ────
+--
+--   ★ 규제 시스템에서 이것이 통제 위반이 아닌 근거
+--     ① 값을 만들어 내지 않습니다. FINALIZED ⇒ 10 은 바로 아래
+--        ck_validation_run_step 이 정의하는 항등식입니다. 추정이 아니라 정의입니다.
+--        ☞ §3 의 item_code 와 결정적으로 다릅니다. 그쪽은 과거 마스터값을 알 수 없으므로
+--          절대 백필하지 않고 멈춥니다. 판단 기준은 "유도 가능한가, 관측된 것인가"입니다.
+--     ② 대상은 V7 이 방금 만든 신규 컬럼 하나뿐입니다. 확정 시점에 존재하지도 않던
+--        컬럼의 초기값을 채우는 것이라, 확정 당시 기록된 판정 근거는 한 글자도 안 바뀝니다.
+--        0 이라는 값도 사람이 기록한 사실이 아니라 ADD COLUMN 의 DEFAULT 부산물입니다.
+--     ③ 우회 사실 자체를 audit_log 에 남깁니다.
+--        기록 없는 우회가 통제 위반이고, 기록된 우회는 그 자체가 통제입니다.
+--        flyway_schema_history 는 "V7이 돌았다"까지만 말해 줍니다.
+--     ④ 고칠 행이 없으면 트리거를 아예 건드리지 않습니다(맨 앞 RETURN).
+--        정상 경로(대부분의 DB)에서는 이 파일이 가드를 만지지도 않습니다.
+--
+--   ★ 트리거 이름을 하나만 지정합니다.
+--     DISABLE TRIGGER ALL  은 FK 내부 트리거까지 끄고 superuser 를 요구합니다.
+--     DISABLE TRIGGER USER 는 trg_validation_run_lifecycle 까지 같이 꺼집니다.
+--     필요한 건 1개입니다. (lifecycle 가드는 status 를 안 바꾸는 이 UPDATE 를 원래 통과시킵니다)
+--
+--   ★ 왜 DISABLE·UPDATE·ENABLE 을 DO 블록 하나에 넣었나
+--     Flyway 는 마이그레이션 1개를 1트랜잭션으로 돌리므로 뒤에서 실패하면 DISABLE 도
+--     함께 롤백됩니다(tgenabled 변경은 트랜잭션 대상입니다).
+--     그런데 누가 이 파일을 psql -f 로 autocommit 상태에서 돌리면 DISABLE 만 커밋되고
+--     뒤에서 터져 "가드가 꺼진 DB"가 남습니다. DO 블록은 그 자체가 한 문장이라
+--     autocommit 에서도 통째로 원자적입니다.
+--     ☞ 수동 실행 시에는 psql --single-transaction 을 쓰세요.
+--
+--   ★ 이 창(window) 동안 다른 세션이 끼어들 수 있나 — 없습니다
+--     ALTER TABLE ... DISABLE TRIGGER 는 SHARE ROW EXCLUSIVE 락을 잡고, 이 락은
+--     ROW EXCLUSIVE(INSERT/UPDATE/DELETE)와 충돌하므로 블록이 끝날 때까지 다른 세션은
+--     이 표에 쓸 수 없습니다. SELECT 는 영향 없습니다.
+--     게다가 tgenabled 변경은 커밋 전까지 다른 세션에 보이지 않고 같은 트랜잭션에서
+--     되돌려지므로, "가드가 꺼진 상태"를 관측한 세션은 존재할 수 없습니다.
+--     참고: 아래 ADD CONSTRAINT 는 ACCESS EXCLUSIVE(더 센 락)입니다.
+--           즉 이 DISABLE 은 동시성 노출을 새로 만들지 않습니다.
+--
+--   ★ 테이블 소유자 권한이 필요합니다(우리는 fgc 가 소유자이자 접속 롤).
+--     소유자가 아닌 롤로 돌리는 DB에서는 권한 오류로 깨끗하게 실패합니다.
+--     조용히 잘못되는 것보다 낫습니다.
+--
+--   ★ 기각한 대안
+--     · NOT VALID 로 눈감기 → 확정 실행이 영구히 0/10 으로 보이고, 트리거가 모든 UPDATE 를
+--       막으므로 영원히 고칠 수 없습니다. V6 §2-1 이 NOT VALID 를 쓴 건 값을 "알 수 없을"
+--       때였습니다. 여기는 바로 아래 CHECK 에 답이 적혀 있습니다.
+--     · 읽기 시점 유도(COALESCE(NULLIF(...))) → CHECK 를 느슨하게 만들고 스텝퍼·진행률바·
+--       대시보드·확정조건 네 곳이 fallback 을 기억해야 합니다.
+--     · ALTER COLUMN ... TYPE ... USING → 테이블 재작성이라 트리거를 안 거치지만,
+--       감사자가 grep 할 수 없는 은닉 우회입니다. DISABLE TRIGGER 는 grep 됩니다.
+DO $$
+DECLARE
+  v_fixed bigint;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM fgc.validation_run
+     WHERE status = 'FINALIZED' AND current_step = 0
+  ) THEN
+    RETURN;   -- ★ 정상 경로. 가드를 건드리지 않고 끝낸다
+  END IF;
+
+  ALTER TABLE fgc.validation_run DISABLE TRIGGER trg_validation_run_finalized;
+
+  WITH fixed AS (
+    UPDATE fgc.validation_run
+       SET current_step = 10
+     WHERE status = 'FINALIZED'
+       AND current_step = 0
+    RETURNING validation_run_id
+  )
+  INSERT INTO fgc.audit_log
+    (action_code, entity_type, entity_id, before_value, after_value, reason)
+  SELECT 'MIGRATION_BACKFILL',
+         'validation_run',
+         f.validation_run_id::text,
+         jsonb_build_object('current_step', 0),
+         jsonb_build_object('current_step', 10),
+         'V7(v2.1.7) 신규 컬럼 current_step 초기값 보정. '
+         'FINALIZED 는 10 이라는 것이 ck_validation_run_step 이 강제하는 항등식이므로 추정값이 아니다. '
+         '확정 당시 기록된 컬럼은 하나도 바꾸지 않았다. '
+         '이 한 문장을 위해 trg_validation_run_finalized 를 같은 트랜잭션 안에서만 껐다 켰다.'
+    FROM fixed f;
+
+  GET DIAGNOSTICS v_fixed = ROW_COUNT;
+
+  ALTER TABLE fgc.validation_run ENABLE TRIGGER trg_validation_run_finalized;
+
+  RAISE NOTICE
+    'V7: FINALIZED 실행 %건의 current_step 을 10 으로 보정하고 audit_log 에 남겼습니다. 불변 가드는 다시 켜졌습니다.',
+    v_fixed;
+END;
+$$;
+
+ALTER TABLE fgc.validation_run DROP CONSTRAINT IF EXISTS ck_validation_run_step;
+ALTER TABLE fgc.validation_run ADD CONSTRAINT ck_validation_run_step CHECK (
+     (status = 'CREATED'             AND current_step = 0)
+  OR (status IN ('RUNNING','FAILED') AND current_step BETWEEN 0 AND 8)
+  OR (status = 'COMPLETED'           AND current_step = 8)
+  OR (status = 'FINALIZED'           AND current_step = 10)
+);
+
+COMMENT ON CONSTRAINT ck_validation_run_step ON fgc.validation_run IS
+  'status 와 current_step 이 서로 어긋나지 않게 한다. 핵심은 두 가지 — '
+  'current_step=10 은 FINALIZED 일 때만 가능하고(돌지 않은 검증이 확정된 것처럼 보이지 않게), '
+  'FINALIZED 는 반드시 10 이다. RUNNING·FAILED 를 0~8 로 느슨하게 둔 것은 의도적이다 — '
+  '실행 직후 RUNNING+0 을 지나가므로 여기를 조이면 얻는 것 없이 정상 흐름을 막는다.';
+
+
+-- ============================================================================
+-- 2. 실행 INSERT 우회 차단  ★ V6 누락 보완
+--
+--    무엇이 문제였나
+--      V6 는 policy_version 의 INSERT 우회를 막았지만(guard_policy_version_lifecycle)
+--      실행 테이블에는 같은 조치를 하지 않았습니다.
+--      trg_validation_run_lifecycle 과 trg_reconciliation_run_lifecycle 이
+--      BEFORE UPDATE 뿐이라, 아래가 지금은 그냥 통과합니다.
+--
+--        INSERT INTO fgc.validation_run
+--          (validation_month, run_no, status, finalized_at)
+--        VALUES (DATE '2026-08-01', 1, 'FINALIZED', now());
+--
+--      ck_validation_finalized(V1:1078)도 finalized_at 만 요구해서 막지 못합니다.
+--      돌지도 않은 검증이 확정 상태로 태어나면 그 확정에는 근거가 없습니다.
+--      V6 가 상태 "전이"는 막았는데 상태를 가진 채 "태어나는" 경로를 놓친 것입니다.
+--
+--    ★ INSERT 분기에서 즉시 RETURN 하므로 아래쪽 to_jsonb(OLD) 가 NULL 을 만지지 않습니다.
+--      (INSERT 트리거에서 OLD 는 존재하지 않습니다)
+--
+--    시드·코드 영향 — 확인했습니다.
+--      V3·V4 에 validation_run / reconciliation_run INSERT 자체가 없습니다.
+--      Java 에도 실행을 생성하는 코드가 없습니다(ValidationRunController 미구현).
+--      current_step 도 DEFAULT 0 이라 CREATED 조건과 자동으로 맞습니다.
+-- ============================================================================
+--   ★★ SET search_path 를 함수 정의에 인라인으로 붙이는 이유 — 반드시 읽으세요
+--     CREATE OR REPLACE FUNCTION 은 함수 수준 SET 옵션을 "초기화"합니다.
+--     V6 가 맨 뒤 DO 루프로 이 함수에 search_path 를 박아 뒀는데,
+--     여기서 CREATE OR REPLACE 를 하면 그 설정이 조용히 날아갑니다.
+--     (실제로 이번에 그렇게 날아갔고, 적용 후 확인 ⑪에서 잡았습니다)
+--
+--     V6 는 루프를 파일 맨 뒤에 둬서 이 문제를 피했습니다. V7 은 루프가 없으므로
+--     정의에 직접 씁니다. 이렇게 하면 다음 사람이 이 함수를 또 교체할 때도 눈에 보입니다.
+--
+--     ☞ 앞으로 fgc 의 함수를 CREATE OR REPLACE 하는 마이그레이션은 반드시
+--       (a) 정의에 SET search_path 를 인라인으로 쓰거나
+--       (b) 파일 맨 뒤에서 V6 §5 의 핀 루프를 다시 돌려야 합니다.
+--       적용 후 확인 ⑪ 로 검증하세요.
+CREATE OR REPLACE FUNCTION fgc.guard_run_lifecycle()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = fgc, pg_temp
+AS $$
+BEGIN
+  -- v2.1.7 신규 : INSERT 우회 차단. 실행은 반드시 CREATED 로 태어난다.
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.status <> 'CREATED' THEN
+      RAISE EXCEPTION
+        '% must be inserted as CREATED (got %); advance it with UPDATE',
+        TG_TABLE_NAME, NEW.status;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF NEW.status IS DISTINCT FROM OLD.status THEN
+    IF NOT (
+      (OLD.status = 'CREATED'   AND NEW.status = 'RUNNING') OR
+      (OLD.status = 'RUNNING'   AND NEW.status IN ('COMPLETED','FAILED')) OR
+      (OLD.status = 'COMPLETED' AND NEW.status = 'FINALIZED') OR
+      (OLD.status = 'FAILED'    AND NEW.status = 'RUNNING')
+    ) THEN
+      RAISE EXCEPTION 'Invalid % status transition: % -> % (run %)',
+        TG_TABLE_NAME, OLD.status, NEW.status, to_jsonb(OLD) ->> TG_ARGV[0];
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION fgc.guard_run_lifecycle() IS
+  'validation_run·reconciliation_run 공용 생명주기 가드. '
+  'INSERT 는 CREATED 만 허용(v2.1.7). '
+  '전이 허용 : CREATED→RUNNING, RUNNING→COMPLETED, RUNNING→FAILED, COMPLETED→FINALIZED, FAILED→RUNNING. '
+  '트리거 인자로 PK 컬럼명을 넘긴다(오류 메시지 전용). '
+  'FINALIZED 이후 불변성은 기존 guard_*_run_finalized 트리거가 담당한다(중복 구현 금지)';
+
+-- 트리거를 INSERT 까지 확장. 이름은 그대로 두어 기존 실행 순서(finalized < lifecycle)를 지킵니다.
+DROP TRIGGER IF EXISTS trg_validation_run_lifecycle ON fgc.validation_run;
+CREATE TRIGGER trg_validation_run_lifecycle
+BEFORE INSERT OR UPDATE ON fgc.validation_run
+FOR EACH ROW EXECUTE FUNCTION fgc.guard_run_lifecycle('validation_run_id');
+
+DROP TRIGGER IF EXISTS trg_reconciliation_run_lifecycle ON fgc.reconciliation_run;
+CREATE TRIGGER trg_reconciliation_run_lifecycle
+BEFORE INSERT OR UPDATE ON fgc.reconciliation_run
+FOR EACH ROW EXECUTE FUNCTION fgc.guard_run_lifecycle('reconciliation_run_id');
+
+
+-- ============================================================================
+-- 3. V5 스냅샷 컬럼 잠금
+--
+--    무엇이 문제였나
+--      V5 는 cap_check_detail 에 item_code·item_name·contract_month_no 를 추가해
+--      "검증 당시 항목명"을 스냅샷으로 남기게 했습니다. 목적은 정확합니다 —
+--      나중에 마스터가 바뀌어도 과거 판정 근거가 그때 값으로 남아야 합니다(CAP-W02).
+--
+--      그런데 세 컬럼 모두 NULL 을 허용해서, 값을 넣지 않아도 행이 저장됩니다.
+--      즉 애플리케이션이 V5 의 목적을 조용히 우회할 수 있었습니다.
+--
+--    ★ dev DB 는 0행이라 지금 잠그는 것이 가장 쌉니다. 데이터가 쌓인 뒤에는 과거 항목명을
+--      복구할 방법이 없습니다(마스터가 이미 바뀌었을 수 있으므로).
+--      ☞ 다만 "0행이니까 안전하다"는 이 파일 초판을 망친 가정입니다.
+--        이 마이그레이션이 살아남아야 할 DB 들에는 거짓입니다.
+--        아래 백필은 행이 있는 DB를 전제로 씁니다.
+--
+--    ★ contract_month_no 는 왜 무조건 NOT NULL 이 아닌가
+--      ck_cap_detail_source(V1:1140-1142)가 transaction_attribution_id 와
+--      schedule_line_id 중 하나만 허용합니다.
+--      귀속행(실제 지급건) 출처의 상세행에는 "회차"라는 개념이 없습니다.
+--      그래서 schedule_line 이 있는 행에만 조건부로 강제합니다.
+--
+--    ★ 읽기 쪽 Java 도 함께 고쳐야 합니다.
+--      CapCheckDetailLine.java 의 contractMonthNo 가 primitive int 였습니다.
+--      귀속행 출처 행을 조회하면 MyBatis 가 NULL 을 언박싱하며 터집니다.
+--      이 마이그레이션과 같은 커밋에서 Integer 로 바꿉니다.
+-- ============================================================================
+
+-- ── 기존 행 보정 ──────────────────────────────────────────────────────────
+--
+--   ★★ 백필의 방향이 §1 과 정반대입니다 — 반드시 읽으세요
+--     §1 의 current_step 은 status 에서 확정적으로 유도됩니다(FINALIZED ⇒ 10).
+--     그래서 §1 은 가드를 잠시 내리고 채웁니다.
+--     여기 item_code·item_name 은 "계산 당시" 마스터 값의 스냅샷입니다.
+--     지금 commission_item 을 읽어 채우면, 그 사이 마스터가 바뀐 만큼
+--     과거 판정 근거를 현재 값으로 위조하는 것이 됩니다.
+--     (commission_item 은 trg_commission_item_updated_at 이 붙은, 실제로 바뀌는 표입니다)
+--     확정(FINALIZED)된 실행에 대해서는 그것이 마이그레이션 실패보다 나쁩니다.
+--     위조된 증거는 조용하고 되돌릴 수 없고 나중에 구별조차 안 됩니다.
+--     실패한 마이그레이션은 시끄럽고 아무것도 바꾸지 않습니다.
+--     ☞ 판단 기준은 하나입니다 : 값이 유도 가능한가, 관측된 것인가.
+--       유도 가능하면 채운다(§1). 관측된 것이면 멈춘다(여기).
+--
+--   ★ 왜 NOT VALID CHECK 로 눈감아 주지 않나 (V6 §2-1 과 다른 판단인 이유)
+--     V6 가 NOT VALID 를 쓴 대상은 "V2 가 만든 그 한 행"으로 정체·출처·처분이 이미
+--     특정되고 팀이 유산으로 남기기로 결정한 행이었습니다.
+--     여기는 그런 행이 있는지조차 모릅니다. 있다면 그건 유산이 아니라,
+--     애플리케이션이 지금도 스냅샷 없이 증거행을 쓰고 있다는 살아 있는 결함입니다.
+--     NOT VALID 는 찾아내야 할 그 신호를 영구히 조용하게 만듭니다.
+--
+--   ★ 아래 DO 블록은 이 파일 초판이 주석으로만 말하던 것을 코드로 만듭니다.
+--     초판에는 "값을 몰래 채우지 말고 담당자 결정을 받아야 합니다"라고 적혀 있었지만,
+--     실제 동작은 트리거 두 겹 안쪽에서 나오는 알아볼 수 없는 오류였습니다.
+--     코드가 배반하는 주석은 없는 주석보다 나쁩니다.
+DO $$
+DECLARE
+  v_item  bigint;
+  v_month bigint;
+BEGIN
+  SELECT count(*) FILTER (WHERE d.item_code IS NULL OR d.item_name IS NULL),
+         count(*) FILTER (WHERE d.schedule_line_id IS NOT NULL AND d.contract_month_no IS NULL)
+    INTO v_item, v_month
+    FROM fgc.cap_check_detail d
+   WHERE (d.item_code IS NULL
+          OR d.item_name IS NULL
+          OR (d.schedule_line_id IS NOT NULL AND d.contract_month_no IS NULL))
+     AND EXISTS (
+           SELECT 1
+             FROM fgc.cap_check c
+             JOIN fgc.validation_run v ON v.validation_run_id = c.validation_run_id
+            WHERE c.cap_check_id = d.cap_check_id
+              AND v.status = 'FINALIZED');
+
+  IF v_item > 0 OR v_month > 0 THEN
+    RAISE EXCEPTION
+      'V7 중단 : 확정(FINALIZED) 실행의 cap_check_detail 에 스냅샷 없는 행이 있습니다 (item_code/item_name %건, contract_month_no %건). 이 값은 되살릴 수 없습니다 — 지금 마스터를 읽어 채우면 과거 판정 근거를 위조합니다. 마이그레이션은 채우지 않고 멈춥니다(아무것도 바뀌지 않았습니다).',
+      v_item, v_month
+      USING HINT =
+        '대상 조회: SELECT d.cap_check_detail_id, v.validation_run_id, v.validation_month, v.run_no, d.item_code, d.item_name, d.schedule_line_id, d.contract_month_no FROM fgc.cap_check_detail d JOIN fgc.cap_check c USING (cap_check_id) JOIN fgc.validation_run v USING (validation_run_id) WHERE v.status = ''FINALIZED'' AND (d.item_code IS NULL OR d.item_name IS NULL OR (d.schedule_line_id IS NOT NULL AND d.contract_month_no IS NULL)); ★ 이것은 감사 결함입니다. 담당자 결정(해당 실행 재검증 또는 예외 승인 기록) 없이 V7 을 적용하지 마세요. 트리거를 끄고 채우는 것은 답이 아닙니다.';
+  END IF;
+END;
+$$;
+
+-- 확정되지 않은 실행(및 run 이 없는 실시간 검증)의 행만 채웁니다.
+--
+--   ★ COALESCE 를 쓰는 이유
+--     초판은 WHERE 가 "둘 중 하나라도 NULL"인데 SET 은 "둘 다"였습니다.
+--     item_name 만 비어 있는 행에서 제대로 저장돼 있던 과거 item_code 가
+--     현재 마스터 값으로 조용히 덮였습니다.
+--     스냅샷을 지키려는 문장이 스냅샷을 파괴하고 있었던 셈입니다.
+--     (UPDATE 의 SET 우변 d.item_code 는 갱신 전 값입니다)
+--
+--   ★ validation_run 을 JOIN 하지 않고 NOT EXISTS 를 쓰는 이유 — 함정입니다
+--     cap_check.validation_run_id 는 NULL 허용입니다(REALTIME 검증은 run 이 없습니다).
+--     JOIN 해서 v.status <> 'FINALIZED' 로 쓰면 run 없는 상세행이 조인에서 탈락해
+--     NULL 로 남고, 바로 아래 SET NOT NULL 이 실패합니다.
+--     고치려는 문장에서 같은 실패를 다시 만드는 것입니다.
+--     NOT EXISTS 는 그 행을 포함합니다. 그리고 이 술어는
+--     guard_finalized_validation_result 가 실제로 검사하는 집합과 정확히 같습니다
+--     (그 함수도 NULL run_id 를 array_remove 로 걸러 통과시킵니다).
+--     그래서 이 UPDATE 는 트리거에 "걸릴 리 없는" 것이 아니라 구조적으로 걸릴 수 없습니다.
+--
+--   ★ 이 백필 뒤에 NULL 이 남지 않는 근거 (SET NOT NULL 성공 보장)
+--     ① cap_check_detail.commission_item_id 는 NOT NULL + FK → 조인이 반드시 1행 매칭됩니다.
+--     ② commission_item.item_code·item_name 은 둘 다 NOT NULL 입니다.
+--     ③ 따라서 조인이 닿는 행은 전부 채워지고, 남는 NULL 은 위에서 제외한
+--        "확정 실행의 행"뿐입니다. 그런 행이 있으면 위 DO 블록이 이미 멈췄으므로
+--        여기까지 오지 못합니다.
+--
+--   ★ ALTER TABLE(SET NOT NULL / ADD CONSTRAINT)은 행 트리거를 발동시키지 않습니다.
+--     트리거에 노출되는 것은 아래 UPDATE 두 개뿐이라, 범위를 좁힐 곳도 여기뿐입니다.
+UPDATE fgc.cap_check_detail d
+   SET item_code = COALESCE(d.item_code, i.item_code),
+       item_name = COALESCE(d.item_name, i.item_name)
+  FROM fgc.commission_item i
+ WHERE i.commission_item_id = d.commission_item_id
+   AND (d.item_code IS NULL OR d.item_name IS NULL)
+   AND NOT EXISTS (
+         SELECT 1
+           FROM fgc.cap_check c
+           JOIN fgc.validation_run v ON v.validation_run_id = c.validation_run_id
+          WHERE c.cap_check_id = d.cap_check_id
+            AND v.status = 'FINALIZED');
+
+-- ★ contract_month_no 도 채웁니다 — 초판이 빠뜨린 세 번째 실패 지점입니다.
+--   V5 는 세 컬럼을 모두 nullable 로 추가했으므로, V5 이전에 들어간 행 중
+--   schedule_line_id 가 있는 행은 contract_month_no 가 NULL 입니다.
+--   그 상태로 아래 ck_cap_detail_month_snapshot 을 (NOT VALID 아닌) 그냥 붙이면
+--   그 DB에서 V7 적용이 실패합니다. item_code 와 똑같은 실패 유형입니다.
+--
+--   이건 위조가 아닙니다 : schedule_line_id 는 FK 라 그 스케줄행이 그대로 살아 있고,
+--   contract_month_no 는 그 행 자체의 속성(schedule_line 에서 NOT NULL)이라
+--   "다른 값을 끌어오는" 것이 아니라 같은 행에서 다시 읽는 것입니다.
+--   그래도 확정 실행은 손대지 않습니다 — 위 DO 블록이 이미 그런 DB를 세웁니다.
+UPDATE fgc.cap_check_detail d
+   SET contract_month_no = s.contract_month_no
+  FROM fgc.schedule_line s
+ WHERE s.schedule_line_id = d.schedule_line_id
+   AND d.contract_month_no IS NULL
+   AND NOT EXISTS (
+         SELECT 1
+           FROM fgc.cap_check c
+           JOIN fgc.validation_run v ON v.validation_run_id = c.validation_run_id
+          WHERE c.cap_check_id = d.cap_check_id
+            AND v.status = 'FINALIZED');
+
+ALTER TABLE fgc.cap_check_detail
+  ALTER COLUMN item_code SET NOT NULL,
+  ALTER COLUMN item_name SET NOT NULL;
+
+ALTER TABLE fgc.cap_check_detail DROP CONSTRAINT IF EXISTS ck_cap_detail_month_snapshot;
+ALTER TABLE fgc.cap_check_detail ADD CONSTRAINT ck_cap_detail_month_snapshot CHECK (
+  schedule_line_id IS NULL OR contract_month_no IS NOT NULL
+);
+
+COMMENT ON CONSTRAINT ck_cap_detail_month_snapshot ON fgc.cap_check_detail IS
+  '예상 스케줄에서 온 상세행은 계산 당시 회차를 반드시 스냅샷한다. '
+  '귀속행(실제 지급건) 출처는 회차 개념이 없어 NULL 이 정당하다 — '
+  '읽는 쪽 DTO 는 primitive 가 아니라 Integer 여야 한다(CapCheckDetailLine).';
+
+COMMENT ON COLUMN fgc.cap_check_detail.item_code IS
+  '계산 당시 commission_item.item_code 스냅샷. NOT NULL(v2.1.7) — '
+  '이후 항목 코드가 바뀌어도 판정 근거는 그대로 남는다(CAP-W02)';
+COMMENT ON COLUMN fgc.cap_check_detail.item_name IS
+  '계산 당시 commission_item.item_name 스냅샷. NOT NULL(v2.1.7)';
+COMMENT ON COLUMN fgc.cap_check_detail.contract_month_no IS
+  '계산 당시 schedule_line.contract_month_no 스냅샷. '
+  'schedule_line 출처면 필수, 귀속행 출처면 NULL(ck_cap_detail_month_snapshot)';
+
+
+-- ============================================================================
+-- 적용 후 확인
+-- ============================================================================
+-- ① 실행을 FINALIZED 로 직삽 (실패해야 정상)
+--    INSERT INTO fgc.validation_run (validation_month, run_no, status, finalized_at)
+--    VALUES (date_trunc('month', current_date)::date, 901, 'FINALIZED', now());
+--    → ERROR: validation_run must be inserted as CREATED (got FINALIZED)
+--
+-- ② 대사 실행도 같은지 (실패해야 정상)
+--    INSERT INTO fgc.reconciliation_run (settlement_month, payment_stage, status)
+--    VALUES (date_trunc('month', current_date)::date, 'GA_TO_FC', 'RUNNING');
+--    → ERROR: reconciliation_run must be inserted as CREATED (got RUNNING)
+--
+-- ③ 정상 생성 후 기본값 (CREATED / 0 이어야 정상)
+--    INSERT INTO fgc.validation_run (validation_month, run_no)
+--    VALUES (date_trunc('month', current_date)::date, 901);
+--    SELECT status, current_step FROM fgc.validation_run WHERE run_no = 901;
+--    → CREATED | 0
+--
+-- ④ 10단계 정상 진행 (전부 성공해야 정상)
+--    UPDATE fgc.validation_run SET status='RUNNING', current_step=1, started_at=now() WHERE run_no=901;
+--    UPDATE fgc.validation_run SET current_step=8, status='COMPLETED', completed_at=now() WHERE run_no=901;
+--    UPDATE fgc.validation_run SET status='FINALIZED', current_step=10, finalized_at=now() WHERE run_no=901;
+--
+-- ⑤ 확정인데 단계가 8 (실패해야 정상)
+--    → ck_validation_run_step 위반
+--
+-- ⑥ RUNNING 인데 단계가 10 (실패해야 정상)
+--    UPDATE fgc.validation_run SET current_step=10 WHERE run_no=901 AND status='RUNNING';
+--    → ck_validation_run_step 위반
+--    (정리) DELETE FROM fgc.validation_run WHERE run_no=901;   -- FINALIZED 면 삭제도 막힙니다
+--
+-- ⑦ 스냅샷 없이 상세행 저장 (실패해야 정상)
+--    item_code / item_name 을 빼고 INSERT → NOT NULL 위반
+--
+-- ⑧ 스케줄 출처인데 회차 없음 (실패해야 정상)
+--    schedule_line_id 를 넣고 contract_month_no 를 비우고 INSERT
+--    → ck_cap_detail_month_snapshot 위반
+--
+-- ⑨ 귀속행 출처이고 회차 없음 (★ 성공해야 정상)
+--    transaction_attribution_id 를 넣고 contract_month_no 를 비우고 INSERT
+--    → 성공. 귀속행에는 회차 개념이 없다
+--
+-- ⑩ V6 회귀 — 아래 세 개가 여전히 막혀야 정상
+--    · 정책을 ACTIVE 로 직삽 → 'must be inserted as DRAFT'
+--    · 실행 상태 점프 CREATED→FINALIZED → 'Invalid ... transition'
+--    · 처리기록 UPDATE → 'is append-only'
+--
+-- ⑪ search_path 가 안 박힌 함수 (★ IMMUTABLE 3개만 나와야 정상)
+--    SELECT proname FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--     WHERE n.nspname='fgc' AND p.prokind='f' AND p.proconfig IS NULL ORDER BY 1;
+--    → is_first_day_of_month / is_within_first_year / round_krw_half_up
+--
+--    이 목록에 guard_* 가 나오면 그 함수를 CREATE OR REPLACE 하면서
+--    SET search_path 를 잃은 것입니다. 위 §2 의 ★★ 주석을 보세요.
+--    함수를 교체하는 마이그레이션마다 이 쿼리를 돌리는 것이 가장 확실합니다.
+--
+-- ⑫ 불변 가드가 다시 켜졌는가 (★ ENABLE 을 빠뜨렸을 때 유일하게 잡아내는 검사)
+--    SELECT tgname, tgenabled FROM pg_trigger
+--     WHERE tgrelid = 'fgc.validation_run'::regclass AND NOT tgisinternal ORDER BY 1;
+--    → trg_validation_run_finalized  O
+--      trg_validation_run_lifecycle  O        ← 'D' 가 나오면 즉시 실패
+--
+-- ⑬ 우회 후에도 불변성이 실제로 복구됐는가 (아래가 실패해야 정상)
+--    UPDATE fgc.validation_run SET failure_message='x' WHERE status='FINALIZED';
+--    → ERROR: Finalized validation run N is immutable
+--
+-- ⑭ 우회가 증거를 남겼는가 (FINALIZED 행을 보정한 DB 에서만 행이 있다)
+--    SELECT entity_id, before_value, after_value, reason FROM fgc.audit_log
+--     WHERE action_code = 'MIGRATION_BACKFILL' AND entity_type = 'validation_run';
+--
+-- ⑮ COALESCE 가 살아 있는가 (★ 누가 "단순화"하면 이것만 잡아낸다)
+--    비확정 실행의 상세행에 item_code='LEGACY_CODE', item_name=NULL 을 넣고 V7 을 적용하면
+--    item_code 는 'LEGACY_CODE' 그대로 남고 item_name 만 채워져야 정상이다.
+--    둘 다 현재 마스터 값으로 바뀌면 스냅샷을 파괴하는 회귀다.
+-- ============================================================================


### PR DESCRIPTION
## 핵심 변경사항

- `validation_run`에 10단계 진행률 `current_step` 추가
- `validation_run`·`reconciliation_run`의 비정상 상태 INSERT 차단
- CAP 계산근거 항목 코드·항목명 스냅샷 필수화
- 스케줄 기반 계산근거의 계약회차 스냅샷 강제
- 기존 Flyway 파일은 수정하지 않고 V6·V7 신규 마이그레이션으로 보강

## 왜 필요한가

**1. 10단계 진행률에 저장할 자리가 없었습니다.**

VRUN-W02 스텝퍼·VRUN-W01·DASH-W01 진행률 바·확정조건 1번이 모두 `step` 값을 읽는데, `validation_run`에 그 컬럼이 없었습니다. 목업은 `localStorage`로 흉내 내고 있었습니다.

`status`(5개)와 10단계는 서로 다른 축입니다. `status`는 실행의 거친 생명주기, 10단계는 `RUNNING` 안에서의 진행 위치입니다. 두 번째 축을 저장하지 않았던 것이 문제였습니다.

Spring Batch 메타테이블(`batch_step_execution`) 역산은 성립하지 않습니다 — Step 8개가 10단계와 1:1이 아니고(6단계=Step 2개, 4단계=partition 2개, 7단계=2회), 9·10단계는 사람이 하므로 Step 자체가 없고, `job_execution_id`를 보존하지 않아 조인할 키도 없습니다. `V2` 헤더가 이미 "배치 메타테이블을 업무 로직이 읽는 구조"를 거부했습니다.

**2. 실행이 확정 상태로 태어날 수 있었습니다.**

lifecycle 가드가 `BEFORE UPDATE` 전용이라 아래가 통과했습니다. 돌지도 않은 검증이 확정되면 그 확정에는 근거가 없습니다.

```sql
INSERT INTO fgc.validation_run (validation_month, run_no, status, finalized_at)
VALUES (DATE '2026-08-01', 1, 'FINALIZED', now());
```

**3. V5 스냅샷 컬럼이 NULL을 허용해 목적을 우회할 수 있었습니다.**

## 검증

빈 DB에 V1→V7 전체 적용 후 확인 항목 15개 통과. `./gradlew test` 전체 통과(15 클래스 54 테스트, 실패 0).

**확정 실행이 있는 DB**를 별도로 재현해 테스트했습니다. 초판은 이 경우 적용이 실패했고(`Finalized validation run N is immutable`), dev DB가 0행이라 잡히지 않았습니다.

| 테스트 | 상태 |
|---|---|
| 확정 실행 존재 시 적용 성공 | 통과 |
| 확정 실행의 스냅샷 결함 시 명확한 메시지로 중단 + 전체 롤백 | 통과 |
| 우회 후 불변 가드 재활성 및 불변성 복구 | 통과 |
| 확정 실행 상세행 스냅샷 위조되지 않음 | 통과 |
| 한쪽만 NULL인 스냅샷에서 살아 있는 값 보존(COALESCE) | 통과 |

## ⚠️ 리뷰어가 알아야 할 것

**V7은 `trg_validation_run_finalized`를 같은 트랜잭션 안에서만 껐다 켭니다.** 확정된 실행의 *신규 컬럼* 초기값을 채우기 위해서입니다.

- `FINALIZED ⇒ 10`은 `ck_validation_run_step`이 강제하는 항등식이라 추정값이 아닙니다
- 대상은 V7이 방금 만든 컬럼 하나뿐 — 확정 당시 기록된 컬럼은 바뀌지 않습니다
- **고칠 행이 없으면 트리거를 아예 건드리지 않습니다**
- 보정 사실은 `audit_log`에 `action_code='MIGRATION_BACKFILL'`로 남습니다

반대로 `cap_check_detail`의 항목명 스냅샷은 **관측된 값**이라 절대 채우지 않고 **중단**합니다. 지금 마스터를 읽어 채우면 과거 판정 근거를 위조하게 됩니다. 판단 기준은 하나입니다 — 값이 유도 가능한가, 관측된 것인가.

## Known follow-up

```
V2에서 직접 ACTIVE로 생성된 STATUS-MONTH-RULE-2026 v1 유산 정책은
운영 데이터 확인 후 RETIRED 처리하고, 정상 승인 절차를 거친 후속 버전을
발행한 뒤 ck_policy_authorship 제약을 VALIDATE해야 한다.
(V6에서 의도적으로 NOT VALID로 두었음)
```

- `MIGRATION_BACKFILL`은 신규 `action_code`입니다. `audit_log`에 CHECK가 없어 안전하지만, 감사로그 화면이 코드별 라벨을 렌더링하면 항목 추가가 필요합니다.
- 별건: `.gitignore`의 `CLAUDE.mdsrc/main/resources/application-prod.yml`이 한 줄로 붙어 있어 `application-prod.yml`이 실제로는 ignore되지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)