### PR TITLE
fix(ci): Dependabot PR의 Claude 리뷰 제외

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   claude-review:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -31,8 +32,6 @@ jobs:
         uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # 자동 의존성 PR만 허용한다. "*"로 모든 bot을 허용하지 않는다.
-          allowed_bots: "dependabot[bot]"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Dependabot 실행에는 Actions secret이 제공되지 않으므로 Claude 리뷰 작업만 건너뜁니다. 사람 작성자의 PR 자동 리뷰는 유지됩니다.