### PR TITLE
[Feat] FUN-009 수수료 항목 기준정보 화면 연동

### DIFF
--- a/src/main/java/com/susukkang/fgc/base/controller/BaseViewController.java
+++ b/src/main/java/com/susukkang/fgc/base/controller/BaseViewController.java
@@ -1,0 +1,33 @@
+package com.susukkang.fgc.base.controller;
+
+import com.susukkang.fgc.base.service.CommissionItemService;
+import com.susukkang.fgc.common.util.DateUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+import java.time.LocalDate;
+
+/**
+ * 설명 : 기준정보 조회 화면
+ *
+ * @author yslee
+ * @since 2026-08-11
+ * @version 1.2
+ */
+@Controller
+@RequiredArgsConstructor
+public class BaseViewController {
+
+    private final CommissionItemService commissionItemService;
+
+    @GetMapping("/base")
+    public String index(@ModelAttribute("month") String month, Model model) {
+        LocalDate asOf = DateUtil.parseSettlementMonth(month);
+        model.addAttribute("asOf", asOf);
+        model.addAttribute("commissionItems", commissionItemService.findEffectiveItems(asOf));
+        return "base/index";
+    }
+}

--- a/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
+++ b/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
@@ -18,11 +18,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class ScreenViewController {
 
-    @GetMapping("/base")
-    public String base() {
-        return "base/index";
-    }
-
     @GetMapping("/policies")
     public String policies() {
         return "policy/list";

--- a/src/main/resources/templates/base/index.html
+++ b/src/main/resources/templates/base/index.html
@@ -28,6 +28,11 @@
     1차에서는 <strong>보기만</strong> 합니다. 등록·수정 기능은 2차에 만듭니다.
   </p>
 
+  <!-- 2026-08-12 yslee - FUN-009 조회 기준일과 실제 수수료 항목 데이터를 화면에 연결 -->
+  <p class="fgc-muted" style="margin-top:8px;font-size:12px">
+    조회 기준일: <span class="fgc-mono" th:text="${asOf}">2026-08-01</span>
+  </p>
+
   <div class="fgc-banner fgc-banner--muted" style="margin-top:12px">
     <span class="material-symbols-outlined" style="font-size:18px">database</span>
     <span>
@@ -50,7 +55,43 @@
     <section class="fgc-tabpanel fgc-card" id="tab-insurer" role="tabpanel" style="border-top:0;border-radius:0 0 .5rem .5rem" hidden><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></section>
     <section class="fgc-tabpanel fgc-card" id="tab-product" role="tabpanel" style="border-top:0;border-radius:0 0 .5rem .5rem" hidden><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></section>
     <section class="fgc-tabpanel fgc-card" id="tab-agent"   role="tabpanel" style="border-top:0;border-radius:0 0 .5rem .5rem" hidden><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></section>
-    <section class="fgc-tabpanel fgc-card" id="tab-item"    role="tabpanel" style="border-top:0;border-radius:0 0 .5rem .5rem" hidden><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></section>
+    <section class="fgc-tabpanel fgc-card" id="tab-item" role="tabpanel"
+             style="border-top:0;border-radius:0 0 .5rem .5rem" hidden>
+      <div class="fgc-card__head">
+        <span class="fgc-card__title">수수료 항목</span>
+        <span class="fgc-muted" style="font-size:12px"
+              th:text="|${#lists.size(commissionItems)}건|">0건</span>
+      </div>
+      <div style="overflow-x:auto">
+        <table class="fgc-table">
+          <thead>
+          <tr>
+            <th>항목코드</th>
+            <th>항목명</th>
+            <th>지급·차감 구분</th>
+            <th>분류</th>
+            <th>사용 시작일</th>
+            <th>사용 종료일</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr th:each="item : ${commissionItems}">
+            <td class="fgc-mono" th:text="${item.itemCode()}">BASE_COMMISSION</td>
+            <td th:text="${item.itemName()}">FC 기본수수료</td>
+            <td th:text="${item.cashflowType()}">PAYMENT</td>
+            <td th:text="${item.itemCategory()}">SALES</td>
+            <td class="fgc-mono" th:text="${item.effectiveFrom()}">2026-01-01</td>
+            <td class="fgc-mono" th:text="${item.effectiveTo() ?: '-'}">-</td>
+          </tr>
+          <tr th:if="${#lists.isEmpty(commissionItems)}">
+            <td colspan="6">
+              <div class="fgc-empty">조건에 맞는 수수료 항목이 없습니다.</div>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
   </div>
 
 <!-- 스크립트는 main 안에 둔다 - 셸의 page()는 ~{::main}만 삽입하므로 main 밖 스크립트는 렌더링에서 사라진다 -->

--- a/src/test/java/com/susukkang/fgc/base/controller/BaseViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/base/controller/BaseViewControllerTest.java
@@ -1,0 +1,157 @@
+package com.susukkang.fgc.base.controller;
+
+import com.susukkang.fgc.auth.dto.AppUserView;
+import com.susukkang.fgc.auth.dto.FgcUserDetails;
+import com.susukkang.fgc.base.dto.CommissionItemResponse;
+import com.susukkang.fgc.base.service.CommissionItemService;
+import com.susukkang.fgc.common.config.SecurityConfig;
+import com.susukkang.fgc.common.exception.ConstraintErrorCodeResolver;
+import com.susukkang.fgc.common.exception.FgcMessageResolver;
+import com.susukkang.fgc.common.exception.GlobalExceptionHandler;
+import com.susukkang.fgc.common.web.ShellAdvice;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * 설명 : 기준정보 조회 화면 테스트
+ *
+ * @author yslee
+ * @since 2026-08-11
+ * @version 1.2
+ */
+@WebMvcTest(BaseViewController.class)
+@Import({BaseViewController.class, SecurityConfig.class, ShellAdvice.class, GlobalExceptionHandler.class,
+        FgcMessageResolver.class, ConstraintErrorCodeResolver.class, MessageSourceAutoConfiguration.class})
+@TestPropertySource(properties = "fgc.demo-month=2026-08")
+class BaseViewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CommissionItemService commissionItemService;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"SYSTEM_ADMIN", "GA_ADMIN", "SETTLEMENT", "COMPLIANCE"})
+    void 로그인한_전체_역할은_수수료_항목을_조회할_수_있다(String roleCode) throws Exception {
+        given(commissionItemService.findEffectiveItems(LocalDate.of(2026, 8, 1)))
+                .willReturn(sampleItems());
+
+        mockMvc.perform(get("/base").with(user(principal(roleCode))))
+                .andExpect(status().isOk())
+                .andExpect(view().name("base/index"))
+                .andExpect(model().attribute("asOf", LocalDate.of(2026, 8, 1)))
+                .andExpect(model().attribute("commissionItems", sampleItems()))
+                .andExpect(content().string(containsString("FGC-UI-BASE-W01")))
+                .andExpect(content().string(containsString("기준정보 조회")))
+                .andExpect(content().string(containsString("조직")))
+                .andExpect(content().string(containsString("보험회사")))
+                .andExpect(content().string(containsString("상품")))
+                .andExpect(content().string(containsString("설계사")))
+                .andExpect(content().string(containsString("수수료 항목")))
+                .andExpect(content().string(containsString("BASE_COMMISSION")))
+                .andExpect(content().string(containsString("FC 기본수수료")))
+                .andExpect(content().string(containsString("2026-01-01")))
+                .andExpect(content().string(not(containsString("<th scope=\"col\">산입 여부</th>"))))
+                .andExpect(content().string(containsString("href=\"/base\" aria-current=\"page\"")))
+                .andExpect(content().string(containsString("id=\"b1\"")))
+                .andExpect(content().string(containsString("id=\"b2\"")))
+                .andExpect(content().string(containsString("id=\"b3\"")))
+                .andExpect(content().string(containsString("id=\"b4\"")))
+                .andExpect(content().string(containsString("id=\"b5\"")))
+                .andExpect(content().string(not(containsString(">등록</button>"))))
+                .andExpect(content().string(not(containsString(">수정</button>"))));
+    }
+
+    @Test
+    void 기준월을_바꾸면_해당_월_첫날로_유효한_항목을_조회한다() throws Exception {
+        given(commissionItemService.findEffectiveItems(LocalDate.of(2026, 7, 1)))
+                .willReturn(sampleItems());
+
+        mockMvc.perform(get("/base")
+                        .param("month", "2026-07")
+                        .with(user(principal("SETTLEMENT"))))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("month", "2026-07"))
+                .andExpect(model().attribute("asOf", LocalDate.of(2026, 7, 1)));
+
+        verify(commissionItemService).findEffectiveItems(LocalDate.of(2026, 7, 1));
+    }
+
+    @Test
+    void 잘못된_기준월은_설정된_기본월로_복구한다() throws Exception {
+        given(commissionItemService.findEffectiveItems(LocalDate.of(2026, 8, 1)))
+                .willReturn(sampleItems());
+
+        mockMvc.perform(get("/base")
+                        .param("month", "2026-13")
+                        .with(user(principal("SETTLEMENT"))))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("month", "2026-08"))
+                .andExpect(model().attribute("asOf", LocalDate.of(2026, 8, 1)));
+
+        verify(commissionItemService).findEffectiveItems(LocalDate.of(2026, 8, 1));
+    }
+
+    @Test
+    void 조회_결과가_없으면_빈_목록_안내를_표시한다() throws Exception {
+        given(commissionItemService.findEffectiveItems(LocalDate.of(2026, 8, 1)))
+                .willReturn(List.of());
+
+        mockMvc.perform(get("/base").with(user(principal("SETTLEMENT"))))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("조건에 맞는 수수료 항목이 없습니다.")));
+    }
+
+    @Test
+    void 로그인하지_않으면_로그인_화면으로_이동한다() throws Exception {
+        mockMvc.perform(get("/base"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
+    private static List<CommissionItemResponse> sampleItems() {
+        return List.of(new CommissionItemResponse(
+                "BASE_COMMISSION",
+                "FC 기본수수료",
+                "PAYMENT",
+                "SALES",
+                LocalDate.of(2026, 1, 1),
+                null
+        ));
+    }
+
+    private static FgcUserDetails principal(String roleCode) {
+        AppUserView view = new AppUserView();
+        view.setUserId(1L);
+        view.setLoginId("base-viewer");
+        view.setPasswordHash("{noop}x");
+        view.setUserName("기준정보 조회자");
+        view.setRoleCode(roleCode);
+        view.setAccountStatus("ACTIVE");
+        return new FgcUserDetails(view, true, true);
+    }
+}

--- a/src/test/java/com/susukkang/fgc/base/controller/BaseViewIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/base/controller/BaseViewIntegrationTest.java
@@ -1,0 +1,84 @@
+package com.susukkang.fgc.base.controller;
+
+import com.susukkang.fgc.auth.dto.AppUserView;
+import com.susukkang.fgc.auth.dto.FgcUserDetails;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 설명 : 기준정보 조회 화면 DB 연동 통합 테스트
+ *
+ * @author yslee
+ * @since 2026-08-11
+ * @version 1.2
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class BaseViewIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void DB의_유효한_수수료_항목을_BASE_W01에_표시한다() throws Exception {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String itemCode = "VIEW_ITEM_" + suffix;
+        String itemName = "화면 통합 테스트 항목 " + suffix;
+        insertCommissionItem(itemCode, itemName);
+
+        mockMvc.perform(get("/base")
+                        .param("month", "2026-08")
+                        .with(user(settlementPrincipal())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString(itemCode)))
+                .andExpect(content().string(containsString(itemName)))
+                .andExpect(content().string(containsString("2026-08-01")));
+    }
+
+    private void insertCommissionItem(String itemCode, String itemName) {
+        jdbcTemplate.update("""
+                INSERT INTO fgc.commission_item (
+                    item_code,
+                    item_name,
+                    cashflow_type,
+                    item_category,
+                    effective_from,
+                    effective_to,
+                    active_yn
+                ) VALUES (?, ?, 'PAYMENT', 'SALES', ?, NULL, TRUE)
+                """,
+                itemCode,
+                itemName,
+                LocalDate.of(2026, 1, 1)
+        );
+    }
+
+    private static FgcUserDetails settlementPrincipal() {
+        AppUserView view = new AppUserView();
+        view.setUserId(1L);
+        view.setLoginId("settle01");
+        view.setPasswordHash("{noop}x");
+        view.setUserName("정산담당자");
+        view.setRoleCode("SETTLEMENT");
+        view.setAccountStatus("ACTIVE");
+        return new FgcUserDetails(view, true, true);
+    }
+}

--- a/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
@@ -48,7 +48,6 @@ class ScreenViewControllerTest {
 
     @ParameterizedTest(name = "{0} → {1}")
     @CsvSource({
-            "/base,                FGC-UI-BASE-W01",
             "/policies,            FGC-UI-POL-W01",
             "/contracts,           FGC-UI-CONT-W01",
             "/contracts/1,         FGC-UI-CONT-W02",


### PR DESCRIPTION
## 📖 1. 변경 사항 요약

- BASE-W01 기준정보 조회 화면에 FUN-009 수수료 항목 데이터를 연결했습니다.
- `origin/develop`의 공통 Thymeleaf 화면 구조를 기준으로 수수료 항목 탭만 구현했습니다.

## 🔗 2. 관련 이슈

* Closes #88

## 🛠 3. 구현 내용

- 정적 화면 라우터의 `GET /base`를 `BaseViewController`로 이관하고 화면 컨트롤러와 JSON API를 분리
- 공통 `CommissionItemService`를 통해 기준월 첫날에 유효한 `commission_item` 조회
- 항목코드·항목명·지급/차감 구분·분류·사용기간 및 빈 목록 상태 렌더링
- FUN-005~008 탭은 기존 placeholder로 유지하고 1,200% 산입 여부는 표시하지 않음
- 로그인 전체 역할, 기준월 변경, 잘못된 월 복구, 빈 목록, DB 연동 렌더링 테스트 추가

## 🧪 4. 테스트 방법

1. PostgreSQL 실행
2. `.\gradlew.bat test --tests "com.susukkang.fgc.base.controller.BaseViewControllerTest" --tests "com.susukkang.fgc.base.controller.BaseViewIntegrationTest" --tests "com.susukkang.fgc.common.web.ScreenViewControllerTest"`
3. `.\gradlew.bat clean build`
4. 애플리케이션 실행 후 `/base`의 수수료 항목 탭 확인

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

- FUN-009 외 기준정보 탭이 기존 정적 상태로 유지되는지 확인
- 기준월에 따라 유효기간 내 수수료 항목만 표시되는지 확인
- 등록·수정 기능과 1,200% 산입 여부가 화면에 노출되지 않는지 확인

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 관련 기능을 테스트했습니다.
* [x] 테스트 코드를 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 디버깅 코드를 포함하지 않았습니다.

## 🖼️ 8. 화면 변경

* BASE-W01 수수료 항목 탭에 실제 기준정보 목록 표시

## 💬 9. 참고 사항

* 조직(FUN-005), 보험회사(FUN-006), 상품(FUN-007), 설계사(FUN-008) API 연동은 이 PR 범위에서 제외했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 기준정보 화면에서 기준월을 선택하고 해당 월의 수수료 항목을 조회할 수 있습니다.
  * 수수료 항목의 코드, 이름, 적용일 및 전체 건수를 표로 확인할 수 있습니다.
  * 조회 결과가 없을 경우 안내 메시지가 표시됩니다.
  * 잘못된 기준월 입력 시 기본 기준일로 복구됩니다.
  * 인증된 사용자만 기준정보 화면에 접근할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->