### PR TITLE
[Fix] API 경로를 /api/v1/cap/checks -> /api/v1/cap-checks로 변경

### DIFF
--- a/src/main/java/com/susukkang/fgc/cap/controller/CapCheckController.java
+++ b/src/main/java/com/susukkang/fgc/cap/controller/CapCheckController.java
@@ -34,7 +34,7 @@ import java.util.Map;
  */
 @Tag(name = "1200% 한도", description = "초년도 모집수수료 한도 계산 목록 조회 API")
 @RestController
-@RequestMapping("/api/v1/cap/checks")
+@RequestMapping("/api/v1/cap-checks")
 @RequiredArgsConstructor
 public class CapCheckController {
 

--- a/src/test/java/com/susukkang/fgc/auth/AuthLoginFlowTest.java
+++ b/src/test/java/com/susukkang/fgc/auth/AuthLoginFlowTest.java
@@ -114,7 +114,7 @@ class AuthLoginFlowTest {
     // 미인증 REST 요청은 리다이렉트하지 않고 401 (인터페이스정의서 3-4: Ajax = 401)
     @Test
     void anonymousApiRequestReturnsUnauthorized() throws Exception {
-        mockMvc.perform(get("/api/v1/cap/checks"))
+        mockMvc.perform(get("/api/v1/cap-checks"))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -133,7 +133,7 @@ class AuthLoginFlowTest {
                 .getRequest()
                 .getSession(false);
 
-        mockMvc.perform(get("/api/v1/cap/checks").param("month", "2026-07").session(session))
+        mockMvc.perform(get("/api/v1/cap-checks").param("month", "2026-07").session(session))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/susukkang/fgc/cap/controller/CapCheckControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/cap/controller/CapCheckControllerTest.java
@@ -79,7 +79,7 @@ class CapCheckControllerTest {
                 PageResponse.of(List.of(sampleListRow(CapResultStatus.NORMAL)), 1, 20, 1, "asOfDate,desc"));
         given(capCheckService.search(any(), anyInt(), anyInt())).willReturn(searchResult);
 
-        mockMvc.perform(get("/api/v1/cap/checks").with(user("settle01").roles("SETTLEMENT")))
+        mockMvc.perform(get("/api/v1/cap-checks").with(user("settle01").roles("SETTLEMENT")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.summary.normal").value(3))
                 .andExpect(jsonPath("$.data.summary.violation").value(1))
@@ -94,7 +94,7 @@ class CapCheckControllerTest {
 
     @Test
     void searchRequiresAuthentication() throws Exception {
-        mockMvc.perform(get("/api/v1/cap/checks")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/v1/cap-checks")).andExpect(status().isUnauthorized());
     }
 
     // page/size 범위 검증은 CapCheckServiceImpl이 담당하지만(단위테스트에서 직접 검증),
@@ -105,7 +105,7 @@ class CapCheckControllerTest {
                 .willThrow(new FgcBusinessException(FgcErrorCode.COMMON_002, "page",
                         java.util.Map.of("field", "page"), null));
 
-        mockMvc.perform(get("/api/v1/cap/checks").param("page", "0")
+        mockMvc.perform(get("/api/v1/cap-checks").param("page", "0")
                         .with(user("settle01").roles("SETTLEMENT")))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error.code").value("FGC-COMMON-002"));
@@ -130,7 +130,7 @@ class CapCheckControllerTest {
     void findDetailReturnsNestedCapCheckDetailsAndCalculationSnapshot() throws Exception {
         given(capCheckService.findDetail(999L)).willReturn(Optional.of(sampleBasisResponse()));
 
-        mockMvc.perform(get("/api/v1/cap/checks/999/details").with(user("settle01").roles("SETTLEMENT")))
+        mockMvc.perform(get("/api/v1/cap-checks/999/details").with(user("settle01").roles("SETTLEMENT")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.capCheck.capCheckId").value(999))
                 .andExpect(jsonPath("$.data.capCheck.contractNo").value("C001"))
@@ -149,13 +149,13 @@ class CapCheckControllerTest {
     void findDetailReturns404WhenCapCheckIdDoesNotExist() throws Exception {
         given(capCheckService.findDetail(999L)).willReturn(Optional.empty());
 
-        mockMvc.perform(get("/api/v1/cap/checks/999/details").with(user("settle01").roles("SETTLEMENT")))
+        mockMvc.perform(get("/api/v1/cap-checks/999/details").with(user("settle01").roles("SETTLEMENT")))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.error.code").value("FGC-COMMON-004"));
     }
 
     @Test
     void findDetailRequiresAuthentication() throws Exception {
-        mockMvc.perform(get("/api/v1/cap/checks/999/details")).andExpect(status().isUnauthorized());
+        mockMvc.perform(get("/api/v1/cap-checks/999/details")).andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* `CapCheckController`의 API 경로를 `/api/v1/cap/checks` → `/api/v1/cap-checks`로 변경

## 🔗 2. 관련 이슈

* Closes #40

## 🛠 3. 구현 내용

* `CapCheckController`의 `@RequestMapping` 값을 `/api/v1/cap/checks`에서 `/api/v1/cap-checks`로 수정 (다른 리소스인 `commission-items`, `validation-runs`, `contracts`와 케밥케이스 명명 규칙 통일)
* 변경된 경로를 참조하던 테스트 코드 수정: `AuthLoginFlowTest`, `CapCheckControllerTest`

## 🧪 4. 테스트 방법

1. `./gradlew test` 실행 (docker-compose로 DB 기동 필요)
2. `CapCheckControllerTest` 6건, `AuthLoginFlowTest` 포함 전체 테스트 통과 확인
3. `GET /api/v1/cap-checks`, `GET /api/v1/cap-checks/{capCheckId}/details` 호출로 정상 응답 확인

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* URL 경로 변경이 프론트엔드/다른 소비자와 계약된 경로와 일치하는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음

## 💬 9. 참고 사항

* URL 경로만 변경되었고 요청/응답 스펙(파라미터, 응답 필드)은 변경되지 않았습니다.
* 이 API를 호출하는 프론트엔드나 외부 클라이언트가 있다면 경로 변경 반영이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - Cap Check API의 기본 경로가 `/api/v1/cap/checks`에서 `/api/v1/cap-checks`로 변경되었습니다.
  - 목록 조회와 상세 조회 기능의 동작 및 응답은 기존과 동일합니다.
  - 익명 요청과 로그인 상태에서 사용하는 관련 API 호출도 새로운 경로를 지원합니다.
  - 페이지 범위 오류, 인증 검증, 존재하지 않는 항목 조회 등 관련 기능이 새 API 경로에서 정상적으로 동작하도록 정비되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->