### PR TITLE
[Feat] CAP-W01 1,200% 한도 검증 현황 화면 구현

### DIFF
--- a/src/main/resources/static/css/features/cap.css
+++ b/src/main/resources/static/css/features/cap.css
@@ -288,6 +288,12 @@
   text-underline-offset: 0.15rem;
 }
 
+.cap-negative-amount,
+.cap-detail-mismatch {
+  color: var(--color-status-error-text);
+  font-weight: 600;
+}
+
 .cap-usage-cell {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 4.5rem;

--- a/src/main/resources/static/css/features/cap.css
+++ b/src/main/resources/static/css/features/cap.css
@@ -1,0 +1,446 @@
+.cap-page {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-3);
+}
+
+.cap-section-header {
+  align-items: flex-start;
+}
+
+.cap-section-description,
+.cap-modal-subtitle {
+  margin-top: var(--space-1);
+  color: var(--color-text-tertiary);
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+}
+
+.cap-filter-panel,
+.cap-stage-panel {
+  border-radius: var(--radius-12);
+}
+
+.cap-filter-form {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr)) auto;
+  gap: var(--space-3);
+  align-items: end;
+  padding: var(--space-4) var(--space-6) var(--space-6);
+}
+
+.cap-filter-actions {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.cap-filter-form .select-control:disabled {
+  border-color: var(--color-border-subtle);
+  color: var(--color-text-tertiary);
+  background: var(--color-bg-subtle);
+}
+
+.cap-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.cap-kpi-card {
+  min-width: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.cap-kpi-card[aria-pressed="true"] {
+  border-color: var(--color-action-primary);
+  box-shadow: var(--shadow-focus);
+}
+
+.cap-kpi-card:focus-visible {
+  outline: 0;
+  box-shadow: var(--shadow-focus);
+}
+
+.cap-kpi-normal {
+  border-color: var(--color-status-success-border);
+}
+
+.cap-kpi-warning {
+  border-color: var(--color-status-warning-border);
+}
+
+.cap-kpi-violation {
+  border-color: var(--color-status-error-border);
+}
+
+.cap-kpi-review {
+  border-color: var(--color-status-review-border);
+}
+
+.cap-kpi-value {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-1);
+}
+
+.cap-kpi-value strong {
+  font-size: 1.75rem;
+  line-height: 2.25rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.cap-kpi-value small {
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+}
+
+.cap-stage-panel > .cap-section-header {
+  padding-bottom: 0;
+}
+
+.cap-stage-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-6) var(--space-6);
+}
+
+.cap-stage-card {
+  min-width: 0;
+  padding: var(--space-5);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-12);
+  background: var(--color-bg-surface);
+}
+
+.cap-stage-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.cap-stage-title {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  line-height: 1.375rem;
+}
+
+.cap-stage-code {
+  margin-top: var(--space-1);
+  color: var(--color-text-tertiary);
+  font-size: 0.6875rem;
+}
+
+.cap-usage-track {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border-radius: var(--radius-full);
+  background: var(--color-bg-subtle);
+}
+
+.cap-usage-bar {
+  display: block;
+  width: var(--cap-progress, 0%);
+  height: 100%;
+  border-radius: inherit;
+  background: var(--color-status-success-solid);
+}
+
+.cap-usage-bar.is-warning {
+  background: var(--color-status-warning-solid);
+}
+
+.cap-usage-bar.is-violation {
+  background: var(--color-status-error-solid);
+}
+
+.cap-usage-bar.is-review {
+  background: var(--color-status-review-solid);
+}
+
+.cap-stage-pending-copy {
+  display: flex;
+  min-height: 7.5rem;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-5) 0;
+  color: var(--color-text-tertiary);
+  text-align: center;
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+}
+
+.cap-stage-note {
+  min-height: 2.75rem;
+  margin-top: var(--space-4);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-8);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-subtle);
+  font-size: 0.6875rem;
+  line-height: 1.125rem;
+}
+
+.cap-guidance {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-6);
+  border: 1px solid var(--color-status-info-border);
+  border-radius: var(--radius-12);
+  color: var(--color-status-info-text);
+  background: var(--color-status-info-bg);
+}
+
+.cap-guidance h2 {
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+}
+
+.cap-guidance p {
+  margin-top: var(--space-1);
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+}
+
+.cap-guidance code {
+  font-size: 0.6875rem;
+}
+
+.cap-table-panel {
+  min-width: 0;
+}
+
+.cap-list-count {
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+}
+
+.cap-list-count strong {
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.cap-inline-message,
+.cap-detail-state {
+  display: flex;
+  min-height: 7rem;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-6);
+  color: var(--color-text-secondary);
+  text-align: center;
+  font-size: 0.8125rem;
+}
+
+.cap-inline-message.is-error,
+.cap-detail-state.is-error {
+  color: var(--color-status-error-text);
+  background: var(--color-status-error-bg);
+}
+
+.cap-contract-table,
+.cap-agent-table {
+  table-layout: fixed;
+}
+
+.cap-contract-table {
+  min-width: 86rem;
+}
+
+.cap-agent-table {
+  min-width: 64rem;
+}
+
+.cap-col-contract { width: 8.5rem; }
+.cap-col-stage { width: 8.75rem; }
+.cap-col-date { width: 6.75rem; }
+.cap-col-money { width: 7.5rem; }
+.cap-col-deduction { width: 8.5rem; }
+.cap-col-usage { width: 11rem; }
+.cap-col-status { width: 6.5rem; }
+.cap-col-rule { width: 7rem; }
+
+.cap-contract-table th,
+.cap-contract-table td,
+.cap-agent-table th,
+.cap-agent-table td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cap-contract-link,
+.cap-basis-button {
+  color: var(--color-text-link);
+  font-weight: 500;
+}
+
+.cap-basis-button {
+  text-decoration: underline;
+  text-underline-offset: 0.15rem;
+}
+
+.cap-usage-cell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 4.5rem;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.cap-usage-track {
+  height: 0.375rem;
+}
+
+.cap-usage-value {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.cap-stage-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.cap-stage-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--color-steel-500);
+}
+
+.cap-stage-dot.is-agent {
+  background: var(--color-blue-500);
+}
+
+.text-right {
+  text-align: right;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.cap-table-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--color-border-default);
+}
+
+.cap-page-size {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+}
+
+.cap-page-size .select-control {
+  width: 4.5rem;
+  min-width: 0;
+}
+
+.pagination {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.cap-agent-header .status-badge {
+  height: auto;
+  min-height: 1.5rem;
+  text-align: center;
+  white-space: normal;
+}
+
+.cap-detail-modal {
+  width: min(76rem, 100%);
+}
+
+.cap-detail-modal .modal-body + .modal-body {
+  padding-top: 0;
+}
+
+.cap-detail-state {
+  min-height: 15rem;
+}
+
+@media (max-width: 79.9375rem) {
+  .cap-filter-form {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .cap-filter-contract {
+    grid-column: span 2;
+  }
+
+  .cap-filter-actions {
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width: 61.25rem) {
+  .cap-stage-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .cap-kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 47.9375rem) {
+  .cap-filter-form,
+  .cap-kpi-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .cap-filter-contract {
+    grid-column: auto;
+  }
+
+  .cap-filter-actions,
+  .cap-filter-actions .button {
+    width: 100%;
+  }
+
+  .cap-filter-actions .button {
+    min-width: 0;
+  }
+
+  .cap-stage-header,
+  .cap-agent-header,
+  .cap-table-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .cap-stage-grid,
+  .cap-filter-form {
+    padding-right: var(--space-4);
+    padding-left: var(--space-4);
+  }
+
+  .cap-stage-card {
+    padding: var(--space-4);
+  }
+
+  .cap-guidance {
+    padding: var(--space-4);
+  }
+
+  .pagination {
+    justify-content: center;
+  }
+}

--- a/src/main/resources/static/js/features/cap/cap-list.js
+++ b/src/main/resources/static/js/features/cap/cap-list.js
@@ -1,0 +1,322 @@
+(function () {
+  "use strict";
+
+  var root = document.querySelector(".cap-page");
+  if (!root) return;
+
+  var form = document.getElementById("cap-search-form");
+  var controls = {
+    month: document.getElementById("cap-month"),
+    stage: document.getElementById("cap-stage"),
+    status: document.getElementById("cap-status"),
+    insurerId: document.getElementById("cap-insurer"),
+    contractNo: document.getElementById("cap-contract-no"),
+    size: document.getElementById("cap-page-size")
+  };
+  var state = { page: 1, abortController: null };
+
+  var STATUS_CLASS = {
+    NORMAL: "status-badge-success",
+    WARNING: "status-badge-warning",
+    VIOLATION: "status-badge-error",
+    REVIEW_REQUIRED: "status-badge-review"
+  };
+  var STATUS_PROGRESS_CLASS = {
+    NORMAL: "",
+    WARNING: "is-warning",
+    VIOLATION: "is-violation",
+    REVIEW_REQUIRED: "is-review"
+  };
+  var CLASSIFICATION_LABEL = {
+    INCLUDED: "산입",
+    EXCLUDED: "제외",
+    REVIEW_REQUIRED: "검토필요"
+  };
+
+  function escapeHtml(value) {
+    return String(value == null ? "" : value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
+  function number(value) {
+    return new Intl.NumberFormat("ko-KR").format(Number(value || 0));
+  }
+
+  function won(value) {
+    return number(value) + "원";
+  }
+
+  function percent(value) {
+    return value == null || value === "" ? "—" : String(value) + "%";
+  }
+
+  function visualWidth(value) {
+    var parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed <= 0) return "0%";
+    return Math.min(parsed, 100) + "%";
+  }
+
+  function queryFromLocation() {
+    var params = new URLSearchParams(window.location.search);
+    ["month", "stage", "status", "contractNo"].forEach(function (key) {
+      if (!params.has(key) || !controls[key]) return;
+      controls[key].value = params.get(key);
+    });
+    if (!controls.month.value) controls.month.value = root.dataset.initialMonth || "";
+    if (params.has("page")) state.page = Math.max(1, Number(params.get("page")) || 1);
+    if (params.has("size")) controls.size.value = params.get("size");
+  }
+
+  function currentParams() {
+    var params = new URLSearchParams();
+    ["month", "stage", "status", "insurerId", "contractNo"].forEach(function (key) {
+      if (!controls[key] || controls[key].disabled) return;
+      var value = controls[key].value.trim();
+      if (value) params.set(key, value);
+    });
+    params.set("page", String(state.page));
+    params.set("size", controls.size.value || "20");
+    return params;
+  }
+
+  function replaceLocation(params) {
+    var url = window.location.pathname + "?" + params.toString();
+    window.history.replaceState(null, "", url);
+  }
+
+  function setLoading() {
+    document.getElementById("cap-kpi-grid").setAttribute("aria-busy", "true");
+    document.getElementById("cap-list-message").className = "cap-inline-message";
+    document.getElementById("cap-list-message").textContent = "판정 목록을 불러오는 중입니다.";
+    document.getElementById("cap-list-message").hidden = false;
+    document.getElementById("cap-contract-table-wrap").hidden = true;
+    document.getElementById("cap-pagination").replaceChildren();
+  }
+
+  function setError(error) {
+    var message = error && error.message ? error.message : "한도 검증 현황을 불러오지 못했습니다.";
+    var element = document.getElementById("cap-list-message");
+    element.className = "cap-inline-message is-error";
+    element.textContent = message;
+    element.hidden = false;
+    document.getElementById("cap-contract-table-wrap").hidden = true;
+    document.getElementById("cap-total-count").textContent = "0";
+    document.querySelectorAll("[data-kpi-value]").forEach(function (value) {
+      value.textContent = "—";
+    });
+    document.getElementById("cap-kpi-grid").setAttribute("aria-busy", "false");
+    document.getElementById("cap-pagination").replaceChildren();
+  }
+
+  function renderKpis(summary) {
+    summary = summary || {};
+    var values = {
+      NORMAL: summary.normal,
+      WARNING: summary.warning,
+      VIOLATION: summary.violation,
+      REVIEW_REQUIRED: summary.reviewRequired
+    };
+    document.querySelectorAll("[data-kpi-value]").forEach(function (element) {
+      element.textContent = number(values[element.dataset.kpiValue]);
+    });
+    document.querySelectorAll("[data-cap-status]").forEach(function (button) {
+      button.setAttribute("aria-pressed", String(button.dataset.capStatus === controls.status.value));
+    });
+    document.getElementById("cap-kpi-grid").setAttribute("aria-busy", "false");
+  }
+
+  function statusBadge(item) {
+    return '<span class="status-badge ' + (STATUS_CLASS[item.resultStatus] || "status-badge-neutral") + '">' + escapeHtml(item.resultStatusLabel) + '</span>';
+  }
+
+  function contractRow(item) {
+    var isAgent = item.paymentStage === "GA_TO_FC";
+    var deduction = isAgent ? '<span class="cap-not-applicable">적용하지 않음</span>' : won(item.complianceDeductionAmount);
+    return "<tr>" +
+      '<td><a class="cap-contract-link" href="/contracts/' + encodeURIComponent(item.contractId) + '?tab=cap">' + escapeHtml(item.contractNo) + '</a></td>' +
+      '<td><span class="cap-stage-label"><span class="cap-stage-dot' + (isAgent ? " is-agent" : "") + '"></span>' + escapeHtml(item.paymentStageLabel) + '</span></td>' +
+      '<td class="tabular-nums">' + escapeHtml(item.asOfDate) + '</td>' +
+      '<td class="text-right tabular-nums">' + won(item.basePremiumAmount) + '</td>' +
+      '<td class="text-right tabular-nums">' + won(item.refund12mAmount) + '</td>' +
+      '<td class="text-right tabular-nums">' + deduction + '</td>' +
+      '<td class="text-right tabular-nums">' + won(item.limitAmount) + '</td>' +
+      '<td class="text-right tabular-nums"><button class="cap-basis-button" type="button" data-cap-detail-id="' + escapeHtml(item.capCheckId) + '">' + won(item.includedAmount) + '</button></td>' +
+      '<td class="text-right tabular-nums">' + won(item.remainingAmount) + '</td>' +
+      '<td><div class="cap-usage-cell"><span class="cap-usage-track"><span class="cap-usage-bar ' + (STATUS_PROGRESS_CLASS[item.resultStatus] || "") + '" style="--cap-progress:' + visualWidth(item.usagePct) + '"></span></span><span class="cap-usage-value">' + escapeHtml(percent(item.usagePct)) + '</span></div></td>' +
+      '<td class="text-center">' + statusBadge(item) + '</td>' +
+      '<td class="tabular-nums">ID ' + escapeHtml(item.capRuleSetId) + '</td></tr>';
+  }
+
+  function renderContracts(data) {
+    var message = document.getElementById("cap-list-message");
+    var tableWrap = document.getElementById("cap-contract-table-wrap");
+    document.getElementById("cap-total-count").textContent = number(data.totalElements);
+    if (!data.content || !data.content.length) {
+      message.className = "cap-inline-message";
+      message.textContent = "조건에 맞는 계약 판정이 없습니다.";
+      message.hidden = false;
+      tableWrap.hidden = true;
+    } else {
+      document.getElementById("cap-contract-body").innerHTML = data.content.map(contractRow).join("");
+      message.hidden = true;
+      tableWrap.hidden = false;
+    }
+    renderPagination(data.page, data.totalPages);
+  }
+
+  function pageButton(label, page, options) {
+    var button = document.createElement("button");
+    button.type = "button";
+    button.className = "pagination-button" + (options.active ? " is-active" : "") + (options.disabled ? " is-disabled" : "");
+    button.textContent = label;
+    button.disabled = options.disabled;
+    if (options.active) button.setAttribute("aria-current", "page");
+    if (!options.disabled && !options.active) {
+      button.addEventListener("click", function () {
+        state.page = page;
+        load();
+      });
+    }
+    return button;
+  }
+
+  function renderPagination(page, totalPages) {
+    var pagination = document.getElementById("cap-pagination");
+    pagination.replaceChildren();
+    if (!totalPages) return;
+    pagination.appendChild(pageButton("‹", page - 1, { disabled: page <= 1, active: false }));
+    var start = Math.max(1, page - 2);
+    var end = Math.min(totalPages, start + 4);
+    start = Math.max(1, end - 4);
+    for (var current = start; current <= end; current += 1) {
+      pagination.appendChild(pageButton(String(current), current, { disabled: false, active: current === page }));
+    }
+    pagination.appendChild(pageButton("›", page + 1, { disabled: page >= totalPages, active: false }));
+  }
+
+  function render(data) {
+    renderKpis(data.summary);
+    renderContracts(data);
+  }
+
+  function load() {
+    if (state.abortController) state.abortController.abort();
+    state.abortController = new AbortController();
+    var params = currentParams();
+    replaceLocation(params);
+    setLoading();
+    window.FgcUi.apiClient.request("/api/v1/cap-checks?" + params.toString(), { signal: state.abortController.signal })
+      .then(function (envelope) { render(envelope.data); })
+      .catch(function (error) {
+        if (error && error.name === "AbortError") return;
+        setError(error);
+      });
+  }
+
+  function detailPair(label, value) {
+    return "<tr><th scope=\"row\">" + escapeHtml(label) + "</th><td class=\"text-right tabular-nums\">" + escapeHtml(value) + "</td></tr>";
+  }
+
+  function renderDetail(data) {
+    var item = data.capCheck;
+    var snapshot = data.calculationSnapshot || {};
+    document.getElementById("sum-contract").textContent = item.contractNo || "—";
+    document.getElementById("sum-stage").textContent = item.paymentStageLabel || "—";
+    document.getElementById("sum-asof").textContent = item.asOfDate || "—";
+    document.getElementById("sum-kind").textContent = item.checkKind || "저장 판정";
+    document.getElementById("sum-ruleset").textContent = "ID " + item.capRuleSetId;
+    document.getElementById("sum-id").textContent = item.capCheckId;
+    document.getElementById("sum-badge").innerHTML = statusBadge(item);
+
+    var insurerStage = item.paymentStage === "INSURER_TO_GA";
+    document.getElementById("input-body").innerHTML =
+      detailPair("월납환산 초회보험료", won(item.basePremiumAmount)) +
+      detailPair("12차월 환급금 가산", won(item.refund12mAmount)) +
+      detailPair("준법경영비 공제", insurerStage ? won(item.complianceDeductionAmount) : "적용하지 않음") +
+      detailPair("보험료 배수", snapshot.premiumMultiplier == null ? "—" : snapshot.premiumMultiplier);
+
+    document.getElementById("formula").textContent = insurerStage
+      ? "기준 보험료 × 배수 + 환급금 가산 − 준법경영비 공제"
+      : "기준 보험료 × 배수 + 환급금 가산";
+    document.getElementById("formula-note").textContent = insurerStage
+      ? "원수사 → GA 단계의 저장된 공제 금액을 표시합니다."
+      : "GA → 설계사 단계에는 준법경영비 공제를 적용하지 않습니다.";
+
+    document.getElementById("final-bar").style.width = visualWidth(item.usagePct);
+    document.getElementById("final-limit-label").textContent = "한도 " + won(item.limitAmount);
+    document.getElementById("final-body").innerHTML =
+      detailPair("한도", won(item.limitAmount)) + detailPair("산입금액", won(item.includedAmount)) +
+      detailPair("잔여", won(item.remainingAmount)) + detailPair("사용률", percent(item.usagePct)) +
+      detailPair("저장 판정", item.resultStatusLabel);
+
+    var details = data.details || [];
+    document.getElementById("detail-body").innerHTML = details.length ? details.map(function (detail) {
+      var label = CLASSIFICATION_LABEL[detail.classificationSnapshot] || detail.classificationSnapshot;
+      var badgeClass = detail.classificationSnapshot === "INCLUDED" ? "status-badge-info" : detail.classificationSnapshot === "REVIEW_REQUIRED" ? "status-badge-review" : "status-badge-neutral";
+      return "<tr><td>" + number(detail.detailSeq) + "</td><td>" + escapeHtml(detail.commissionItemName || "—") +
+        '</td><td class="text-right tabular-nums">' + won(detail.amount) + '</td><td><span class="status-badge ' + badgeClass + '">' + escapeHtml(label) +
+        "</span></td><td>" + escapeHtml(detail.decisionReason || "—") + "</td><td>" + escapeHtml(detail.evidenceRef || "—") + "</td><td>저장 스냅샷</td></tr>";
+    }).join("") : '<tr><td colspan="7"><div class="cap-inline-message">저장된 항목별 산입 내역이 없습니다.</div></td></tr>';
+    document.getElementById("detail-included").textContent = number(item.includedAmount);
+  }
+
+  function openDetail(capCheckId) {
+    var stateBox = document.getElementById("cap-detail-state");
+    var content = document.getElementById("cap-detail-content");
+    stateBox.className = "modal-body cap-detail-state";
+    stateBox.textContent = "계산근거를 불러오는 중입니다.";
+    stateBox.hidden = false;
+    content.hidden = true;
+    window.FgcUi.modal.open("cap-detail");
+    window.FgcUi.apiClient.request("/api/v1/cap-checks/" + encodeURIComponent(capCheckId) + "/details")
+      .then(function (envelope) {
+        renderDetail(envelope.data);
+        stateBox.hidden = true;
+        content.hidden = false;
+      })
+      .catch(function (error) {
+        stateBox.className = "modal-body cap-detail-state is-error";
+        stateBox.textContent = error && error.message ? error.message : "계산근거를 불러오지 못했습니다.";
+      });
+  }
+
+  form.addEventListener("submit", function (event) {
+    event.preventDefault();
+    state.page = 1;
+    load();
+  });
+  document.getElementById("cap-reset").addEventListener("click", function () {
+    form.reset();
+    controls.month.value = root.dataset.initialMonth || "";
+    controls.size.value = "20";
+    state.page = 1;
+    load();
+  });
+  controls.status.addEventListener("change", function () {
+    document.querySelectorAll("[data-cap-status]").forEach(function (button) {
+      button.setAttribute("aria-pressed", String(button.dataset.capStatus === controls.status.value));
+    });
+  });
+  controls.size.addEventListener("change", function () {
+    state.page = 1;
+    load();
+  });
+  document.getElementById("cap-kpi-grid").addEventListener("click", function (event) {
+    var button = event.target.closest("[data-cap-status]");
+    if (!button) return;
+    controls.status.value = controls.status.value === button.dataset.capStatus ? "" : button.dataset.capStatus;
+    state.page = 1;
+    load();
+  });
+  document.getElementById("cap-contract-body").addEventListener("click", function (event) {
+    var button = event.target.closest("[data-cap-detail-id]");
+    if (button) openDetail(button.dataset.capDetailId);
+  });
+
+  queryFromLocation();
+  load();
+})();

--- a/src/main/resources/static/js/features/cap/cap-list.js
+++ b/src/main/resources/static/js/features/cap/cap-list.js
@@ -13,7 +13,12 @@
     contractNo: document.getElementById("cap-contract-no"),
     size: document.getElementById("cap-page-size")
   };
-  var state = { page: 1, abortController: null };
+  var state = {
+    page: 1,
+    abortController: null,
+    detailAbortController: null,
+    detailRequestId: 0
+  };
 
   var STATUS_CLASS = {
     NORMAL: "status-badge-success",
@@ -48,6 +53,18 @@
 
   function won(value) {
     return number(value) + "원";
+  }
+
+  function refundAddition(value) {
+    return Number(value) === 0 ? "해당없음" : won(value);
+  }
+
+  function remainingAmount(value) {
+    var parsed = Number(value);
+    if (parsed < 0) {
+      return '<span class="cap-negative-amount">(' + number(Math.abs(parsed)) + "원)</span>";
+    }
+    return won(value);
   }
 
   function percent(value) {
@@ -141,11 +158,11 @@
       '<td><span class="cap-stage-label"><span class="cap-stage-dot' + (isAgent ? " is-agent" : "") + '"></span>' + escapeHtml(item.paymentStageLabel) + '</span></td>' +
       '<td class="tabular-nums">' + escapeHtml(item.asOfDate) + '</td>' +
       '<td class="text-right tabular-nums">' + won(item.basePremiumAmount) + '</td>' +
-      '<td class="text-right tabular-nums">' + won(item.refund12mAmount) + '</td>' +
+      '<td class="text-right tabular-nums">' + refundAddition(item.refund12mAmount) + '</td>' +
       '<td class="text-right tabular-nums">' + deduction + '</td>' +
       '<td class="text-right tabular-nums">' + won(item.limitAmount) + '</td>' +
       '<td class="text-right tabular-nums"><button class="cap-basis-button" type="button" data-cap-detail-id="' + escapeHtml(item.capCheckId) + '">' + won(item.includedAmount) + '</button></td>' +
-      '<td class="text-right tabular-nums">' + won(item.remainingAmount) + '</td>' +
+      '<td class="text-right tabular-nums">' + remainingAmount(item.remainingAmount) + '</td>' +
       '<td><div class="cap-usage-cell"><span class="cap-usage-track"><span class="cap-usage-bar ' + (STATUS_PROGRESS_CLASS[item.resultStatus] || "") + '" style="--cap-progress:' + visualWidth(item.usagePct) + '"></span></span><span class="cap-usage-value">' + escapeHtml(percent(item.usagePct)) + '</span></div></td>' +
       '<td class="text-center">' + statusBadge(item) + '</td>' +
       '<td class="tabular-nums">ID ' + escapeHtml(item.capRuleSetId) + '</td></tr>';
@@ -221,6 +238,10 @@
     return "<tr><th scope=\"row\">" + escapeHtml(label) + "</th><td class=\"text-right tabular-nums\">" + escapeHtml(value) + "</td></tr>";
   }
 
+  function detailPairHtml(label, valueHtml) {
+    return "<tr><th scope=\"row\">" + escapeHtml(label) + "</th><td class=\"text-right tabular-nums\">" + valueHtml + "</td></tr>";
+  }
+
   function renderDetail(data) {
     var item = data.capCheck;
     var snapshot = data.calculationSnapshot || {};
@@ -235,7 +256,7 @@
     var insurerStage = item.paymentStage === "INSURER_TO_GA";
     document.getElementById("input-body").innerHTML =
       detailPair("월납환산 초회보험료", won(item.basePremiumAmount)) +
-      detailPair("12차월 환급금 가산", won(item.refund12mAmount)) +
+      detailPair("12차월 환급금 가산", refundAddition(item.refund12mAmount)) +
       detailPair("준법경영비 공제", insurerStage ? won(item.complianceDeductionAmount) : "적용하지 않음") +
       detailPair("보험료 배수", snapshot.premiumMultiplier == null ? "—" : snapshot.premiumMultiplier);
 
@@ -250,7 +271,7 @@
     document.getElementById("final-limit-label").textContent = "한도 " + won(item.limitAmount);
     document.getElementById("final-body").innerHTML =
       detailPair("한도", won(item.limitAmount)) + detailPair("산입금액", won(item.includedAmount)) +
-      detailPair("잔여", won(item.remainingAmount)) + detailPair("사용률", percent(item.usagePct)) +
+      detailPairHtml("잔여", remainingAmount(item.remainingAmount)) + detailPair("사용률", percent(item.usagePct)) +
       detailPair("저장 판정", item.resultStatusLabel);
 
     var details = data.details || [];
@@ -261,10 +282,22 @@
         '</td><td class="text-right tabular-nums">' + won(detail.amount) + '</td><td><span class="status-badge ' + badgeClass + '">' + escapeHtml(label) +
         "</span></td><td>" + escapeHtml(detail.decisionReason || "—") + "</td><td>" + escapeHtml(detail.evidenceRef || "—") + "</td><td>저장 스냅샷</td></tr>";
     }).join("") : '<tr><td colspan="7"><div class="cap-inline-message">저장된 항목별 산입 내역이 없습니다.</div></td></tr>';
-    document.getElementById("detail-included").textContent = number(item.includedAmount);
+    var includedDetailTotal = details.reduce(function (total, detail) {
+      return detail.classificationSnapshot === "INCLUDED" ? total + Number(detail.amount || 0) : total;
+    }, 0);
+    document.getElementById("detail-included").textContent = number(includedDetailTotal);
+    var includedNote = document.getElementById("detail-included-note");
+    var includedMatches = includedDetailTotal === Number(item.includedAmount);
+    includedNote.classList.toggle("cap-detail-mismatch", !includedMatches);
+    includedNote.textContent = includedMatches
+      ? "제외·검토필요 금액은 합계에 넣지 않습니다 · 저장 산입금액과 일치"
+      : "저장 산입금액과 항목별 산입 합계가 일치하지 않습니다.";
   }
 
   function openDetail(capCheckId) {
+    if (state.detailAbortController) state.detailAbortController.abort();
+    state.detailAbortController = new AbortController();
+    var requestId = ++state.detailRequestId;
     var stateBox = document.getElementById("cap-detail-state");
     var content = document.getElementById("cap-detail-content");
     stateBox.className = "modal-body cap-detail-state";
@@ -272,13 +305,17 @@
     stateBox.hidden = false;
     content.hidden = true;
     window.FgcUi.modal.open("cap-detail");
-    window.FgcUi.apiClient.request("/api/v1/cap-checks/" + encodeURIComponent(capCheckId) + "/details")
+    window.FgcUi.apiClient.request("/api/v1/cap-checks/" + encodeURIComponent(capCheckId) + "/details", {
+      signal: state.detailAbortController.signal
+    })
       .then(function (envelope) {
+        if (requestId !== state.detailRequestId) return;
         renderDetail(envelope.data);
         stateBox.hidden = true;
         content.hidden = false;
       })
       .catch(function (error) {
+        if (requestId !== state.detailRequestId || (error && error.name === "AbortError")) return;
         stateBox.className = "modal-body cap-detail-state is-error";
         stateBox.textContent = error && error.message ? error.message : "계산근거를 불러오지 못했습니다.";
       });

--- a/src/main/resources/templates/cap/detail-modal.html
+++ b/src/main/resources/templates/cap/detail-modal.html
@@ -132,7 +132,7 @@
             <tr>
               <td colspan="2">산입 합계</td>
               <td class="fgc-td-num"><span class="fgc-amount" id="detail-included">0</span></td>
-              <td colspan="4" class="fgc-muted" style="font-weight:400">제외·검토필요 금액은 합계에 넣지 않습니다</td>
+              <td colspan="4" class="fgc-muted" id="detail-included-note">제외·검토필요 금액은 합계에 넣지 않습니다</td>
             </tr>
           </tfoot>
         </table>

--- a/src/main/resources/templates/cap/list.html
+++ b/src/main/resources/templates/cap/list.html
@@ -1,169 +1,197 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
-  FGC-UI-CAP-W01 1,200% 한도 검증 현황  ★ 규제 검증의 중심 화면
-  요구사항 FUN-030 · FUN-032 · FUN-034 / REG-08 · 09 · 10 · 23
-  데이터  읽기 cap_check, cap_rule_set, insurance_contract, vw_latest_cap_check
-  API     GET /api/v1/cap-checks?month=&stage=&status=&insurerId=&contractNo=
-  라우트  GET /cap-checks → cap/list.html (화면정의서 5-2)
+  FGC-UI-CAP-W01 1,200% 한도 검증 현황
+  현재 연결 API: GET /api/v1/cap-checks?month=&stage=&status=&insurerId=&contractNo=&page=&size=
 
-  ★★ 절대 규칙 ★★
-   1) 게이지는 지급단계별로 반드시 2개를 따로 그립니다.
-        원수사→GA (INSURER_TO_GA)  ·  GA→설계사 (GA_TO_FC)
-      둘은 서로 다른 규제입니다. 절대 합산하지 않습니다.
-   2) 준법경영비 3% 공제는 원수사→GA 단계에만 적용합니다(REG-10).
-      GA→설계사 게이지에는 공제란 자체를 그리지 않습니다. DB CHECK 로도 0이 강제됩니다.
-   3) 규제 판정 단위는 "계약 1건"입니다.
-      설계사별·지점별 합계는 규제 판정이 아니라 모니터링 지표일 뿐이므로 라벨을 반드시 붙입니다.
-   4) 화면에서 판정을 바꾸지 않습니다. 저장된 result_status 를 그대로 씁니다.
-
-  [정적 부착 단계] 목업(30_산출물/화면_MVP/FGC-UI-CAP-W01)의 정적 골격만 옮겼다.
-  데이터 영역(게이지·요약카드·목록)은 IF-API-30 연동 시 서버 렌더링으로 채운다.
+  현재 응답의 summary와 content만 연결한다. 아직 응답에 없는 지급단계별·설계사별 집계는
+  페이징된 content로 다시 계산하지 않고 연동 대기로 표시한다. 저장된 resultStatus를 그대로
+  표시하며 CAP-W02는 현재 상세 API를 사용하는 팝업으로 유지한다.
 -->
-<html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-CAP-W01', '1,200% 한도 검증 현황', null, null)}"
-      xmlns:th="http://www.thymeleaf.org">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-CAP-W01', '1,200% 한도 검증 현황', null, null)}">
 <body>
-<main class="fgc-main">
+<main id="main-content" class="page-content cap-page" th:attr="data-initial-month=${month}">
+  <header class="page-header">
+    <div class="page-header-copy">
+      <h1 class="page-title">1,200% 한도 검증 현황</h1>
+      <p class="page-description">계약 단위 한도 판정과 지급단계별 사용 현황을 확인합니다.</p>
+    </div>
+  </header>
 
-  <h1 class="fgc-page-title">1,200% 한도 검증 현황</h1>
-  <p class="fgc-page-desc">
-    계약 1건에 대해 <strong>첫 1년 동안 준 돈</strong>이 월납환산 초회보험료의 <strong>12배</strong>를 넘었는지 봅니다.
-    넘으면 위반입니다. 일시적으로 넘긴 시점이 있어도 위반입니다.
-  </p>
-
-  <!-- 공식 안내 -->
-  <div class="fgc-banner fgc-banner--info" style="margin-top:12px">
-    <span class="material-symbols-outlined" style="font-size:18px">function</span>
-    <span>
-      <span class="fgc-mono">한도 = 월납환산 초회보험료 × 12 ( + 12차월 예상 해약환급금 ) ( − 준법경영비 공제 )</span><br>
-      <span class="fgc-mono">사용률 = 산입금액 ÷ 한도 × 100</span> ·
-      90% 이상이면 <strong>주의</strong>, 100%를 넘으면 <strong>위반</strong>입니다.
-      배수 12와 주의 기준 90%는 코드가 아니라 룰셋(<span class="fgc-mono">cap_rule_set</span>)에서 읽습니다.
-    </span>
-  </div>
-
-  <!-- 지급단계 2개 게이지 — IF-API-30 연동 시 서버 렌더링으로 채운다 -->
-  <section style="margin-top:16px;display:grid;grid-template-columns:1fr 1fr;gap:16px" id="stage-grid"></section>
-
-  <div class="fgc-banner fgc-banner--warn" style="margin-top:12px">
-    <span class="material-symbols-outlined" style="font-size:18px">warning</span>
-    <span>
-      <strong>위 두 게이지를 더하지 마세요.</strong>
-      원수사→GA와 GA→설계사는 서로 다른 규제이고 기준도 다릅니다.
-      하나로 합쳐 보여주면 둘 다 틀린 숫자가 됩니다(규제조문표 §0.3 금지사항 ③).
-    </span>
-  </div>
-
-  <!-- ① 검색 -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__body fgc-toolbar">
-      <div class="fgc-field" style="min-width:140px">
-        <label class="fgc-label" for="f-month">정산월</label>
-        <input class="fgc-input" id="f-month" type="month" th:value="${month}" value="2026-07">
+  <section class="surface cap-filter-panel" aria-labelledby="cap-filter-title">
+    <header class="surface-header cap-section-header">
+      <div>
+        <h2 id="cap-filter-title" class="surface-title">검색 조건</h2>
+        <p class="cap-section-description">기준월과 계약 조건으로 저장된 판정 결과를 조회합니다.</p>
       </div>
-      <div class="fgc-field" style="min-width:170px">
-        <label class="fgc-label" for="f-stage">지급단계</label>
-        <select class="fgc-select" id="f-stage">
-          <option value="">전체 (단계별로 행이 나뉩니다)</option>
-          <option value="GA_TO_FC">GA→설계사</option>
-          <option value="INSURER_TO_GA">원수사→GA</option>
+    </header>
+    <form id="cap-search-form" class="cap-filter-form">
+      <div class="field cap-filter-month">
+        <label class="field-label" for="cap-month">기준월</label>
+        <input class="field-control" id="cap-month" name="month" type="month">
+      </div>
+      <div class="field">
+        <label class="field-label" for="cap-stage">지급단계</label>
+        <select class="select-control" id="cap-stage" name="stage">
+          <option value="">전체</option>
+          <option value="INSURER_TO_GA">원수사 → GA</option>
+          <option value="GA_TO_FC">GA → 설계사</option>
         </select>
       </div>
-      <div class="fgc-field" style="min-width:150px">
-        <label class="fgc-label" for="f-status">판정</label>
-        <select class="fgc-select" id="f-status"><option value="">전체</option></select>
+      <div class="field">
+        <label class="field-label" for="cap-status">판정</label>
+        <select class="select-control" id="cap-status" name="status">
+          <option value="">전체</option>
+          <option value="NORMAL">정상</option>
+          <option value="WARNING">주의</option>
+          <option value="VIOLATION">위반</option>
+          <option value="REVIEW_REQUIRED">검토필요</option>
+        </select>
       </div>
-      <div class="fgc-field" style="min-width:130px">
-        <label class="fgc-label" for="f-insurer">보험회사</label>
-        <select class="fgc-select" id="f-insurer"><option value="">전체</option></select>
+      <div class="field">
+        <label class="field-label" for="cap-insurer">보험회사</label>
+        <select class="select-control" id="cap-insurer" name="insurerId" disabled aria-describedby="cap-insurer-help">
+          <option value="">기준정보 연동 대기</option>
+        </select>
+        <span id="cap-insurer-help" class="field-helper">보험회사 조회 API 연결 후 사용할 수 있습니다.</span>
       </div>
-      <div class="fgc-field" style="min-width:120px">
-        <label class="fgc-label" for="f-contract">계약번호</label>
-        <input class="fgc-input" id="f-contract" type="text" placeholder="C004">
+      <div class="field">
+        <label class="field-label" for="cap-organization">조직</label>
+        <select class="select-control" id="cap-organization" name="organizationId" disabled aria-describedby="cap-organization-help">
+          <option value="">기준정보 연동 대기</option>
+        </select>
+        <span id="cap-organization-help" class="field-helper">조직 조회 API 연결 후 사용할 수 있습니다.</span>
       </div>
-      <button class="fgc-btn fgc-btn--ghost" id="f-reset">
-        <span class="material-symbols-outlined" style="font-size:18px">restart_alt</span> 초기화
-      </button>
+      <div class="field cap-filter-contract">
+        <label class="field-label" for="cap-contract-no">계약번호</label>
+        <input class="field-control" id="cap-contract-no" name="contractNo" type="search" placeholder="계약번호 입력" autocomplete="off">
+      </div>
+      <div class="cap-filter-actions">
+        <button class="button button-secondary" id="cap-reset" type="button">
+          <span class="material-symbols-outlined" aria-hidden="true">restart_alt</span>
+          초기화
+        </button>
+        <button class="button button-primary" type="submit">
+          <span class="material-symbols-outlined" aria-hidden="true">search</span>
+          조회
+        </button>
+      </div>
+    </form>
+  </section>
+
+  <section id="cap-kpi-grid" class="cap-kpi-grid" aria-label="판정별 건수">
+    <button class="kpi-card cap-kpi-card cap-kpi-normal" type="button" data-cap-status="NORMAL" aria-pressed="false">
+      <span class="kpi-label">정상</span><span class="cap-kpi-value"><strong data-kpi-value="NORMAL">0</strong><small>건</small></span><span class="kpi-comparison">저장 판정 정상</span>
+    </button>
+    <button class="kpi-card cap-kpi-card cap-kpi-warning" type="button" data-cap-status="WARNING" aria-pressed="false">
+      <span class="kpi-label">주의</span><span class="cap-kpi-value"><strong data-kpi-value="WARNING">0</strong><small>건</small></span><span class="kpi-comparison">저장 판정 주의</span>
+    </button>
+    <button class="kpi-card cap-kpi-card cap-kpi-violation" type="button" data-cap-status="VIOLATION" aria-pressed="false">
+      <span class="kpi-label">위반</span><span class="cap-kpi-value"><strong data-kpi-value="VIOLATION">0</strong><small>건</small></span><span class="kpi-comparison">저장 판정 위반</span>
+    </button>
+    <button class="kpi-card cap-kpi-card cap-kpi-review" type="button" data-cap-status="REVIEW_REQUIRED" aria-pressed="false">
+      <span class="kpi-label">검토필요</span><span class="cap-kpi-value"><strong data-kpi-value="REVIEW_REQUIRED">0</strong><small>건</small></span><span class="kpi-comparison">추가 확인 필요</span>
+    </button>
+  </section>
+
+  <section class="surface cap-stage-panel" aria-labelledby="cap-stage-title">
+    <header class="surface-header cap-section-header cap-stage-header">
+      <div>
+        <h2 id="cap-stage-title" class="surface-title">지급단계별 Stage Gauges</h2>
+        <p class="cap-section-description">서로 다른 규제이므로 두 단계를 합산하지 않습니다.</p>
+      </div>
+      <span class="status-badge status-badge-neutral">전체 검색범위 집계</span>
+    </header>
+    <div id="cap-stage-grid" class="cap-stage-grid" aria-live="polite">
+      <article class="cap-stage-card cap-stage-card-pending">
+        <header class="cap-stage-card-header"><div><h3 class="cap-stage-title">원수사→GA</h3><p class="cap-stage-code">INSURER_TO_GA</p></div><span class="status-badge status-badge-neutral">연동 대기</span></header>
+        <div class="cap-stage-pending-copy"><span class="material-symbols-outlined" aria-hidden="true">hourglass_top</span><p>전체 검색범위 Stage 집계 API가 아직 제공되지 않습니다.</p></div>
+        <p class="cap-stage-note">준법경영비 공제는 이 단계에만 적용됩니다.</p>
+      </article>
+      <article class="cap-stage-card cap-stage-card-pending">
+        <header class="cap-stage-card-header"><div><h3 class="cap-stage-title">GA→설계사</h3><p class="cap-stage-code">GA_TO_FC</p></div><span class="status-badge status-badge-neutral">연동 대기</span></header>
+        <div class="cap-stage-pending-copy"><span class="material-symbols-outlined" aria-hidden="true">hourglass_top</span><p>전체 검색범위 Stage 집계 API가 아직 제공되지 않습니다.</p></div>
+        <p class="cap-stage-note">준법경영비 공제를 적용하지 않습니다.</p>
+      </article>
     </div>
   </section>
 
-  <!-- ② 요약 카드 4장 — IF-API-30 연동 시 채운다 -->
-  <section style="margin-top:16px;display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px"
-           id="summary-cards"></section>
-
-  <!-- ③ 계약별 목록 -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__head">
-      <span class="fgc-card__title">계약별 판정 목록</span>
-      <span class="fgc-muted" style="font-size:12px"><span id="row-count">0</span>건 · 한 화면 20행</span>
+  <section class="cap-guidance" aria-labelledby="cap-guidance-title">
+    <span class="material-symbols-outlined" aria-hidden="true">verified_user</span>
+    <div>
+      <h2 id="cap-guidance-title">계산 기준</h2>
+      <p><strong>한도 = 월납환산 초회보험료 × 12 + 12차월 예상 해약환급금 − 준법경영비 공제</strong></p>
+      <p>준법경영비 공제는 원수사 → GA에만 적용합니다. GA → 설계사에는 적용하지 않습니다. 판정 색상은 저장된 <code>resultStatus</code>를 사용합니다.</p>
     </div>
-    <div style="overflow-x:auto">
-      <table class="fgc-table" style="min-width:1180px">
-        <thead>
-          <tr>
-            <th style="width:66px">계약</th>
-            <th style="width:110px">지급단계</th>
-            <th style="width:92px">기준일</th>
-            <th class="fgc-th-num" style="width:100px">기준 보험료</th>
-            <th class="fgc-th-num" style="width:100px">환급금 가산</th>
-            <th class="fgc-th-num" style="width:110px">준법경영비 공제</th>
-            <th class="fgc-th-num" style="width:100px">한도</th>
-            <th class="fgc-th-num" style="width:100px">산입금액</th>
-            <th class="fgc-th-num" style="width:100px">잔여</th>
-            <th style="width:190px">사용률</th>
-            <th style="width:120px">판정</th>
-            <th style="width:126px">룰셋</th>
-          </tr>
-        </thead>
-        <tbody id="list-body">
-          <tr><td colspan="12"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
-        </tbody>
+  </section>
+
+  <section class="surface cap-table-panel" aria-labelledby="cap-contract-list-title">
+    <header class="surface-header cap-section-header">
+      <div>
+        <h2 id="cap-contract-list-title" class="surface-title">계약별 판정 목록</h2>
+        <p class="cap-section-description">규제 판정 단위는 계약 1건입니다.</p>
+      </div>
+      <span class="cap-list-count"><strong id="cap-total-count">0</strong>건</span>
+    </header>
+    <div id="cap-list-message" class="cap-inline-message" role="status" aria-live="polite">판정 목록을 불러오는 중입니다.</div>
+    <div id="cap-contract-table-wrap" class="data-table-viewport cap-contract-table-wrap" hidden>
+      <table class="data-table cap-contract-table">
+        <caption class="visually-hidden">계약별 1,200% 한도 판정 목록</caption>
+        <colgroup>
+          <col class="cap-col-contract"><col class="cap-col-stage"><col class="cap-col-date">
+          <col class="cap-col-money"><col class="cap-col-money"><col class="cap-col-deduction">
+          <col class="cap-col-money"><col class="cap-col-money"><col class="cap-col-money">
+          <col class="cap-col-usage"><col class="cap-col-status"><col class="cap-col-rule">
+        </colgroup>
+        <thead><tr>
+          <th scope="col">계약번호</th><th scope="col">지급단계</th><th scope="col">기준일</th>
+          <th scope="col" class="text-right">기준 보험료</th><th scope="col" class="text-right">환급금 가산</th><th scope="col" class="text-right">준법경영비 공제</th>
+          <th scope="col" class="text-right">한도</th><th scope="col" class="text-right">산입금액</th><th scope="col" class="text-right">잔여</th>
+          <th scope="col">사용률</th><th scope="col" class="text-center">판정</th><th scope="col">룰셋</th>
+        </tr></thead>
+        <tbody id="cap-contract-body"></tbody>
+      </table>
+    </div>
+    <footer class="cap-table-footer">
+      <label class="cap-page-size" for="cap-page-size">페이지당
+        <select id="cap-page-size" class="select-control" aria-label="페이지당 표시 건수">
+          <option value="10">10</option><option value="20" selected>20</option><option value="50">50</option>
+        </select>
+      </label>
+      <nav id="cap-pagination" class="pagination" aria-label="계약 목록 페이지"></nav>
+    </footer>
+  </section>
+
+  <section class="surface cap-table-panel" aria-labelledby="cap-agent-title">
+    <header class="surface-header cap-section-header cap-agent-header">
+      <div>
+        <h2 id="cap-agent-title" class="surface-title">설계사별 모니터링 지표</h2>
+        <p class="cap-section-description">GA → 설계사 지급단계만 집계합니다.</p>
+      </div>
+      <span class="status-badge status-badge-neutral">모니터링 지표 · 규제 판정 아님</span>
+    </header>
+    <div id="cap-agent-message" class="cap-inline-message">전체 검색범위 설계사 집계 API 연동 대기 · 현재 페이지 목록으로 합산하지 않습니다.</div>
+    <div id="cap-agent-table-wrap" class="data-table-viewport cap-agent-table-wrap" hidden>
+      <table class="data-table cap-agent-table">
+        <caption class="visually-hidden">설계사별 GA에서 설계사 단계 모니터링 지표</caption>
+        <colgroup><col><col><col><col><col><col></colgroup>
+        <thead><tr><th scope="col">설계사</th><th scope="col">소속</th><th scope="col" class="text-right">계약 수</th><th scope="col" class="text-right">한도 합계</th><th scope="col" class="text-right">산입 합계</th><th scope="col">사용률</th></tr></thead>
+        <tbody id="cap-agent-body"></tbody>
       </table>
     </div>
   </section>
 
-  <!-- 모니터링 지표 (규제 판정 아님) -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__head">
-      <span class="fgc-card__title">설계사별 합계</span>
-      <span class="fgc-badge fgc-badge--neutral">모니터링 지표 — 규제 판정이 아닙니다</span>
-    </div>
-    <div class="fgc-card__body" style="padding-bottom:0">
-      <div class="fgc-banner fgc-banner--muted">
-        <span class="material-symbols-outlined" style="font-size:18px">info</span>
-        <span>
-          1,200%룰은 <strong>계약 1건 단위</strong>로 판단합니다.
-          아래 설계사별 합계는 회사 내부에서 흐름을 보려고 만든 참고 수치이며,
-          이것으로 위반 여부를 판정하지 않습니다.
-        </span>
-      </div>
-    </div>
-    <div style="overflow-x:auto">
-      <table class="fgc-table">
-        <thead>
-          <tr><th>설계사</th><th>소속</th><th class="fgc-th-num">계약 수</th>
-              <th class="fgc-th-num">한도 합계</th><th class="fgc-th-num">산입 합계</th>
-              <th class="fgc-th-num">평균 사용률</th></tr>
-        </thead>
-        <tbody id="agent-body">
-          <tr><td colspan="6"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
-        </tbody>
-      </table>
-    </div>
-  </section>
-
-<!-- 스크립트는 main 안에 둔다 — 셸의 page()는 ~{::main}만 삽입하므로 main 밖 스크립트는 렌더링에서 사라진다 -->
-<script>
-/* 화면 폭이 좁으면 게이지 2장을 세로로 — 데이터 렌더링은 IF-API-30 연동 시 추가 */
-(function () {
-  "use strict";
-  function reflow() {
-    document.getElementById("stage-grid").style.gridTemplateColumns =
-      window.innerWidth < 980 ? "1fr" : "1fr 1fr";
-  }
-  reflow();
-  window.addEventListener("resize", reflow);
-})();
-</script>
+  <div class="modal-backdrop" data-modal="cap-detail" data-close-on-backdrop="true" hidden aria-hidden="true">
+    <section class="modal modal-large cap-detail-modal" role="dialog" aria-modal="true" aria-labelledby="cap-detail-title">
+      <header class="modal-header">
+        <div><h2 id="cap-detail-title" class="modal-title">1,200% 계산근거</h2><p class="cap-modal-subtitle">검증 당시 저장된 스냅샷</p></div>
+        <button class="icon-button" type="button" data-modal-close aria-label="팝업 닫기" data-modal-initial-focus><span class="material-symbols-outlined" aria-hidden="true">close</span></button>
+      </header>
+      <div id="cap-detail-state" class="modal-body cap-detail-state">계산근거를 불러오는 중입니다.</div>
+      <div id="cap-detail-content" class="modal-body" hidden th:insert="~{cap/detail-modal :: modal}"></div>
+      <footer class="modal-footer"><button class="button button-secondary" type="button" data-modal-close>닫기</button></footer>
+    </section>
+  </div>
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/contract/detail.html
+++ b/src/main/resources/templates/contract/detail.html
@@ -365,6 +365,14 @@
           next.focus();
         });
       });
+
+      var requestedTab = new URLSearchParams(window.location.search).get("tab");
+      var requestedTabElement = requestedTab
+        ? document.getElementById("contract-tab-" + requestedTab)
+        : null;
+      if (requestedTabElement && requestedTabElement.classList.contains("contract-detail-tab")) {
+        activateTab(requestedTabElement);
+      }
     }
 
     function initializeSort() {

--- a/src/main/resources/templates/layout/default.html
+++ b/src/main/resources/templates/layout/default.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" th:href="@{/css/common/utilities.css}">
   <link rel="stylesheet" th:if="${screenId == 'FGC-UI-DASH-W01'}" th:href="@{/css/features/dashboard.css}">
   <link rel="stylesheet" th:if="${#strings.startsWith(screenId, 'FGC-UI-CONT-')}" th:href="@{/css/features/contract.css}">
+  <link rel="stylesheet" th:if="${#strings.startsWith(screenId, 'FGC-UI-CAP-')}" th:href="@{/css/features/cap.css}">
 </head>
 <body class="app-shell" th:attr="data-workspace-tab-id=${screenId},data-workspace-tab-title=${title},data-workspace-tab-icon=${screenId == 'FGC-UI-DASH-W01' ? 'dashboard' : 'description'}">
   <a class="skip-link" href="#main-content">본문으로 건너뛰기</a>
@@ -35,5 +36,6 @@
   <script th:src="@{/js/common/toast.js}" defer></script>
   <script th:src="@{/js/common/api-client.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-DASH-W01'}" th:src="@{/js/features/dashboard/dashboard.js}" defer></script>
+  <script th:if="${screenId == 'FGC-UI-CAP-W01'}" th:src="@{/js/features/cap/cap-list.js}" defer></script>
 </body>
 </html>

--- a/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
@@ -126,6 +126,8 @@ class ScreenViewControllerTest {
                         "aria-label=\"한도 재검증, 연동 대기\"")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString(
                         "timeZone: \"Asia/Seoul\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "new URLSearchParams(window.location.search).get(\"tab\")")))
                 .andExpect(content().string(org.hamcrest.Matchers.not(
                         org.hamcrest.Matchers.containsString("processingJob: \"후속 처리\""))))
                 .andExpect(content().string(org.hamcrest.Matchers.not(
@@ -140,6 +142,7 @@ class ScreenViewControllerTest {
                         org.hamcrest.Matchers.containsString("교육용 프로토타입입니다"))));
     }
 
+    /** FGC-FUN-030 / REG-08 — 현재 제공 API만 연결하고 미제공 전체범위 집계를 만들지 않는다. */
     @Test
     void cap_screen_uses_only_available_api_data_and_marks_pending_aggregates() throws Exception {
         mvc.perform(get("/cap-checks").with(user(settleUser())))

--- a/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
@@ -140,6 +140,22 @@ class ScreenViewControllerTest {
                         org.hamcrest.Matchers.containsString("교육용 프로토타입입니다"))));
     }
 
+    @Test
+    void cap_screen_uses_only_available_api_data_and_marks_pending_aggregates() throws Exception {
+        mvc.perform(get("/cap-checks").with(user(settleUser())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "/js/features/cap/cap-list.js")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "id=\"cap-insurer\" name=\"insurerId\" disabled")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "id=\"cap-organization\" name=\"organizationId\" disabled")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "전체 검색범위 Stage 집계 API가 아직 제공되지 않습니다.")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "현재 페이지 목록으로 합산하지 않습니다.")));
+    }
+
     private static com.susukkang.fgc.auth.dto.FgcUserDetails gaAdminUser() {
         var view = new com.susukkang.fgc.auth.dto.AppUserView();
         view.setUserId(3L);


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- FGC-UI-CAP-W01 1,200% 한도 검증 현황 화면을 최신 HTML 목업과 App Shell 기준으로 구현했습니다.
- 백엔드, DB, 인터페이스 문서는 변경하지 않고 현재 구현된 CAP API 범위까지만 연결했습니다.
- 서버에서 제공하지 않는 전체범위 집계 기능은 페이징 결과로 임의 계산하지 않고 연동 대기 상태로 표시했습니다.

## 🔗 2. 관련 이슈

- Closes #112

## 🛠 3. 구현 내용

- 검색 조건, 판정 KPI 카드, Stage 영역, 계산 기준 Guidance, 계약별 판정 목록, 설계사별 모니터링 영역 구현
- `GET /api/v1/cap-checks`의 `summary`, `content`, 페이징 응답 연결
- KPI 선택과 판정 필터를 동기화하고 `aria-pressed` 적용
- 기준월, 지급단계, 판정, 계약번호 조회 및 초기화 기능 구현
- 계약 상세 이동과 `GET /api/v1/cap-checks/{capCheckId}/details` 기반 CAP-W02 팝업 연결
- 저장된 `resultStatus`와 `usagePct`를 재계산 없이 표시
- `INSURER_TO_GA`와 `GA_TO_FC` Stage를 별도로 유지
- 준법경영비 공제는 `INSURER_TO_GA`에만 표시하고 `GA_TO_FC`에는 `적용하지 않음` 표시
- 로딩, 오류, 빈 결과 상태 및 서버 페이징 UI 구현
- 980px 이하 Stage 1열 배치 및 좁은 화면의 테이블 내부 가로 스크롤 적용
- 보험회사·조직 Select는 기준정보 조회 API가 없어 연동 대기 상태로 비활성화
- Stage Gauge와 설계사별 집계는 전체범위 집계 API가 없어 연동 대기 상태로 표시

## 🧪 4. 테스트 방법

1. 정산담당자 계정으로 로그인한 후 `/cap-checks`에 접근합니다.
2. 기준월, 지급단계, 판정, 계약번호 조건으로 조회하고 URL 파라미터와 목록 결과를 확인합니다.
3. KPI 카드를 선택해 판정 필터 및 `aria-pressed` 동기화를 확인합니다.
4. 초기화 버튼과 App Header의 전역 기준월 변경 동작을 확인합니다.
5. 계약 목록 데이터가 있는 환경에서 계약 상세 링크와 계산근거 팝업을 확인합니다.
6. 1440px, 900px, 720px에서 본문 가로 넘침과 Stage 카드 배치를 확인합니다.
7. 다음 명령으로 전체 회귀 테스트를 실행합니다.

```bash
./gradlew test
```

추가 검증:

```bash
node --check src/main/resources/static/js/features/cap/cap-list.js
git diff --check
```

## 🗄️ 5. DB / Flyway 변경

- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

- 없음

## 📋 6. 리뷰 요구사항

- 페이징된 `content`로 Stage Gauge 또는 설계사 지표를 임의 합산하지 않는지 확인 부탁드립니다.
- `INSURER_TO_GA`와 `GA_TO_FC`가 별도 Stage로 유지되는지 확인 부탁드립니다.
- GA → 설계사 단계에 준법경영비 공제 금액이 표시되지 않는지 확인 부탁드립니다.
- KPI와 판정 필터의 선택 상태가 동기화되는지 확인 부탁드립니다.
- 미구현 API 영역이 오류처럼 보이지 않고 연동 대기 상태로 명확히 표시되는지 확인 부탁드립니다.
- CAP-W02가 별도 페이지가 아닌 팝업 구조로 유지되는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

- [x] `develop` 기준으로 작업 브랜치를 생성했습니다.
- [x] 로컬 빌드 및 전체 테스트에 성공했습니다.
- [x] 애플리케이션 실행을 확인했습니다.
- [x] 관련 기능을 직접 테스트했습니다.
- [x] 프론트 렌더링 회귀 테스트를 추가했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 디버깅 코드를 제거했습니다.
- [x] 백엔드 Controller, Service, Mapper 및 인터페이스 문서를 변경하지 않았습니다.

## 🖼️ 8. 화면 변경

- FGC-UI-CAP-W01 전체 화면을 최신 목업 기준으로 변경
- 검색 조건 및 판정 KPI 카드 추가
- 지급단계별 Stage 카드 2개 구성
- 계산 기준 Guidance 추가
- 계약별 판정 목록 및 설계사 모니터링 영역 구성
- 데스크톱, 노트북, 모바일 반응형 레이아웃 적용

## 💬 9. 참고 사항

- 현재 API로 KPI 요약, 계약 목록, 페이징, 계산근거 팝업까지 연결했습니다.
- 보험회사 Select 활성화에는 보험회사 기준정보 조회 API가 필요합니다.
- 조직 필터 활성화에는 `organizationId` 검색 지원과 조직 기준정보 조회 API가 필요합니다.
- Stage Gauge 실데이터 표시에는 전체 검색범위 기준 Stage 집계 API가 필요합니다.
- 설계사별 모니터링 지표 표시에는 GA → 설계사 전체범위 집계 API가 필요합니다.
- 위 미구현 기능은 현재 페이지의 페이징 결과로 대체 계산하지 않았습니다.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 계약·에이전트 한도 검증 화면을 API 연동 기반으로 개편했습니다.
  * 기준월, 지급 단계, 판정, 계약번호로 목록을 검색할 수 있습니다.
  * 판정별 KPI, 계약 목록, 페이지네이션, 로딩·오류 상태를 제공합니다.
  * 계약별 계산 근거를 상세 모달에서 확인할 수 있습니다.
  * 단계별·설계사별 집계는 연동 대기 상태로 안내합니다.

* **개선**
  * 반응형 레이아웃과 상태별 색상, 포커스 및 오류 표시를 지원합니다.
  * 검색 조건과 판정 결과를 화면 이동 후에도 유지합니다.
  * 계약 상세 화면에서 URL로 원하는 탭을 바로 열 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->