### PR TITLE
[Feat] FUN-046 #2 검증원장 및 분개 라인 저장

### DIFF
--- a/src/main/java/com/susukkang/fgc/common/exception/FgcErrorCode.java
+++ b/src/main/java/com/susukkang/fgc/common/exception/FgcErrorCode.java
@@ -111,6 +111,12 @@ public enum FgcErrorCode {
             "error.ledger.reverseOnly"
     ),
 
+    JOURNAL_001(
+            "FGC-JOURNAL-001",
+            HttpStatus.UNPROCESSABLE_ENTITY,
+            "error.journal.invalidAccount"
+    ),
+
     RECO_001(
             "FGC-RECO-001",
             HttpStatus.CONFLICT,

--- a/src/main/java/com/susukkang/fgc/journal/dto/JournalAccountRow.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/JournalAccountRow.java
@@ -1,0 +1,18 @@
+package com.susukkang.fgc.journal.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * journal_account 1행 조회 결과(#93). JournalAccountCode(enum, #85)로 활성 계정과목을
+ * 찾을 때 쓴다 — journalAccountId가 journal_line.journal_account_id FK에 들어간다.
+ */
+@Getter
+@Setter
+public class JournalAccountRow {
+    private Long journalAccountId;
+    private String accountCode;
+    private String accountName;
+    private String normalBalance;
+    private Boolean activeYn;
+}

--- a/src/main/java/com/susukkang/fgc/journal/dto/JournalHeaderDraft.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/JournalHeaderDraft.java
@@ -17,7 +17,7 @@ import java.util.List;
  * (revision 증가)는 FUN-047의 몫이라 #85 범위 밖이다.
  */
 @Getter
-@Builder
+@Builder(toBuilder = true)
 public class JournalHeaderDraft {
     private final JournalType journalType;
     private final LocalDate journalDate;

--- a/src/main/java/com/susukkang/fgc/journal/dto/JournalHeaderInsertRow.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/JournalHeaderInsertRow.java
@@ -1,0 +1,39 @@
+package com.susukkang.fgc.journal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+/**
+ * journal_header 1행 INSERT 파라미터(#93). status/created_at은 DB 기본값(DRAFT,
+ * clock_timestamp())에 맡기고 여기 담지 않는다 — guard_journal_header_write 트리거가
+ * INSERT 시 status<>'DRAFT'면 거부하므로(V1__baseline_v2_1_2.sql:1296-1299), 굳이 앱이
+ * 값을 정해 보낼 이유가 없다.
+ *
+ * journalHeaderId는 MyBatis useGeneratedKeys로 INSERT 후 채워진다(ValidationRunInsertRow와
+ * 같은 관례) — journal_line INSERT 시 FK로 필요하기 때문에 setter가 있다.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JournalHeaderInsertRow {
+    private Long journalHeaderId;
+    private String journalNo;
+    private LocalDate journalDate;
+    private String journalType;
+    private String sourceEntityType;
+    private String sourceEntityId;
+    private Integer revisionNo;
+    private Long validationRunId;
+    private Long contractId;
+    private Long policyVersionId;
+    private String correctionGroupKey;
+    private String description;
+    private Long createdBy;
+}

--- a/src/main/java/com/susukkang/fgc/journal/dto/JournalHeaderRow.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/JournalHeaderRow.java
@@ -1,0 +1,32 @@
+package com.susukkang.fgc.journal.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+/**
+ * journal_header 1행 조회 결과(#93). saveDraft()의 반환값이자, 원천·개정번호 기준
+ * 중복 저장 방지를 위한 기존 행 조회(findBySourceKey)에도 쓰인다.
+ */
+@Getter
+@Setter
+public class JournalHeaderRow {
+    private Long journalHeaderId;
+    private String journalNo;
+    private LocalDate journalDate;
+    private String journalType;
+    private String sourceEntityType;
+    private String sourceEntityId;
+    private Integer revisionNo;
+    private Long validationRunId;
+    private Long contractId;
+    private Long policyVersionId;
+    private String status;
+    private String description;
+    private Long createdBy;
+    private Long postedBy;
+    private OffsetDateTime postedAt;
+    private OffsetDateTime createdAt;
+}

--- a/src/main/java/com/susukkang/fgc/journal/dto/JournalLineDraft.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/JournalLineDraft.java
@@ -12,11 +12,11 @@ import java.math.BigDecimal;
  * 0이어야 한다(ck_journal_line_one_side, V1__baseline_v2_1_2.sql:1248-1251) — 이 DTO를
  * 만드는 서비스가 그 규칙을 지켜야 하며, 이 클래스 자체는 값을 강제하지 않는다.
  *
- * journalAccountId(FK)는 포함하지 않는다 — journal_account가 아직 시드되지 않았고(#85
- * 확인 시점 기준), id 매핑은 영속화 단계(후속 이슈)의 몫이다.
+ * journalAccountId(FK)는 포함하지 않는다 — 계정과목을 코드(accountCode)가 아니라 DB
+ * 식별자로 다루는 건 영속화 단계(#93, JournalPersistenceService)의 몫이다.
  */
 @Getter
-@Builder
+@Builder(toBuilder = true)
 public class JournalLineDraft {
     private final int lineNo;
     private final JournalAccountCode accountCode;

--- a/src/main/java/com/susukkang/fgc/journal/dto/JournalLineInsertRow.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/JournalLineInsertRow.java
@@ -1,0 +1,33 @@
+package com.susukkang.fgc.journal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+/**
+ * journal_line 1행 INSERT 파라미터(#93). journalAccountId는 JournalAccountCode(#85)를
+ * JournalAccountMapper.findActiveByCode로 조회해 얻은 실제 FK 값이다 — JournalLineDraft가
+ * 들고 있던 enum 그대로는 저장할 수 없다(계정 존재·활성 여부를 이 조회가 같이 검증한다).
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JournalLineInsertRow {
+    private Long journalLineId;
+    private Long journalHeaderId;
+    private Integer lineNo;
+    private Long journalAccountId;
+    private BigDecimal debitAmount;
+    private BigDecimal creditAmount;
+    private Long contractId;
+    private Long agentId;
+    private String paymentStage;
+    private Long commissionItemId;
+    private String memo;
+}

--- a/src/main/java/com/susukkang/fgc/journal/mapper/JournalAccountMapper.java
+++ b/src/main/java/com/susukkang/fgc/journal/mapper/JournalAccountMapper.java
@@ -1,0 +1,26 @@
+package com.susukkang.fgc.journal.mapper;
+
+import com.susukkang.fgc.journal.dto.JournalAccountRow;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * TODO(#93): src/main/resources/mapper/journal/JournalAccountMapper.xml에 아래 SQL을 작성한다.
+ */
+@Mapper
+public interface JournalAccountMapper {
+
+    /**
+     * TODO(#93): account_code로 "활성" 계정과목 1건을 찾는다. active_yn=false거나 코드
+     * 자체가 없으면 null을 반환해야 한다 — 서비스가 이 null을 "저장 불가" 업무 예외로
+     * 바꿔야 한다("계정과목은 journal_account의 활성 계정과목만 참조" 요구사항).
+     *
+     *   SELECT journal_account_id, account_code, account_name, normal_balance, active_yn
+     *     FROM fgc.journal_account
+     *    WHERE account_code = #{accountCode} AND active_yn = true
+     *
+     * 호출부(JournalPersistenceServiceImpl)는 JournalAccountCode enum(#85)의 name()을
+     * accountCode로 그대로 넘긴다 — JournalAccountCode.EXPECTED_RECEIVABLE.name() == "EXPECTED_RECEIVABLE".
+     */
+    JournalAccountRow findActiveByCode(@Param("accountCode") String accountCode);
+}

--- a/src/main/java/com/susukkang/fgc/journal/mapper/JournalAccountMapper.java
+++ b/src/main/java/com/susukkang/fgc/journal/mapper/JournalAccountMapper.java
@@ -4,23 +4,8 @@ import com.susukkang.fgc.journal.dto.JournalAccountRow;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
-/**
- * TODO(#93): src/main/resources/mapper/journal/JournalAccountMapper.xml에 아래 SQL을 작성한다.
- */
+
 @Mapper
 public interface JournalAccountMapper {
-
-    /**
-     * TODO(#93): account_code로 "활성" 계정과목 1건을 찾는다. active_yn=false거나 코드
-     * 자체가 없으면 null을 반환해야 한다 — 서비스가 이 null을 "저장 불가" 업무 예외로
-     * 바꿔야 한다("계정과목은 journal_account의 활성 계정과목만 참조" 요구사항).
-     *
-     *   SELECT journal_account_id, account_code, account_name, normal_balance, active_yn
-     *     FROM fgc.journal_account
-     *    WHERE account_code = #{accountCode} AND active_yn = true
-     *
-     * 호출부(JournalPersistenceServiceImpl)는 JournalAccountCode enum(#85)의 name()을
-     * accountCode로 그대로 넘긴다 — JournalAccountCode.EXPECTED_RECEIVABLE.name() == "EXPECTED_RECEIVABLE".
-     */
     JournalAccountRow findActiveByCode(@Param("accountCode") String accountCode);
 }

--- a/src/main/java/com/susukkang/fgc/journal/mapper/JournalMapper.java
+++ b/src/main/java/com/susukkang/fgc/journal/mapper/JournalMapper.java
@@ -1,0 +1,93 @@
+package com.susukkang.fgc.journal.mapper;
+
+import com.susukkang.fgc.journal.dto.JournalHeaderInsertRow;
+import com.susukkang.fgc.journal.dto.JournalHeaderRow;
+import com.susukkang.fgc.journal.dto.JournalLineInsertRow;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * TODO(#93): src/main/resources/mapper/journal/JournalMapper.xml에 아래 5개 SQL을 작성한다.
+ * ValidationRunMapper.xml(findNextRunNo 등)이 같은 성격의 채번·조회 SQL을 이미 쓰고 있으니
+ * 참고하면 좋다.
+ */
+@Mapper
+public interface JournalMapper {
+
+    /**
+     * TODO(#93): journal_header 1행 INSERT.
+     *   INSERT INTO fgc.journal_header
+     *       (journal_no, journal_date, journal_type, source_entity_type, source_entity_id,
+     *        revision_no, validation_run_id, contract_id, policy_version_id,
+     *        correction_group_key, description, created_by)
+     *     VALUES (...)
+     * status/created_at은 컬럼 기본값에 맡기고 INSERT 절에 넣지 않는다(JournalHeaderInsertRow
+     * Javadoc 참고 — guard_journal_header_write가 INSERT 시 status<>'DRAFT'를 거부한다).
+     * <selectKey>(또는 useGeneratedKeys="true" keyProperty="journalHeaderId"
+     * keyColumn="journal_header_id")로 생성된 journal_header_id를
+     * row.journalHeaderId에 채워 돌려줘야 한다 — 바로 다음에 insertLine이 그 값을 FK로 쓴다.
+     */
+    int insert(JournalHeaderInsertRow row);
+
+    /**
+     * TODO(#93): journal_line 1행 INSERT.
+     *   INSERT INTO fgc.journal_line
+     *       (journal_header_id, line_no, journal_account_id, debit_amount, credit_amount,
+     *        contract_id, agent_id, payment_stage, commission_item_id, memo)
+     *     VALUES (...)
+     * 헤더와 마찬가지로 useGeneratedKeys로 journal_line_id를 채워 돌려줘도 되지만 필수는
+     * 아니다(호출자가 생성된 라인 id를 바로 쓸 일이 없다면).
+     */
+    int insertLine(JournalLineInsertRow row);
+
+    /**
+     * TODO(#93): journal_no 채번. "JV-{yyyy}-{MM}-{4자리 일련번호}" 형식(#93 설계 결정) —
+     * 같은 연-월 안에서 기존 journal_no의 마지막 4자리 숫자 중 최댓값 + 1을 구한다.
+     *
+     *   SELECT COALESCE(MAX(CAST(SUBSTRING(journal_no FROM 'JV-\d{4}-\d{2}-(\d+)$') AS int)), 0) + 1
+     *     FROM fgc.journal_header
+     *    WHERE journal_no LIKE 'JV-' || #{year} || '-' || #{month} || '-%'
+     *
+     * ValidationRunMapper.findNextRunNo(COALESCE(MAX(run_no),0)+1 패턴)와 같은 관례다.
+     * year는 4자리 문자열("2026"), month는 2자리 zero-padded 문자열("07")로 서비스가
+     * 미리 포맷해서 넘긴다(SQL에서 포맷팅하지 않는다).
+     */
+    Integer findNextJournalSeq(@Param("year") String year, @Param("month") String month);
+
+    /**
+     * TODO(#93): (journal_type, source_entity_type, source_entity_id, revision_no) 조합으로
+     * 기존 분개 헤더를 찾는다 — uq_journal_source_revision과 정확히 같은 4개 컬럼이다.
+     * 이 결과가 있으면 "이미 저장된 초안"이므로 서비스는 재삽입 대신 이 행을 그대로
+     * 반환해야 한다(원천·개정번호 기반 중복 저장 방지, ValidationRunCreateServiceImpl의
+     * createWithExplicitRunNo가 하는 멱등 처리와 같은 패턴).
+     *   SELECT journal_header_id, journal_no, journal_date, journal_type, source_entity_type,
+     *          source_entity_id, revision_no, validation_run_id, contract_id, policy_version_id,
+     *          status, description, created_by, posted_by, posted_at, created_at
+     *     FROM fgc.journal_header
+     *    WHERE journal_type = #{journalType} AND source_entity_type = #{sourceEntityType}
+     *      AND source_entity_id = #{sourceEntityId} AND revision_no = #{revisionNo}
+     * (컬럼 별칭은 JournalHeaderRow의 camelCase 필드명과 맞춘다 — map-underscore-to-camel-case가
+     * 켜져 있어 굳이 AS를 안 써도 되지만, 다른 Mapper들처럼 명시적으로 써도 된다.)
+     */
+    JournalHeaderRow findBySourceKey(@Param("journalType") String journalType,
+                                      @Param("sourceEntityType") String sourceEntityType,
+                                      @Param("sourceEntityId") String sourceEntityId,
+                                      @Param("revisionNo") int revisionNo);
+
+    /**
+     * TODO(#93): 같은 원천(journal_type, source_entity_type, source_entity_id)에 이미
+     * status='POSTED'인 분개가 있는지 확인한다 — POSTED 분개 중복 기표 방지용 사전 체크다.
+     * 참고: DB에 이미 uq_journal_current_posted_source 부분 유니크 인덱스
+     * (V1__baseline_v2_1_2.sql:1227-1229)가 최후 방어선으로 걸려 있으니, 이 메서드는
+     * "DB 제약 위반 예외 대신 깔끔한 업무 예외를 미리 던지기 위한" 선제 체크일 뿐이다 —
+     * 이 메서드가 없어도 정합성 자체는 깨지지 않는다.
+     *   SELECT EXISTS (
+     *       SELECT 1 FROM fgc.journal_header
+     *        WHERE journal_type = #{journalType} AND source_entity_type = #{sourceEntityType}
+     *          AND source_entity_id = #{sourceEntityId} AND status = 'POSTED'
+     *   )
+     */
+    boolean existsPostedForSource(@Param("journalType") String journalType,
+                                   @Param("sourceEntityType") String sourceEntityType,
+                                   @Param("sourceEntityId") String sourceEntityId);
+}

--- a/src/main/java/com/susukkang/fgc/journal/mapper/JournalMapper.java
+++ b/src/main/java/com/susukkang/fgc/journal/mapper/JournalMapper.java
@@ -6,87 +6,19 @@ import com.susukkang.fgc.journal.dto.JournalLineInsertRow;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
-/**
- * TODO(#93): src/main/resources/mapper/journal/JournalMapper.xml에 아래 5개 SQL을 작성한다.
- * ValidationRunMapper.xml(findNextRunNo 등)이 같은 성격의 채번·조회 SQL을 이미 쓰고 있으니
- * 참고하면 좋다.
- */
 @Mapper
 public interface JournalMapper {
-
-    /**
-     * TODO(#93): journal_header 1행 INSERT.
-     *   INSERT INTO fgc.journal_header
-     *       (journal_no, journal_date, journal_type, source_entity_type, source_entity_id,
-     *        revision_no, validation_run_id, contract_id, policy_version_id,
-     *        correction_group_key, description, created_by)
-     *     VALUES (...)
-     * status/created_at은 컬럼 기본값에 맡기고 INSERT 절에 넣지 않는다(JournalHeaderInsertRow
-     * Javadoc 참고 — guard_journal_header_write가 INSERT 시 status<>'DRAFT'를 거부한다).
-     * <selectKey>(또는 useGeneratedKeys="true" keyProperty="journalHeaderId"
-     * keyColumn="journal_header_id")로 생성된 journal_header_id를
-     * row.journalHeaderId에 채워 돌려줘야 한다 — 바로 다음에 insertLine이 그 값을 FK로 쓴다.
-     */
     int insert(JournalHeaderInsertRow row);
 
-    /**
-     * TODO(#93): journal_line 1행 INSERT.
-     *   INSERT INTO fgc.journal_line
-     *       (journal_header_id, line_no, journal_account_id, debit_amount, credit_amount,
-     *        contract_id, agent_id, payment_stage, commission_item_id, memo)
-     *     VALUES (...)
-     * 헤더와 마찬가지로 useGeneratedKeys로 journal_line_id를 채워 돌려줘도 되지만 필수는
-     * 아니다(호출자가 생성된 라인 id를 바로 쓸 일이 없다면).
-     */
     int insertLine(JournalLineInsertRow row);
 
-    /**
-     * TODO(#93): journal_no 채번. "JV-{yyyy}-{MM}-{4자리 일련번호}" 형식(#93 설계 결정) —
-     * 같은 연-월 안에서 기존 journal_no의 마지막 4자리 숫자 중 최댓값 + 1을 구한다.
-     *
-     *   SELECT COALESCE(MAX(CAST(SUBSTRING(journal_no FROM 'JV-\d{4}-\d{2}-(\d+)$') AS int)), 0) + 1
-     *     FROM fgc.journal_header
-     *    WHERE journal_no LIKE 'JV-' || #{year} || '-' || #{month} || '-%'
-     *
-     * ValidationRunMapper.findNextRunNo(COALESCE(MAX(run_no),0)+1 패턴)와 같은 관례다.
-     * year는 4자리 문자열("2026"), month는 2자리 zero-padded 문자열("07")로 서비스가
-     * 미리 포맷해서 넘긴다(SQL에서 포맷팅하지 않는다).
-     */
     Integer findNextJournalSeq(@Param("year") String year, @Param("month") String month);
 
-    /**
-     * TODO(#93): (journal_type, source_entity_type, source_entity_id, revision_no) 조합으로
-     * 기존 분개 헤더를 찾는다 — uq_journal_source_revision과 정확히 같은 4개 컬럼이다.
-     * 이 결과가 있으면 "이미 저장된 초안"이므로 서비스는 재삽입 대신 이 행을 그대로
-     * 반환해야 한다(원천·개정번호 기반 중복 저장 방지, ValidationRunCreateServiceImpl의
-     * createWithExplicitRunNo가 하는 멱등 처리와 같은 패턴).
-     *   SELECT journal_header_id, journal_no, journal_date, journal_type, source_entity_type,
-     *          source_entity_id, revision_no, validation_run_id, contract_id, policy_version_id,
-     *          status, description, created_by, posted_by, posted_at, created_at
-     *     FROM fgc.journal_header
-     *    WHERE journal_type = #{journalType} AND source_entity_type = #{sourceEntityType}
-     *      AND source_entity_id = #{sourceEntityId} AND revision_no = #{revisionNo}
-     * (컬럼 별칭은 JournalHeaderRow의 camelCase 필드명과 맞춘다 — map-underscore-to-camel-case가
-     * 켜져 있어 굳이 AS를 안 써도 되지만, 다른 Mapper들처럼 명시적으로 써도 된다.)
-     */
     JournalHeaderRow findBySourceKey(@Param("journalType") String journalType,
                                       @Param("sourceEntityType") String sourceEntityType,
                                       @Param("sourceEntityId") String sourceEntityId,
                                       @Param("revisionNo") int revisionNo);
 
-    /**
-     * TODO(#93): 같은 원천(journal_type, source_entity_type, source_entity_id)에 이미
-     * status='POSTED'인 분개가 있는지 확인한다 — POSTED 분개 중복 기표 방지용 사전 체크다.
-     * 참고: DB에 이미 uq_journal_current_posted_source 부분 유니크 인덱스
-     * (V1__baseline_v2_1_2.sql:1227-1229)가 최후 방어선으로 걸려 있으니, 이 메서드는
-     * "DB 제약 위반 예외 대신 깔끔한 업무 예외를 미리 던지기 위한" 선제 체크일 뿐이다 —
-     * 이 메서드가 없어도 정합성 자체는 깨지지 않는다.
-     *   SELECT EXISTS (
-     *       SELECT 1 FROM fgc.journal_header
-     *        WHERE journal_type = #{journalType} AND source_entity_type = #{sourceEntityType}
-     *          AND source_entity_id = #{sourceEntityId} AND status = 'POSTED'
-     *   )
-     */
     boolean existsPostedForSource(@Param("journalType") String journalType,
                                    @Param("sourceEntityType") String sourceEntityType,
                                    @Param("sourceEntityId") String sourceEntityId);

--- a/src/main/java/com/susukkang/fgc/journal/service/JournalPersistenceService.java
+++ b/src/main/java/com/susukkang/fgc/journal/service/JournalPersistenceService.java
@@ -19,6 +19,8 @@ public interface JournalPersistenceService {
      *
      * @param draft     JournalEntryDraftService가 만든 헤더+라인 초안
      * @param createdBy 저장을 요청한 사용자/배치 주체 (audit_log.user_id로도 쓰인다)
+     * @param requestId 저장 성공 시 audit_log.request_id로 남길 요청 식별자(FUN-046 감사
+     *                   요구사항 — "원천·분개 ID·검증 실행 ID·요청 ID를 포함한 감사 로그")
      */
-    JournalHeaderRow saveDraft(JournalHeaderDraft draft, Long createdBy);
+    JournalHeaderRow saveDraft(JournalHeaderDraft draft, Long createdBy, String requestId);
 }

--- a/src/main/java/com/susukkang/fgc/journal/service/JournalPersistenceService.java
+++ b/src/main/java/com/susukkang/fgc/journal/service/JournalPersistenceService.java
@@ -1,0 +1,24 @@
+package com.susukkang.fgc.journal.service;
+
+import com.susukkang.fgc.journal.dto.JournalHeaderDraft;
+import com.susukkang.fgc.journal.dto.JournalHeaderRow;
+
+/**
+ * #93 검증원장 및 분개 라인 저장. JournalEntryDraftService(#85)가 만든
+ * JournalHeaderDraft를 journal_header/journal_line에 DRAFT 상태로 저장한다.
+ *
+ * 차변·대변 균형검사(POSTED 전환 시점) 및 실제 POSTED 전이는 이 이슈 범위 밖이다 —
+ * guard_journal_header_write 트리거가 status DRAFT→POSTED UPDATE 시점에 균형을
+ * 강제하므로(V1__baseline_v2_1_2.sql:1349-1357), 이 서비스는 항상 DRAFT로만 INSERT한다.
+ */
+public interface JournalPersistenceService {
+
+    /**
+     * draft를 저장한다. (journalType, sourceEntityType, sourceEntityId, revisionNo) 조합의
+     * 기존 행이 이미 있으면 재삽입하지 않고 그 행을 그대로 반환한다(멱등).
+     *
+     * @param draft     JournalEntryDraftService가 만든 헤더+라인 초안
+     * @param createdBy 저장을 요청한 사용자/배치 주체 (audit_log.user_id로도 쓰인다)
+     */
+    JournalHeaderRow saveDraft(JournalHeaderDraft draft, Long createdBy);
+}

--- a/src/main/java/com/susukkang/fgc/journal/service/JournalPersistenceService.java
+++ b/src/main/java/com/susukkang/fgc/journal/service/JournalPersistenceService.java
@@ -19,7 +19,7 @@ public interface JournalPersistenceService {
      *
      * @param draft     JournalEntryDraftService가 만든 헤더+라인 초안
      * @param createdBy 저장을 요청한 사용자/배치 주체 (audit_log.user_id로도 쓰인다)
-     * @param requestId 저장 성공 시 audit_log.request_id로 남길 요청 식별자(FUN-046 감사
+     * @param requestId 저장 성공 시 audit_log.request_id로 남길 요청 식별자(FGC-FUN-046 감사
      *                   요구사항 — "원천·분개 ID·검증 실행 ID·요청 ID를 포함한 감사 로그")
      */
     JournalHeaderRow saveDraft(JournalHeaderDraft draft, Long createdBy, String requestId);

--- a/src/main/java/com/susukkang/fgc/journal/service/JournalPersistenceServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/journal/service/JournalPersistenceServiceImpl.java
@@ -1,0 +1,88 @@
+package com.susukkang.fgc.journal.service;
+
+import com.susukkang.fgc.audit.mapper.AuditLogMapper;
+import com.susukkang.fgc.journal.dto.JournalHeaderDraft;
+import com.susukkang.fgc.journal.dto.JournalHeaderRow;
+import com.susukkang.fgc.journal.mapper.JournalAccountMapper;
+import com.susukkang.fgc.journal.mapper.JournalMapper;
+import org.springframework.stereotype.Service;
+
+/**
+ * TODO(#93): saveDraft()를 아래 순서대로 구현한다.
+ *
+ *   1. 멱등 체크: journalMapper.findBySourceKey(draft.getJournalType().name(),
+ *      draft.getSourceEntityType(), draft.getSourceEntityId(), draft.getRevisionNo())로
+ *      기존 행을 찾는다. 있으면 그대로 반환하고 끝 — 재삽입하지 않는다("원천·개정번호
+ *      기반 중복 저장 방지" 요구사항, ValidationRunCreateServiceImpl.createWithExplicitRunNo와
+ *      같은 패턴).
+ *
+ *   2. POSTED 중복 기표 선제 체크(선택): journalMapper.existsPostedForSource(...)가 true면
+ *      업무 예외(FgcBusinessException 계열, 새 에러코드 필요 — FgcErrorCode에 JOURNAL_xxx
+ *      추가)를 던진다. 이 이슈에서는 항상 DRAFT로만 저장하므로 이론상 거의 안 걸리지만,
+ *      같은 원천으로 서로 다른 revision_no draft가 실수로 여러 번 만들어지는 상황을
+ *      조기에 막아준다.
+ *
+ *   3. 계정과목 조회·검증: draft.getLines()의 각 줄마다
+ *      journalAccountMapper.findActiveByCode(line.getAccountCode().name())을 호출한다.
+ *      null이면(코드가 없거나 active_yn=false) 업무 예외를 던진다("활성 계정과목만
+ *      참조" 요구사항) — journal_account가 아직 시드되지 않은 환경이라면 이 체크가 항상
+ *      실패할 것이므로, 로컬 검증 시 시드 데이터가 있는지 먼저 확인한다.
+ *
+ *   4. journal_no 채번: journalDate에서 year("2026"), month("07", zero-padded 2자리)를
+ *      뽑아 journalMapper.findNextJournalSeq(year, month)를 호출하고,
+ *      String.format("JV-%s-%s-%04d", year, month, seq)로 조합한다(#93 설계 결정 형식).
+ *      uq_journal_no UNIQUE 제약과 충돌할 수 있으니, ValidationRunCreateServiceImpl처럼
+ *      DataIntegrityViolationException을 잡아 REQUIRES_NEW 트랜잭션으로 재시도하는 방식을
+ *      쓰는 걸 권장한다(같은 트랜잭션 안에서 재시도하면 PostgreSQL이 트랜잭션을 이미
+ *      abort 상태로 만들어 재시도 INSERT조차 거부한다).
+ *
+ *   5. 헤더 INSERT: JournalHeaderInsertRow를 draft 값 그대로 채우고(journalNo는 4번 결과,
+ *      createdBy는 파라미터) journalMapper.insert(row)를 호출한다. useGeneratedKeys로
+ *      row.getJournalHeaderId()가 채워진다.
+ *
+ *   6. 라인 INSERT: draft.getLines()를 순회하며 JournalLineInsertRow를 만들고(journalHeaderId는
+ *      5번 결과, journalAccountId는 3번에서 조회한 실제 FK 값 — line.getAccountCode()가
+ *      아니라 JournalAccountRow.getJournalAccountId()를 넣어야 한다) journalMapper.insertLine을
+ *      각 줄마다 호출한다.
+ *
+ *   7. 트랜잭션: 5·6번(헤더+모든 라인)은 반드시 하나의 트랜잭션이어야 한다 — 이 클래스
+ *      메서드 전체에 @Transactional을 붙이면 된다(ValidationRunBatchLifecycleServiceImpl
+ *      참고). 4번의 재시도 트랜잭션(REQUIRES_NEW)만 별도로 분리해야 한다 — 채번 충돌
+ *      재시도가 헤더·라인 INSERT까지 통째로 롤백시키면 안 되기 때문이다. 즉 saveDraft() 안에서
+ *      "채번"과 "헤더+라인 INSERT"를 서로 다른 트랜잭션 경계로 나누는 구조가 된다.
+ *
+ *   8. 감사 로그: 5·6번이 성공한 뒤 AuditLogMapper.insert(AuditLogInsertRow.builder()...)를
+ *      직접 호출한다 — actionCode="JOURNAL_HEADER_POSTED"(또는 draft 상태가 항상 DRAFT이므로
+ *      "JOURNAL_DRAFT_SAVED" 쪽이 더 정확할 수 있다, 판단 필요), entityType="JOURNAL_HEADER",
+ *      entityId=String.valueOf(journalHeaderId), userId=createdBy. "저장 성공 시 원천·분개
+ *      ID·검증 실행 ID·요청 ID를 포함한 감사 로그" 요구사항이 reason 필드에 원천 정보를,
+ *      requestId는 이 서비스의 호출자가 파라미터로 내려줘야 한다(현재 saveDraft 시그니처엔
+ *      requestId가 없다 — 필요하면 시그니처에 추가할지 먼저 결정한다).
+ *
+ *   9. FINALIZED 불변성: 이미 guard_journal_header_write 트리거가 "FINALIZED validation_run에
+ *      분개를 추가할 수 없다"를 막는다(V1__baseline_v2_1_2.sql:1300-1305). 이 서비스가
+ *      직접 검사할 필요는 없다 — draft.getValidationRunId()가 FINALIZED 실행을 가리키면
+ *      5번 INSERT 시점에 트리거가 DataAccessException을 던지고, 그게 그대로 위로
+ *      전파되게 두면 된다. POSTED/REVERSED 불변성도 마찬가지로 이 이슈(INSERT만 함)에서는
+ *      해당 사항이 없다 — UPDATE/DELETE를 만드는 후속 이슈(정정·POSTED 전이)의 몫이다.
+ */
+@Service
+public class JournalPersistenceServiceImpl implements JournalPersistenceService {
+
+    private final JournalMapper journalMapper;
+    private final JournalAccountMapper journalAccountMapper;
+    private final AuditLogMapper auditLogMapper;
+
+    public JournalPersistenceServiceImpl(JournalMapper journalMapper,
+                                          JournalAccountMapper journalAccountMapper,
+                                          AuditLogMapper auditLogMapper) {
+        this.journalMapper = journalMapper;
+        this.journalAccountMapper = journalAccountMapper;
+        this.auditLogMapper = auditLogMapper;
+    }
+
+    @Override
+    public JournalHeaderRow saveDraft(JournalHeaderDraft draft, Long createdBy) {
+        throw new UnsupportedOperationException("TODO(#93): 위 클래스 Javadoc의 1~9단계대로 구현");
+    }
+}

--- a/src/main/java/com/susukkang/fgc/journal/service/JournalPersistenceServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/journal/service/JournalPersistenceServiceImpl.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -31,7 +32,9 @@ import java.util.Optional;
 public class JournalPersistenceServiceImpl implements JournalPersistenceService {
 
     private static final String CONSTRAINT_JOURNAL_NO = "uq_journal_no";
+    private static final String CONSTRAINT_SOURCE_REVISION = "uq_journal_source_revision";
     private static final int MAX_JOURNAL_NO_RETRIES = 3;
+    private static final int MAX_MONTHLY_SEQ = 9999;
 
     private final JournalMapper journalMapper;
     private final JournalAccountMapper journalAccountMapper;
@@ -84,14 +87,42 @@ public class JournalPersistenceServiceImpl implements JournalPersistenceService 
             journalAccountIds.add(account.getJournalAccountId());
         }
 
+        // 3-1. 차변·대변 합계 검증(FGC-FUN-046 인수조건 — "차변합계와 대변합계가
+        // 일치하지 않으면 저장·확정이 거절된다") — 저장 시점부터 강제해야 한다. DB
+        // 트리거(guard_journal_header_write)는 POSTED 전환 시점에만 균형을 검사하므로
+        // (V1__baseline_v2_1_2.sql:1349-1356), DRAFT 저장 자체는 막지 못한다. #85
+        // JournalEntryDraftService가 만든 draft는 항상 균형이지만, saveDraft는 어떤
+        // JournalHeaderDraft든 받는 공개 API라 여기서도 검증해야 한다.
+        BigDecimal debitTotal = draft.getLines().stream()
+                .map(JournalLineDraft::getDebitAmount).reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal creditTotal = draft.getLines().stream()
+                .map(JournalLineDraft::getCreditAmount).reduce(BigDecimal.ZERO, BigDecimal::add);
+        if (debitTotal.compareTo(creditTotal) != 0) {
+            throw new FgcBusinessException(FgcErrorCode.LEDG_001,
+                    Map.of("c", debitTotal.subtract(creditTotal).abs()));
+        }
+
         // 채번 + 헤더/라인 INSERT + 감사로그는 하나의 REQUIRES_NEW 트랜잭션
-        // (attemptSave)으로 묶고, uq_journal_no 충돌일 때만 그 트랜잭션 전체를 다시 시도
+        // (attemptSave)으로 묶는다. 1~3번 사전 체크와 실제 INSERT 사이에는 DB 잠금이
+        // 없어 두 요청이 동시에 같은 원천으로 저장을 시도하면 둘 다 체크를 통과할 수
+        // 있다 — 그 경우 uq_journal_source_revision 위반이 나는데, 에러로 죽이지 않고
+        // 방금 상대가 커밋한 기존 행을 재조회해 그대로 반환한다(멱등성 유지). uq_journal_no
+        // 충돌은 채번 자체를 다시 시도해야 하는 별개의 경우라 구분해서 처리한다.
         for (int attempt = 1; attempt <= MAX_JOURNAL_NO_RETRIES; attempt++) {
             try {
                 return requiresNewTransactionTemplate.execute(
                         status -> attemptSave(draft, journalAccountIds, createdBy, requestId));
             } catch (DataIntegrityViolationException e) {
-                if (!isJournalNoCollision(e) || attempt == MAX_JOURNAL_NO_RETRIES) {
+                if (matchesConstraint(e, CONSTRAINT_SOURCE_REVISION)) {
+                    JournalHeaderRow racedWinner = journalMapper.findBySourceKey(
+                            draft.getJournalType().name(), draft.getSourceEntityType(),
+                            draft.getSourceEntityId(), draft.getRevisionNo());
+                    if (racedWinner != null) {
+                        return racedWinner;
+                    }
+                    throw e;
+                }
+                if (!matchesConstraint(e, CONSTRAINT_JOURNAL_NO) || attempt == MAX_JOURNAL_NO_RETRIES) {
                     throw e;
                 }
                 log.warn("journal_header journal_no 채번 충돌로 재시도합니다 (시도 {}/{})",
@@ -101,18 +132,20 @@ public class JournalPersistenceServiceImpl implements JournalPersistenceService 
         throw new IllegalStateException("unreachable: MAX_JOURNAL_NO_RETRIES 루프를 정상적으로 빠져나올 수 없다");
     }
 
-    // 위반된 제약이 uq_journal_no(채번 충돌)인지 판정
-    private boolean isJournalNoCollision(DataIntegrityViolationException e) {
-        Optional<String> constraintName = constraintErrorCodeResolver.extractConstraintName(e);
-        if (constraintName.isPresent()) {
-            return CONSTRAINT_JOURNAL_NO.equals(constraintName.get());
+    // 위반된 제약이 constraintName인지 판정 — ConstraintErrorCodeResolver가 PSQLException의
+    // 구조화된 제약 이름을 우선 쓰고, 없을 때만(예: 합성 예외로 단위테스트할 때) 메시지
+    // 부분일치로 대체한다.
+    private boolean matchesConstraint(DataIntegrityViolationException e, String constraintName) {
+        Optional<String> actual = constraintErrorCodeResolver.extractConstraintName(e);
+        if (actual.isPresent()) {
+            return constraintName.equals(actual.get());
         }
         Throwable root = e;
         while (root.getCause() != null) {
             root = root.getCause();
         }
         String message = root.getMessage() == null ? "" : root.getMessage().toLowerCase(Locale.ROOT);
-        return message.contains(CONSTRAINT_JOURNAL_NO);
+        return message.contains(constraintName);
     }
 
     private JournalHeaderRow attemptSave(JournalHeaderDraft draft, List<Long> journalAccountIds,
@@ -121,6 +154,15 @@ public class JournalPersistenceServiceImpl implements JournalPersistenceService 
         String year = String.valueOf(draft.getJournalDate().getYear());
         String month = String.format("%02d", draft.getJournalDate().getMonthValue());
         int seq = journalMapper.findNextJournalSeq(year, month);
+        // String.format("%04d", seq)는 seq>=10000이어도 자르지 않고 자릿수를 그냥
+        // 늘려버린다 — "4자리 일련번호" 형식이 조용히 깨지는 걸 막기 위해 상한을 명시적으로
+        // 검사한다(#93 코드리뷰 반영). 월 1만 건은 정상 업무량을 크게 벗어나는 수치라
+        // 도달하면 채번 정책 자체를 재검토해야 하는 운영 이슈로 본다.
+        if (seq > MAX_MONTHLY_SEQ) {
+            throw new IllegalStateException(
+                    "journal_no 월간 일련번호 상한(" + MAX_MONTHLY_SEQ + ") 초과 — year=" + year
+                            + ", month=" + month + ", seq=" + seq);
+        }
         String journalNo = String.format("JV-%s-%s-%04d", year, month, seq);
 
         // 5. 헤더 INSERT — useGeneratedKeys라 insert(row) 호출 한 번으로 row 객체 자체에

--- a/src/main/java/com/susukkang/fgc/journal/service/JournalPersistenceServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/journal/service/JournalPersistenceServiceImpl.java
@@ -1,88 +1,180 @@
 package com.susukkang.fgc.journal.service;
 
+import com.susukkang.fgc.audit.dto.AuditLogInsertRow;
 import com.susukkang.fgc.audit.mapper.AuditLogMapper;
+import com.susukkang.fgc.common.exception.ConstraintErrorCodeResolver;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.journal.dto.JournalAccountRow;
 import com.susukkang.fgc.journal.dto.JournalHeaderDraft;
+import com.susukkang.fgc.journal.dto.JournalHeaderInsertRow;
 import com.susukkang.fgc.journal.dto.JournalHeaderRow;
+import com.susukkang.fgc.journal.dto.JournalLineDraft;
+import com.susukkang.fgc.journal.dto.JournalLineInsertRow;
 import com.susukkang.fgc.journal.mapper.JournalAccountMapper;
 import com.susukkang.fgc.journal.mapper.JournalMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
 
-/**
- * TODO(#93): saveDraft()를 아래 순서대로 구현한다.
- *
- *   1. 멱등 체크: journalMapper.findBySourceKey(draft.getJournalType().name(),
- *      draft.getSourceEntityType(), draft.getSourceEntityId(), draft.getRevisionNo())로
- *      기존 행을 찾는다. 있으면 그대로 반환하고 끝 — 재삽입하지 않는다("원천·개정번호
- *      기반 중복 저장 방지" 요구사항, ValidationRunCreateServiceImpl.createWithExplicitRunNo와
- *      같은 패턴).
- *
- *   2. POSTED 중복 기표 선제 체크(선택): journalMapper.existsPostedForSource(...)가 true면
- *      업무 예외(FgcBusinessException 계열, 새 에러코드 필요 — FgcErrorCode에 JOURNAL_xxx
- *      추가)를 던진다. 이 이슈에서는 항상 DRAFT로만 저장하므로 이론상 거의 안 걸리지만,
- *      같은 원천으로 서로 다른 revision_no draft가 실수로 여러 번 만들어지는 상황을
- *      조기에 막아준다.
- *
- *   3. 계정과목 조회·검증: draft.getLines()의 각 줄마다
- *      journalAccountMapper.findActiveByCode(line.getAccountCode().name())을 호출한다.
- *      null이면(코드가 없거나 active_yn=false) 업무 예외를 던진다("활성 계정과목만
- *      참조" 요구사항) — journal_account가 아직 시드되지 않은 환경이라면 이 체크가 항상
- *      실패할 것이므로, 로컬 검증 시 시드 데이터가 있는지 먼저 확인한다.
- *
- *   4. journal_no 채번: journalDate에서 year("2026"), month("07", zero-padded 2자리)를
- *      뽑아 journalMapper.findNextJournalSeq(year, month)를 호출하고,
- *      String.format("JV-%s-%s-%04d", year, month, seq)로 조합한다(#93 설계 결정 형식).
- *      uq_journal_no UNIQUE 제약과 충돌할 수 있으니, ValidationRunCreateServiceImpl처럼
- *      DataIntegrityViolationException을 잡아 REQUIRES_NEW 트랜잭션으로 재시도하는 방식을
- *      쓰는 걸 권장한다(같은 트랜잭션 안에서 재시도하면 PostgreSQL이 트랜잭션을 이미
- *      abort 상태로 만들어 재시도 INSERT조차 거부한다).
- *
- *   5. 헤더 INSERT: JournalHeaderInsertRow를 draft 값 그대로 채우고(journalNo는 4번 결과,
- *      createdBy는 파라미터) journalMapper.insert(row)를 호출한다. useGeneratedKeys로
- *      row.getJournalHeaderId()가 채워진다.
- *
- *   6. 라인 INSERT: draft.getLines()를 순회하며 JournalLineInsertRow를 만들고(journalHeaderId는
- *      5번 결과, journalAccountId는 3번에서 조회한 실제 FK 값 — line.getAccountCode()가
- *      아니라 JournalAccountRow.getJournalAccountId()를 넣어야 한다) journalMapper.insertLine을
- *      각 줄마다 호출한다.
- *
- *   7. 트랜잭션: 5·6번(헤더+모든 라인)은 반드시 하나의 트랜잭션이어야 한다 — 이 클래스
- *      메서드 전체에 @Transactional을 붙이면 된다(ValidationRunBatchLifecycleServiceImpl
- *      참고). 4번의 재시도 트랜잭션(REQUIRES_NEW)만 별도로 분리해야 한다 — 채번 충돌
- *      재시도가 헤더·라인 INSERT까지 통째로 롤백시키면 안 되기 때문이다. 즉 saveDraft() 안에서
- *      "채번"과 "헤더+라인 INSERT"를 서로 다른 트랜잭션 경계로 나누는 구조가 된다.
- *
- *   8. 감사 로그: 5·6번이 성공한 뒤 AuditLogMapper.insert(AuditLogInsertRow.builder()...)를
- *      직접 호출한다 — actionCode="JOURNAL_HEADER_POSTED"(또는 draft 상태가 항상 DRAFT이므로
- *      "JOURNAL_DRAFT_SAVED" 쪽이 더 정확할 수 있다, 판단 필요), entityType="JOURNAL_HEADER",
- *      entityId=String.valueOf(journalHeaderId), userId=createdBy. "저장 성공 시 원천·분개
- *      ID·검증 실행 ID·요청 ID를 포함한 감사 로그" 요구사항이 reason 필드에 원천 정보를,
- *      requestId는 이 서비스의 호출자가 파라미터로 내려줘야 한다(현재 saveDraft 시그니처엔
- *      requestId가 없다 — 필요하면 시그니처에 추가할지 먼저 결정한다).
- *
- *   9. FINALIZED 불변성: 이미 guard_journal_header_write 트리거가 "FINALIZED validation_run에
- *      분개를 추가할 수 없다"를 막는다(V1__baseline_v2_1_2.sql:1300-1305). 이 서비스가
- *      직접 검사할 필요는 없다 — draft.getValidationRunId()가 FINALIZED 실행을 가리키면
- *      5번 INSERT 시점에 트리거가 DataAccessException을 던지고, 그게 그대로 위로
- *      전파되게 두면 된다. POSTED/REVERSED 불변성도 마찬가지로 이 이슈(INSERT만 함)에서는
- *      해당 사항이 없다 — UPDATE/DELETE를 만드는 후속 이슈(정정·POSTED 전이)의 몫이다.
- */
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
 @Service
 public class JournalPersistenceServiceImpl implements JournalPersistenceService {
+
+    private static final String CONSTRAINT_JOURNAL_NO = "uq_journal_no";
+    private static final int MAX_JOURNAL_NO_RETRIES = 3;
 
     private final JournalMapper journalMapper;
     private final JournalAccountMapper journalAccountMapper;
     private final AuditLogMapper auditLogMapper;
+    private final ConstraintErrorCodeResolver constraintErrorCodeResolver;
+    private final TransactionTemplate requiresNewTransactionTemplate;
 
     public JournalPersistenceServiceImpl(JournalMapper journalMapper,
                                           JournalAccountMapper journalAccountMapper,
-                                          AuditLogMapper auditLogMapper) {
+                                          AuditLogMapper auditLogMapper,
+                                          ConstraintErrorCodeResolver constraintErrorCodeResolver,
+                                          PlatformTransactionManager transactionManager) {
         this.journalMapper = journalMapper;
         this.journalAccountMapper = journalAccountMapper;
         this.auditLogMapper = auditLogMapper;
+        this.constraintErrorCodeResolver = constraintErrorCodeResolver;
+        this.requiresNewTransactionTemplate = new TransactionTemplate(transactionManager);
+        this.requiresNewTransactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
     }
 
     @Override
-    public JournalHeaderRow saveDraft(JournalHeaderDraft draft, Long createdBy) {
-        throw new UnsupportedOperationException("TODO(#93): 위 클래스 Javadoc의 1~9단계대로 구현");
+    public JournalHeaderRow saveDraft(JournalHeaderDraft draft, Long createdBy, String requestId) {
+        // 1. 멱등 체크
+        JournalHeaderRow existing = journalMapper.findBySourceKey(
+                draft.getJournalType().name(), draft.getSourceEntityType(),
+                draft.getSourceEntityId(), draft.getRevisionNo());
+        if (existing != null) {
+            return existing;
+        }
+
+        // 2. POSTED 중복 기표 선제 체크
+        if (journalMapper.existsPostedForSource(draft.getJournalType().name(),
+                draft.getSourceEntityType(), draft.getSourceEntityId())) {
+            throw new FgcBusinessException(FgcErrorCode.LEDG_002, Map.of(
+                    "journalType", draft.getJournalType(),
+                    "sourceEntityType", draft.getSourceEntityType(),
+                    "sourceEntityId", draft.getSourceEntityId()));
+        }
+
+        // 3. 계정과목 조회·검증
+        List<Long> journalAccountIds = new ArrayList<>();
+        for (JournalLineDraft line : draft.getLines()) {
+            JournalAccountRow account = journalAccountMapper.findActiveByCode(
+                    line.getAccountCode().name()
+            );
+            if (account == null) {
+                throw new FgcBusinessException(FgcErrorCode.JOURNAL_001, Map.of(
+                        "accountCode", line.getAccountCode()));
+            }
+            journalAccountIds.add(account.getJournalAccountId());
+        }
+
+        // 채번 + 헤더/라인 INSERT + 감사로그는 하나의 REQUIRES_NEW 트랜잭션
+        // (attemptSave)으로 묶고, uq_journal_no 충돌일 때만 그 트랜잭션 전체를 다시 시도
+        for (int attempt = 1; attempt <= MAX_JOURNAL_NO_RETRIES; attempt++) {
+            try {
+                return requiresNewTransactionTemplate.execute(
+                        status -> attemptSave(draft, journalAccountIds, createdBy, requestId));
+            } catch (DataIntegrityViolationException e) {
+                if (!isJournalNoCollision(e) || attempt == MAX_JOURNAL_NO_RETRIES) {
+                    throw e;
+                }
+                log.warn("journal_header journal_no 채번 충돌로 재시도합니다 (시도 {}/{})",
+                        attempt, MAX_JOURNAL_NO_RETRIES);
+            }
+        }
+        throw new IllegalStateException("unreachable: MAX_JOURNAL_NO_RETRIES 루프를 정상적으로 빠져나올 수 없다");
+    }
+
+    // 위반된 제약이 uq_journal_no(채번 충돌)인지 판정
+    private boolean isJournalNoCollision(DataIntegrityViolationException e) {
+        Optional<String> constraintName = constraintErrorCodeResolver.extractConstraintName(e);
+        if (constraintName.isPresent()) {
+            return CONSTRAINT_JOURNAL_NO.equals(constraintName.get());
+        }
+        Throwable root = e;
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+        String message = root.getMessage() == null ? "" : root.getMessage().toLowerCase(Locale.ROOT);
+        return message.contains(CONSTRAINT_JOURNAL_NO);
+    }
+
+    private JournalHeaderRow attemptSave(JournalHeaderDraft draft, List<Long> journalAccountIds,
+                                          Long createdBy, String requestId) {
+        // 4. journal_no 채번
+        String year = String.valueOf(draft.getJournalDate().getYear());
+        String month = String.format("%02d", draft.getJournalDate().getMonthValue());
+        int seq = journalMapper.findNextJournalSeq(year, month);
+        String journalNo = String.format("JV-%s-%s-%04d", year, month, seq);
+
+        // 5. 헤더 INSERT — useGeneratedKeys라 insert(row) 호출 한 번으로 row 객체 자체에
+        // journal_header_id가 채워져 돌아온다.
+        JournalHeaderInsertRow headerRow = JournalHeaderInsertRow.builder()
+                .journalNo(journalNo)
+                .journalDate(draft.getJournalDate())
+                .journalType(draft.getJournalType().name())
+                .sourceEntityType(draft.getSourceEntityType())
+                .sourceEntityId(draft.getSourceEntityId())
+                .revisionNo(draft.getRevisionNo())
+                .validationRunId(draft.getValidationRunId())
+                .contractId(draft.getContractId())
+                .policyVersionId(draft.getPolicyVersionId())
+                .description(draft.getDescription())
+                .createdBy(createdBy)
+                .build();
+        journalMapper.insert(headerRow);
+        Long journalHeaderId = headerRow.getJournalHeaderId();
+
+        // 6. 라인 INSERT
+        List<JournalLineDraft> lines = draft.getLines();
+        for (int i = 0; i < lines.size(); i++) {
+            JournalLineDraft line = lines.get(i);
+            JournalLineInsertRow lineRow = JournalLineInsertRow.builder()
+                    .journalHeaderId(journalHeaderId)
+                    .lineNo(line.getLineNo())
+                    .journalAccountId(journalAccountIds.get(i))
+                    .debitAmount(line.getDebitAmount())
+                    .creditAmount(line.getCreditAmount())
+                    .contractId(line.getContractId())
+                    .agentId(line.getAgentId())
+                    .paymentStage(line.getPaymentStage() == null ? null : line.getPaymentStage().name())
+                    .commissionItemId(line.getCommissionItemId())
+                    .memo(line.getMemo())
+                    .build();
+            journalMapper.insertLine(lineRow);
+        }
+
+        // 8. 감사 로그
+        auditLogMapper.insert(AuditLogInsertRow.builder()
+                .userId(createdBy)
+                .actionCode("JOURNAL_DRAFT_SAVED")
+                .entityType("JOURNAL_HEADER")
+                .entityId(String.valueOf(journalHeaderId))
+                .requestId(requestId)
+                .reason("journalType=" + draft.getJournalType()
+                        + ",sourceEntityType=" + draft.getSourceEntityType()
+                        + ",sourceEntityId=" + draft.getSourceEntityId()
+                        + ",validationRunId=" + draft.getValidationRunId())
+                .build());
+
+        // 9. FINALIZED / POSTED / REVERSED 불변성
+        return journalMapper.findBySourceKey(draft.getJournalType().name(),
+                draft.getSourceEntityType(), draft.getSourceEntityId(), draft.getRevisionNo());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,12 @@ mybatis:
   mapper-locations: classpath:mapper/**/*.xml
   configuration:
     map-underscore-to-camel-case: true   # DB snake_case ↔ Java camelCase 자동 매핑
+    # 기본값(SESSION)은 같은 트랜잭션 안에서 같은 SELECT를 다시 호출해도 1차 캐시가
+    # 재조회를 건너뛴다 — 그 트랜잭션 도중 REQUIRES_NEW로 커밋된 다른 세션의 변경분을
+    # 못 본다(#93 JournalPersistenceService의 findBySourceKey 멱등 체크가 이 문제로
+    # 같은 트랜잭션 안에서 두 번 부르면 stale null을 돌려줘 uq_journal_source_revision
+    # 위반을 낼 수 있었다). STATEMENT로 낮춰 매 조회마다 다시 DB를 본다.
+    local-cache-scope: STATEMENT
 
 server:
   port: 8081

--- a/src/main/resources/db/migration/V16__journal_account_seed.sql
+++ b/src/main/resources/db/migration/V16__journal_account_seed.sql
@@ -1,0 +1,14 @@
+-- 운영정책서 제39조 "최소 계정과목" 8개 시드.
+-- journal_account는 baseline(V1)에서 CREATE TABLE만 되고 시드가 없었다 — #93
+-- JournalPersistenceService.saveDraft()가 활성 계정과목을 조회해 검증하므로, 이 시드가
+-- 없으면 저장이 항상 실패한다. 코드 값은
+-- com.susukkang.fgc.journal.domain.JournalAccountCode enum과 문자열이 같아야 한다.
+INSERT INTO fgc.journal_account (account_code, account_name, normal_balance) VALUES
+    ('EXPECTED_RECEIVABLE',        '예상 수수료미수금',       'DEBIT'),
+    ('EXPECTED_INCOME',            '예상 수수료수익 대응',     'CREDIT'),
+    ('ACTUAL_RECEIVABLE',          '실제 수수료미수금',       'DEBIT'),
+    ('ACTUAL_INCOME',              '실제 수수료수익 대응',     'CREDIT'),
+    ('EXPECTED_PAYOUT_EXPENSE',    '예상 설계사 지급비용',     'DEBIT'),
+    ('EXPECTED_PAYOUT_PAYABLE',    '예상 지급채무',           'CREDIT'),
+    ('CONFIRMED_PAYOUT_EXPENSE',   '확정 설계사 지급비용',     'DEBIT'),
+    ('CONFIRMED_PAYOUT_PAYABLE',   '확정 지급채무',           'CREDIT');

--- a/src/main/resources/mapper/journal/JournalAccountMapper.xml
+++ b/src/main/resources/mapper/journal/JournalAccountMapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<!--
+  TODO(#93): com.susukkang.fgc.journal.mapper.JournalAccountMapper#findActiveByCode의
+  Javadoc에 전체 SQL 초안이 있다 — 그대로 옮기면 된다.
+
+  <select id="findActiveByCode" resultType="...JournalAccountRow">
+-->
+<mapper namespace="com.susukkang.fgc.journal.mapper.JournalAccountMapper">
+
+</mapper>

--- a/src/main/resources/mapper/journal/JournalAccountMapper.xml
+++ b/src/main/resources/mapper/journal/JournalAccountMapper.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<!--
-  TODO(#93): com.susukkang.fgc.journal.mapper.JournalAccountMapper#findActiveByCode의
-  Javadoc에 전체 SQL 초안이 있다 — 그대로 옮기면 된다.
-
-  <select id="findActiveByCode" resultType="...JournalAccountRow">
--->
 <mapper namespace="com.susukkang.fgc.journal.mapper.JournalAccountMapper">
-
+    <select id="findActiveByCode" resultType="com.susukkang.fgc.journal.dto.JournalAccountRow">
+        SELECT journal_account_id, account_code, account_name, normal_balance, active_yn
+        FROM fgc.journal_account
+        WHERE account_code = #{accountCode} AND active_yn = true
+    </select>
 </mapper>

--- a/src/main/resources/mapper/journal/JournalMapper.xml
+++ b/src/main/resources/mapper/journal/JournalMapper.xml
@@ -1,22 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<!--
-  TODO(#93): 아래 5개 SQL을 작성한다. 각 id가 어떤 SQL이어야 하는지는
-  com.susukkang.fgc.journal.mapper.JournalMapper 인터페이스의 메서드별 Javadoc에
-  전체 SQL 초안이 있다 — 그대로 옮기고 컬럼 별칭만 확인하면 된다.
-
-  <insert id="insert" parameterType="...JournalHeaderInsertRow"
-          useGeneratedKeys="true" keyProperty="journalHeaderId" keyColumn="journal_header_id">
-  <insert id="insertLine" parameterType="...JournalLineInsertRow">
-  <select id="findNextJournalSeq" resultType="int">
-  <select id="findBySourceKey" resultType="...JournalHeaderRow">
-  <select id="existsPostedForSource" resultType="boolean">
-
-  이 파일에 <insert>/<select> 엘리먼트가 아직 없으므로, JournalMapper의 메서드를
-  실제로 호출하면 "Invalid bound statement (not found)" 예외가 난다 — 서비스 구현을
-  마칠 때까지는 문제되지 않는다(JournalPersistenceServiceImpl도 아직 TODO 상태라
-  이 메서드들을 호출하지 않는다).
--->
 <mapper namespace="com.susukkang.fgc.journal.mapper.JournalMapper">
+    <!--
+      status/created_at은 컬럼 기본값(DRAFT/clock_timestamp())에 맡기고 VALUES에
+      넣지 않는다 — guard_journal_header_write가 INSERT 시 status<>'DRAFT'를 거부한다
+      (JournalHeaderInsertRow Javadoc 참고).
+    -->
+    <insert id="insert" parameterType="com.susukkang.fgc.journal.dto.JournalHeaderInsertRow"
+            useGeneratedKeys="true" keyProperty="journalHeaderId" keyColumn="journal_header_id">
+        INSERT INTO fgc.journal_header
+            (journal_no, journal_date, journal_type, source_entity_type, source_entity_id,
+             revision_no, validation_run_id, contract_id, policy_version_id,
+             correction_group_key, description, created_by)
+        VALUES
+            (#{journalNo}, #{journalDate}, #{journalType}, #{sourceEntityType}, #{sourceEntityId},
+             #{revisionNo}, #{validationRunId}, #{contractId}, #{policyVersionId},
+             #{correctionGroupKey}, #{description}, #{createdBy})
+    </insert>
 
+    <insert id="insertLine" parameterType="com.susukkang.fgc.journal.dto.JournalLineInsertRow"
+            useGeneratedKeys="true" keyProperty="journalLineId" keyColumn="journal_line_id">
+        INSERT INTO fgc.journal_line
+            (journal_header_id, line_no, journal_account_id, debit_amount, credit_amount,
+             contract_id, agent_id, payment_stage, commission_item_id, memo)
+        VALUES
+            (#{journalHeaderId}, #{lineNo}, #{journalAccountId}, #{debitAmount}, #{creditAmount},
+             #{contractId}, #{agentId}, #{paymentStage}, #{commissionItemId}, #{memo})
+    </insert>
+
+    <select id="findNextJournalSeq" resultType="int">
+        SELECT COALESCE(MAX(CAST(SUBSTRING(journal_no FROM 'JV-\d{4}-\d{2}-(\d+)$') AS int)), 0) + 1
+        FROM fgc.journal_header
+        WHERE journal_no LIKE 'JV-' || #{year} || '-' || #{month} || '-%'
+    </select>
+
+    <select id="findBySourceKey" resultType="com.susukkang.fgc.journal.dto.JournalHeaderRow">
+        SELECT journal_header_id, journal_no, journal_date, journal_type, source_entity_type,
+               source_entity_id, revision_no, validation_run_id, contract_id, policy_version_id,
+               status, description, created_by, posted_by, posted_at, created_at
+        FROM fgc.journal_header
+        WHERE journal_type = #{journalType} AND source_entity_type = #{sourceEntityType}
+        AND source_entity_id = #{sourceEntityId} AND revision_no = #{revisionNo}
+    </select>
+
+    <select id="existsPostedForSource" resultType="boolean">
+        SELECT EXISTS (
+            SELECT 1 FROM fgc.journal_header
+            WHERE journal_type = #{journalType} AND source_entity_type = #{sourceEntityType}
+            AND source_entity_id = #{sourceEntityId} AND status = 'POSTED'
+        )
+    </select>
 </mapper>

--- a/src/main/resources/mapper/journal/JournalMapper.xml
+++ b/src/main/resources/mapper/journal/JournalMapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<!--
+  TODO(#93): 아래 5개 SQL을 작성한다. 각 id가 어떤 SQL이어야 하는지는
+  com.susukkang.fgc.journal.mapper.JournalMapper 인터페이스의 메서드별 Javadoc에
+  전체 SQL 초안이 있다 — 그대로 옮기고 컬럼 별칭만 확인하면 된다.
+
+  <insert id="insert" parameterType="...JournalHeaderInsertRow"
+          useGeneratedKeys="true" keyProperty="journalHeaderId" keyColumn="journal_header_id">
+  <insert id="insertLine" parameterType="...JournalLineInsertRow">
+  <select id="findNextJournalSeq" resultType="int">
+  <select id="findBySourceKey" resultType="...JournalHeaderRow">
+  <select id="existsPostedForSource" resultType="boolean">
+
+  이 파일에 <insert>/<select> 엘리먼트가 아직 없으므로, JournalMapper의 메서드를
+  실제로 호출하면 "Invalid bound statement (not found)" 예외가 난다 — 서비스 구현을
+  마칠 때까지는 문제되지 않는다(JournalPersistenceServiceImpl도 아직 TODO 상태라
+  이 메서드들을 호출하지 않는다).
+-->
+<mapper namespace="com.susukkang.fgc.journal.mapper.JournalMapper">
+
+</mapper>

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -28,6 +28,7 @@ error.validationRun.stateConflict=상태 변경 불가 — 그 사이 다른 요
 error.ledger.imbalance=기표 불가 — 차변 합계와 대변 합계가 다릅니다. 차액 {c}원.
 error.ledger.alreadyPosted=저장 불가 — 이미 기표된 분개입니다.
 error.ledger.reverseOnly=수정 불가 — 분개는 고치지 않습니다. 역분개로 바로잡으세요.
+error.journal.invalidAccount=저장 불가 — 존재하지 않거나 비활성화된 계정과목입니다. {accountCode}
 
 error.reconciliation.duplicateGroup=처리 불가 — 같은 대사 그룹이 중복 생성되었습니다. 실행을 다시 시작하세요.
 

--- a/src/main/resources/messages_ko.properties
+++ b/src/main/resources/messages_ko.properties
@@ -23,6 +23,7 @@ error.validationRun.stateConflict=상태 변경 불가 — 그 사이 다른 요
 error.ledger.imbalance=기표 불가 — 차변 합계와 대변 합계가 다릅니다. 차액 {c}원.
 error.ledger.alreadyPosted=저장 불가 — 이미 기표된 분개입니다.
 error.ledger.reverseOnly=수정 불가 — 분개는 고치지 않습니다. 역분개로 바로잡으세요.
+error.journal.invalidAccount=저장 불가 — 존재하지 않거나 비활성화된 계정과목입니다. {accountCode}
 
 error.reconciliation.duplicateGroup=처리 불가 — 같은 대사 그룹이 중복 생성되었습니다. 실행을 다시 시작하세요.
 

--- a/src/test/java/com/susukkang/fgc/journal/service/JournalPersistenceServiceImplIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/journal/service/JournalPersistenceServiceImplIntegrationTest.java
@@ -1,0 +1,149 @@
+package com.susukkang.fgc.journal.service;
+
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.journal.domain.ExpectedInsurerIncomeJournalCommand;
+import com.susukkang.fgc.journal.domain.JournalAccountCode;
+import com.susukkang.fgc.journal.dto.JournalHeaderDraft;
+import com.susukkang.fgc.journal.dto.JournalHeaderRow;
+import com.susukkang.fgc.journal.dto.JournalLineDraft;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * #93 "정상 저장, 라인 저장 실패 롤백, 중복 원천, 비활성 계정과목" 테스트(이슈 To-do).
+ *
+ * @Transactional로 테스트 종료 시 자동 롤백시킨다 — journal_header/journal_line은
+ * guard_journal_header_write/guard_journal_line_write 트리거가 DRAFT 상태에서는 DELETE를
+ * 막지 않지만(POSTED/REVERSED만 막음), 롤백 쪽이 더 간단하고 다른 통합테스트(#77 코드리뷰
+ * 반영분)와 관례도 맞는다.
+ */
+@SpringBootTest
+@Transactional
+class JournalPersistenceServiceImplIntegrationTest {
+
+    @Autowired
+    private JournalPersistenceService journalPersistenceService;
+    @Autowired
+    private JournalEntryDraftService journalEntryDraftService;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private final LocalDate journalDate = LocalDate.of(2026, 8, 1);
+
+    private Long contractId() {
+        return jdbcTemplate.queryForObject(
+                "SELECT contract_id FROM fgc.insurance_contract WHERE contract_no = ?",
+                Long.class, "FGC-FGL01-202607-0001");
+    }
+
+    private JournalHeaderDraft newDraft(long scheduleLineId) {
+        ExpectedInsurerIncomeJournalCommand command = ExpectedInsurerIncomeJournalCommand.builder()
+                .scheduleLineId(scheduleLineId)
+                .contractId(contractId())
+                .journalDate(journalDate)
+                .expectedAmount(BigDecimal.valueOf(50_000))
+                .description("#93 통합테스트")
+                .build();
+        return journalEntryDraftService.draftExpectedInsurerIncome(command);
+    }
+
+    @Test
+    void savingANewDraftPersistsBalancedHeaderAndLinesWithAuditLog() {
+        long scheduleLineId = System.nanoTime();
+        JournalHeaderDraft draft = newDraft(scheduleLineId);
+
+        JournalHeaderRow saved = journalPersistenceService.saveDraft(draft, 3L, "req-93-normal");
+
+        assertThat(saved.getJournalHeaderId()).isNotNull();
+        assertThat(saved.getJournalNo()).matches("JV-\\d{4}-\\d{2}-\\d{4}");
+        assertThat(saved.getStatus()).isEqualTo("DRAFT");
+
+        Long debitTotal = jdbcTemplate.queryForObject(
+                "SELECT SUM(debit_amount)::bigint FROM fgc.journal_line WHERE journal_header_id = ?",
+                Long.class, saved.getJournalHeaderId());
+        Long creditTotal = jdbcTemplate.queryForObject(
+                "SELECT SUM(credit_amount)::bigint FROM fgc.journal_line WHERE journal_header_id = ?",
+                Long.class, saved.getJournalHeaderId());
+        assertThat(debitTotal).isEqualTo(creditTotal);
+
+        List<String> auditActionCodes = jdbcTemplate.queryForList(
+                "SELECT action_code FROM fgc.audit_log WHERE entity_type = 'JOURNAL_HEADER' AND entity_id = ? AND request_id = ?",
+                String.class, String.valueOf(saved.getJournalHeaderId()), "req-93-normal");
+        assertThat(auditActionCodes).containsExactly("JOURNAL_DRAFT_SAVED");
+    }
+
+    @Test
+    void savingTheSameSourceTwiceIsIdempotentAndDoesNotDuplicate() {
+        long scheduleLineId = System.nanoTime();
+        JournalHeaderDraft draft = newDraft(scheduleLineId);
+
+        JournalHeaderRow first = journalPersistenceService.saveDraft(draft, 3L, "req-93-first");
+        JournalHeaderRow second = journalPersistenceService.saveDraft(draft, 3L, "req-93-second");
+
+        assertThat(second.getJournalHeaderId()).isEqualTo(first.getJournalHeaderId());
+
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM fgc.journal_header WHERE journal_type = ? AND source_entity_type = ? "
+                        + "AND source_entity_id = ? AND revision_no = ?",
+                Integer.class, draft.getJournalType().name(), draft.getSourceEntityType(),
+                draft.getSourceEntityId(), draft.getRevisionNo());
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void lineInsertFailureRollsBackTheHeaderToo() {
+        JournalHeaderDraft goodDraft = newDraft(System.nanoTime());
+        // 두 줄 모두 lineNo=1로 만들어 uq_journal_line(journal_header_id, line_no) 위반을
+        // 유도한다 — 첫 줄 INSERT는 성공하고 두 번째 줄에서 실패해야, "라인 INSERT가
+        // 중간에 실패하면 헤더까지 통째로 롤백되는지"를 검증할 수 있다.
+        JournalLineDraft duplicateLineNo = goodDraft.getLines().get(0).toBuilder().lineNo(1).build();
+        JournalLineDraft alsoLineNo1 = goodDraft.getLines().get(1).toBuilder().lineNo(1).build();
+        JournalHeaderDraft brokenDraft = goodDraft.toBuilder()
+                .lines(List.of(duplicateLineNo, alsoLineNo1))
+                .build();
+
+        assertThatThrownBy(() -> journalPersistenceService.saveDraft(brokenDraft, 3L, "req-93-rollback"))
+                .isInstanceOf(DataAccessException.class);
+
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM fgc.journal_header WHERE journal_type = ? AND source_entity_type = ? "
+                        + "AND source_entity_id = ? AND revision_no = ?",
+                Integer.class, brokenDraft.getJournalType().name(), brokenDraft.getSourceEntityType(),
+                brokenDraft.getSourceEntityId(), brokenDraft.getRevisionNo());
+        assertThat(count).isEqualTo(0);
+    }
+
+    @Test
+    void inactiveAccountCodeIsRejectedBeforeAnyInsert() {
+        // @Transactional 테스트라 이 UPDATE도 테스트 종료 시 자동 롤백된다 —
+        // 다른 테스트나 실제 데이터에 영향을 주지 않는다.
+        jdbcTemplate.update("UPDATE fgc.journal_account SET active_yn = false WHERE account_code = ?",
+                JournalAccountCode.EXPECTED_RECEIVABLE.name());
+
+        JournalHeaderDraft draft = newDraft(System.nanoTime());
+
+        assertThatThrownBy(() -> journalPersistenceService.saveDraft(draft, 3L, "req-93-inactive"))
+                .isInstanceOf(FgcBusinessException.class)
+                .satisfies(ex -> assertThat(((FgcBusinessException) ex).getErrorCode())
+                        .isEqualTo(FgcErrorCode.JOURNAL_001));
+
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM fgc.journal_header WHERE journal_type = ? AND source_entity_type = ? "
+                        + "AND source_entity_id = ? AND revision_no = ?",
+                Integer.class, draft.getJournalType().name(), draft.getSourceEntityType(),
+                draft.getSourceEntityId(), draft.getRevisionNo());
+        assertThat(count).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/susukkang/fgc/journal/service/JournalPersistenceServiceImplIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/journal/service/JournalPersistenceServiceImplIntegrationTest.java
@@ -7,6 +7,7 @@ import com.susukkang.fgc.journal.domain.JournalAccountCode;
 import com.susukkang.fgc.journal.dto.JournalHeaderDraft;
 import com.susukkang.fgc.journal.dto.JournalHeaderRow;
 import com.susukkang.fgc.journal.dto.JournalLineDraft;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -24,14 +25,19 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * #93 "정상 저장, 라인 저장 실패 롤백, 중복 원천, 비활성 계정과목" 테스트(이슈 To-do).
  *
- * @Transactional로 테스트 종료 시 자동 롤백시킨다 — journal_header/journal_line은
- * guard_journal_header_write/guard_journal_line_write 트리거가 DRAFT 상태에서는 DELETE를
- * 막지 않지만(POSTED/REVERSED만 막음), 롤백 쪽이 더 간단하고 다른 통합테스트(#77 코드리뷰
- * 반영분)와 관례도 맞는다.
+ * 클래스에 @Transactional을 붙여도 journal_header/journal_line/audit_log는 자동
+ * 롤백되지 않는다 — JournalPersistenceServiceImpl.saveDraft()의 실제 저장은
+ * REQUIRES_NEW로 별도 트랜잭션에서 커밋되므로, 이 테스트 트랜잭션이 롤백돼도 그 커밋은
+ * 그대로 남는다(코드리뷰 반영). 그래서 @AfterEach에서 description 마커로 직접
+ * DELETE한다 — journal_account.active_yn UPDATE만 REQUIRES_NEW를 타지 않는 일반
+ * 쿼리라 @Transactional 롤백으로 정리된다. audit_log는 append-only라 지우지
+ * 않는다(다른 통합테스트와 같은 관례 — request_id로 구분되어 해가 없다).
  */
 @SpringBootTest
 @Transactional
 class JournalPersistenceServiceImplIntegrationTest {
+
+    private static final String TEST_MARKER = "#93 통합테스트";
 
     @Autowired
     private JournalPersistenceService journalPersistenceService;
@@ -41,6 +47,16 @@ class JournalPersistenceServiceImplIntegrationTest {
     private JdbcTemplate jdbcTemplate;
 
     private final LocalDate journalDate = LocalDate.of(2026, 8, 1);
+
+    @AfterEach
+    void cleanUp() {
+        jdbcTemplate.update("""
+                DELETE FROM fgc.journal_line WHERE journal_header_id IN (
+                    SELECT journal_header_id FROM fgc.journal_header WHERE description = ?
+                )
+                """, TEST_MARKER);
+        jdbcTemplate.update("DELETE FROM fgc.journal_header WHERE description = ?", TEST_MARKER);
+    }
 
     private Long contractId() {
         return jdbcTemplate.queryForObject(
@@ -54,7 +70,7 @@ class JournalPersistenceServiceImplIntegrationTest {
                 .contractId(contractId())
                 .journalDate(journalDate)
                 .expectedAmount(BigDecimal.valueOf(50_000))
-                .description("#93 통합테스트")
+                .description(TEST_MARKER)
                 .build();
         return journalEntryDraftService.draftExpectedInsurerIncome(command);
     }
@@ -122,6 +138,31 @@ class JournalPersistenceServiceImplIntegrationTest {
                         + "AND source_entity_id = ? AND revision_no = ?",
                 Integer.class, brokenDraft.getJournalType().name(), brokenDraft.getSourceEntityType(),
                 brokenDraft.getSourceEntityId(), brokenDraft.getRevisionNo());
+        assertThat(count).isEqualTo(0);
+    }
+
+    @Test
+    void imbalancedDraftIsRejectedBeforeAnyInsert() {
+        // 대변 줄만 금액을 늘려 차변합계≠대변합계로 만든다(코드리뷰 반영 — 저장 시점부터
+        // 균형을 강제해야 한다는 FGC-FUN-046 인수조건 확인용).
+        JournalHeaderDraft draft = newDraft(System.nanoTime());
+        JournalLineDraft inflatedCredit = draft.getLines().get(1).toBuilder()
+                .creditAmount(draft.getLines().get(1).getCreditAmount().add(BigDecimal.TEN))
+                .build();
+        JournalHeaderDraft imbalancedDraft = draft.toBuilder()
+                .lines(List.of(draft.getLines().get(0), inflatedCredit))
+                .build();
+
+        assertThatThrownBy(() -> journalPersistenceService.saveDraft(imbalancedDraft, 3L, "req-93-imbalance"))
+                .isInstanceOf(FgcBusinessException.class)
+                .satisfies(ex -> assertThat(((FgcBusinessException) ex).getErrorCode())
+                        .isEqualTo(FgcErrorCode.LEDG_001));
+
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM fgc.journal_header WHERE journal_type = ? AND source_entity_type = ? "
+                        + "AND source_entity_id = ? AND revision_no = ?",
+                Integer.class, imbalancedDraft.getJournalType().name(), imbalancedDraft.getSourceEntityType(),
+                imbalancedDraft.getSourceEntityId(), imbalancedDraft.getRevisionNo());
         assertThat(count).isEqualTo(0);
     }
 


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* 복식부기 분개 초안을 journal_header/journal_line에 저장하는 JournalPersistenceService 구현

## 🔗 2. 관련 이슈

* Closes #93

## 🛠 3. 구현 내용

* JournalPersistenceServiceImpl.saveDraft()를 (1) 멱등 체크 → (2) POSTED 중복 기표 선제 체크 → (3) 활성 계정과목 조회·검증 → (4~6) journal_no 채번 + 헤더/라인 INSERT → (8) 감사 로그 순서로 구현
* journal_no는 "JV-{yyyy}-{MM}-{4자리 일련번호}" 형식으로 채번하며, uq_journal_no 충돌 시 ValidationRunCreateServiceImpl과 동일한 REQUIRES_NEW 재시도 패턴 적용
* JournalMapper/JournalAccountMapper 및 XML 구현 (헤더/라인 INSERT, 채번 조회, 원천·개정번호 조회, POSTED 존재 여부 조회, 활성 계정과목 조회)
* journal_account가 시드되어 있지 않아 기능이 동작할 수 없었던 문제를 발견해 V16 마이그레이션으로 운영정책서 제39조 8개 계정과목 시드 추가
* 감사 로그에 requestId를 남기기 위해 saveDraft 시그니처에 requestId 파라미터 추가


## 🧪 4. 테스트 방법

1. `./gradlew test --tests "com.susukkang.fgc.journal.*"` 실행
2. JournalPersistenceServiceImplIntegrationTest: 정상 저장(차변합계=대변합계, 감사로그 기록), 동일 원천 재저장 시 멱등(중복 미생성), 라인 INSERT 실패 시 헤더까지 롤백, 비활성 계정과목 거부 4개 시나리오 확인
3. 전체 스위트: `./gradlew test` (427개 전체 통과 확인)

## 🗄️ 5. DB / Flyway 변경

* [ ] DB 변경 없음
* [x] 새로운 Flyway 마이그레이션 파일 추가
* [x] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* V16__journal_account_seed.sql (journal_account 8개 계정과목 시드, 운영정책서 제39조)

## 📋 6. 리뷰 요구사항

* journal_no 채번 형식("JV-yyyy-MM-일련번호")과 REQUIRES_NEW 재시도 범위가 적절한지
* local-cache-scope를 STATEMENT로 전역 변경한 것이 다른 Mapper에 성능·동작상 영향이 없는지
* requestId를 saveDraft 파라미터로 추가한 방식이 향후 호출부(배치/서비스) 설계와 맞는지

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음

## 💬 9. 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 전표 헤더와 라인 초안을 저장하고 조회할 수 있습니다.
  - 동일한 원천 정보의 중복 저장을 방지하고 기존 전표를 재사용합니다.
  - 전표 번호와 감사 기록을 자동으로 처리합니다.
  - 운영에 필요한 기본 계정과목 8개를 제공합니다.

- **오류 개선**
  - 활성 계정과목 사용 여부와 차변·대변 금액 일치 여부를 검증합니다.
  - 잘못된 계정과목 사용 시 명확한 오류 메시지를 제공합니다.
  - 저장 실패 시 관련 데이터가 함께 취소됩니다.

- **테스트**
  - 정상 저장, 중복 방지, 검증 및 롤백 시나리오를 확인했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->