### PR TITLE
fix(ci): Dependabot PR 자동화 오류 수정

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-    labels: [dependencies]
     # 일반 버전 업데이트는 minor/patch만 한 PR로 묶는다.
     # 메이저 업그레이드는 호환성·마이그레이션 검토가 필요한 별도 작업으로 진행한다.
     groups:
@@ -35,7 +34,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
-    labels: [dependencies]
     # SHA 고정은 유지하면서 같은 메이저 안의 업데이트만 한 PR로 받는다.
     groups:
       github-actions-minor-patch:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,6 +31,8 @@ jobs:
         uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # 자동 의존성 PR만 허용한다. "*"로 모든 bot을 허용하지 않는다.
+          allowed_bots: "dependabot[bot]"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
존재하지 않는 dependencies 라벨 설정을 제거하고 Claude 리뷰에서 dependabot[bot]만 명시적으로 허용합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **자동화**
  * Dependabot 업데이트에 자동으로 추가되던 `[dependencies]` 라벨을 제거했습니다.
  * Claude 코드 리뷰가 Dependabot의 자동 의존성 업데이트 PR을 지원하도록 개선했습니다.
  * 기존 업데이트 주기, 그룹화 및 메이저 버전 제외 설정은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->