### PR TITLE
[Fix] 대시보드 중복 범위 선택 UI 제거

### DIFF
--- a/src/main/resources/static/css/features/dashboard.css
+++ b/src/main/resources/static/css/features/dashboard.css
@@ -3,63 +3,6 @@
   gap: var(--space-3);
 }
 
-.dashboard-control-bar {
-  display: flex;
-  min-height: 3.25rem;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-4);
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-8);
-  background: var(--color-bg-surface);
-}
-
-.dashboard-control-fields,
-.dashboard-control-actions,
-.dashboard-control-field {
-  display: flex;
-  align-items: center;
-}
-
-.dashboard-control-fields {
-  min-width: 0;
-  gap: var(--space-3);
-}
-
-.dashboard-control-field {
-  align-items: flex-start;
-  flex-direction: column;
-  gap: 0.125rem;
-}
-
-.dashboard-control-field .select-control {
-  width: 10rem;
-}
-
-.dashboard-control-label,
-.dashboard-updated-label {
-  color: var(--color-text-secondary);
-  font-size: 0.6875rem;
-  line-height: 1.125rem;
-}
-
-.dashboard-updated {
-  min-width: 12rem;
-  padding-left: var(--space-1);
-}
-
-.dashboard-updated-value {
-  color: var(--color-text-secondary);
-  font-size: 0.6875rem;
-  line-height: 1.125rem;
-  font-variant-numeric: tabular-nums;
-}
-
-.dashboard-control-actions {
-  gap: var(--space-2);
-}
-
 .dashboard-main-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 25.5rem;
@@ -293,36 +236,8 @@
   }
 }
 
-@media (max-width: 63.9375rem) {
-  .dashboard-control-bar,
-  .dashboard-control-fields {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .dashboard-control-field,
-  .dashboard-control-field .select-control,
-  .dashboard-control-actions,
-  .dashboard-control-actions .button {
-    width: 100%;
-  }
-
-  .dashboard-updated {
-    min-width: 0;
-    padding-left: 0;
-  }
-
-  .dashboard-control-actions {
-    flex-direction: row;
-  }
-}
-
 @media (max-width: 47.9375rem) {
   .dashboard-secondary-column {
     grid-template-columns: 1fr;
-  }
-
-  .dashboard-control-actions {
-    flex-direction: column;
   }
 }

--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -7,16 +7,6 @@
     <div class="page-header-copy"><h1 class="page-title">업무 대시보드</h1><p class="page-description">이번 달 정산 병목과 우선 처리 업무를 한눈에 확인합니다.</p></div>
   </header>
 
-  <form class="dashboard-control-bar" method="get" th:action="@{/}">
-    <input type="hidden" name="month" th:value="${month}">
-    <div class="dashboard-control-fields">
-      <label class="dashboard-control-field"><span class="dashboard-control-label">집계 기준</span><select class="select-control" disabled><option>저장 완료 결과</option></select></label>
-      <label class="dashboard-control-field"><span class="dashboard-control-label">조직 범위</span><select class="select-control" disabled><option>전체 조직</option></select></label>
-      <div class="dashboard-updated"><p class="dashboard-updated-label">집계 정산월</p><p class="dashboard-updated-value" th:text="${month == null ? '집계월 미지정 · 저장 결과 기준' : month + ' · 저장 결과 기준'}">2026-07 · 저장 결과 기준</p></div>
-    </div>
-    <div class="dashboard-control-actions"><button class="button button-secondary" type="submit">새로고침</button><a class="button button-primary" th:href="@{/validation-runs}">정산 실행</a></div>
-  </form>
-
   <section class="kpi-grid" aria-label="주요 검증 지표">
     <a class="kpi-card kpi-card-error" th:href="@{/cap-checks(status='VIOLATION',month=${month})}"><div class="kpi-card-header"><span class="kpi-label">1,200% 위반</span></div><div class="kpi-value-row"><strong class="kpi-value" th:text="${summary.capViolation()}">0</strong><span class="kpi-unit">건</span></div><div class="kpi-card-footer"><span class="kpi-comparison">확정 위반 판정</span></div></a>
     <a class="kpi-card kpi-card-warning" th:href="@{/cap-checks(status='WARNING',month=${month})}"><div class="kpi-card-header"><span class="kpi-label">1,200% 주의</span></div><div class="kpi-value-row"><strong class="kpi-value" th:text="${summary.capWarning()}">0</strong><span class="kpi-unit">건</span></div><div class="kpi-card-footer"><span class="kpi-comparison">사용률 경고 기준 이상</span></div></a>

--- a/src/test/java/com/susukkang/fgc/dashboard/controller/DashboardViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/dashboard/controller/DashboardViewControllerTest.java
@@ -98,8 +98,15 @@ class DashboardViewControllerTest {
                 // ShellAdvice 기본 기준월(fgc.demo-month)
                 .andExpect(model().attribute("month", "2026-07"))
                 .andExpect(content().string(containsString("2026-07")))
+                .andExpect(content().string(containsString("id=\"global-settlement-month\"")))
                 .andExpect(content().string(containsString(
-                        "type=\"hidden\" name=\"month\" value=\"2026-07\"")))
+                        "/cap-checks?status=VIOLATION&amp;month=2026-07")))
+                .andExpect(content().string(org.hamcrest.Matchers.not(
+                        containsString("dashboard-control-bar"))))
+                .andExpect(content().string(org.hamcrest.Matchers.not(containsString("집계 기준"))))
+                .andExpect(content().string(org.hamcrest.Matchers.not(containsString("조직 범위"))))
+                .andExpect(content().string(org.hamcrest.Matchers.not(containsString("새로고침"))))
+                .andExpect(content().string(org.hamcrest.Matchers.not(containsString("정산 실행"))))
                 // 사이드바가 서버에서 렌더링됐는지 — 목업의 fgc-shell.js 를 대체한 부분
                 .andExpect(content().string(containsString("업무 대시보드")))
                 .andExpect(content().string(containsString("FGC-UI-DASH-W01")))


### PR DESCRIPTION
# Pull Request

## 1. 변경 사항 요약

- 최신 Figma 결정에 따라 업무 대시보드의 중복된 Dashboard Scope 영역을 제거했습니다.
- App Header의 전역 기준 정산월과 KPI 필터 전달 동작은 유지했습니다.

## 2. 관련 이슈

- Refs #97

## 3. 구현 내용

- `dashboard-control-bar` 전체와 집계 기준, 조직 범위, 새로고침, 정산 실행 UI를 제거했습니다.
- 제거된 UI 전용 `dashboard-control-*`, `dashboard-updated*` CSS 및 반응형 규칙을 정리했습니다.
- Page Header 바로 아래에서 KPI Grid가 시작되도록 기존 12px 간격을 유지했습니다.
- 대시보드 렌더링 테스트에 Scope UI 부재, 전역 기준월 Select, KPI month 전달 검증을 추가했습니다.

## 4. 테스트 방법

1. `./gradlew test` 전체 테스트 실행
2. `/` 대시보드를 1440px, 1023px, 390px 화면 폭에서 확인
3. App Header 기준월을 변경하고 URL 및 KPI 링크의 `month` 반영 확인

## 5. DB / Flyway 변경

- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

- 없음

## 6. 리뷰 요구사항

- Dashboard Scope가 별도 대체 UI 없이 완전히 제거되었는지 확인 부탁드립니다.
- App Header 전역 기준월과 KPI 링크의 month/filter 전달이 유지되는지 확인 부탁드립니다.

## 7. 체크리스트

- [x] `develop` 최신 내용을 반영했습니다.
- [x] 로컬 빌드에 성공했습니다.
- [x] 애플리케이션 실행을 확인했습니다.
- [x] 관련 기능을 직접 테스트했습니다.
- [x] 테스트 코드를 수정했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 8. 화면 변경

- Dashboard Scope 영역 삭제
- Page Header 다음에 KPI Grid가 바로 시작하도록 정리
- App Header의 전역 기준월 Select는 유지

## 9. 참고 사항

- PR #105 병합 이후 확정된 최신 Figma 결정에 따른 후속 수정입니다.
- 별도의 정산 실행 버튼은 추가하지 않았으며 향후 별도 요구 시 반영합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 대시보드 헤더 아래의 조회 제어 영역을 제거했습니다.
  * 월 선택, 집계 기준 및 조직 범위 정보, 집계월 표시를 더 이상 제공하지 않습니다.
  * 새로고침 및 정산 실행 버튼이 대시보드에서 제거되었습니다.
  * 작은 화면에서 보조 콘텐츠가 단일 열로 표시되는 반응형 동작은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->