### PR TITLE
[Feat] FUN-048-02 보험사→GA 스케줄·명세 매칭

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
 # ---------------------------------------------------------------- #
 # AI 기본 설정 (언어 및 페르소나)
 # ---------------------------------------------------------------- #
@@ -98,9 +100,14 @@ reviews:
   # 자동 리뷰 트리거 설정
   # ---------------------------------------------------------------- #
   auto_review:
-    # PR이 생성됐을 때
-    # `@coderabbitai review`를 코멘트에 입력하면 리뷰를 시작합니다.
-    # enabled: false
+    # 2026-08-13 yslee - Draft 및 스택형 PR도 자동 리뷰 대상에 포함
+    # 기존 코드: enabled가 주석 처리되고 drafts/base_branches가 없어 CodeRabbit 기본값에 의존
+    # 문제: Draft PR은 기본적으로 제외되고 기본 브랜치가 아닌 feature 브랜치 대상 PR도 자동 리뷰에서 빠질 수 있음
+    # 개선: 자동 리뷰를 명시적으로 활성화하고 Draft와 모든 base 브랜치를 허용
+    enabled: true
+    drafts: true
+    base_branches:
+      - ".*"
     # 이미 리뷰가 진행된 PR에 새로운 커밋이 추가될 때, 변경된 부분에 대해서만 자동으로 리뷰를 진행할지 여부입니다.
     # false로 두면 "Review skipped: incremental reviews are disabled"가 뜨면서
     # 첫 리뷰 이후에 밀어넣은 커밋은 아무도 검토하지 않은 채 머지됩니다.

--- a/src/main/java/com/susukkang/fgc/reconciliation/domain/ReconciliationResultType.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/domain/ReconciliationResultType.java
@@ -1,0 +1,22 @@
+package com.susukkang.fgc.reconciliation.domain;
+
+/**
+ * 설명 : 예상·실제 대사 결과 유형
+ *
+ * @author yslee
+ * @since 2026-08-12
+ * @version 1.2
+ */
+public enum ReconciliationResultType {
+    MATCHED,
+    AMOUNT_DIFFERENCE,
+    EXPECTED_MISSING,
+    ACTUAL_MISSING,
+    DUPLICATE,
+    AGENT_MISMATCH,
+    INSTALLMENT_MISMATCH,
+    INVALID_CONTRACT_PAYMENT,
+    POLICY_VERSION_ERROR,
+    JOURNAL_IMBALANCE,
+    REVIEW_REQUIRED
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaActualSourceRow.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaActualSourceRow.java
@@ -28,6 +28,11 @@ public class InsurerGaActualSourceRow {
     private Long actualAgentId;
     private Integer actualAgentMappingCount;
     private Long commissionItemId;
+    // 2026-08-13 yslee - 실제 원수사 명세 회차 비교값 추가
+    // 기존 코드: 실제 명세 DTO에 회차가 없어 예상 회차와의 일치 여부를 판정할 수 없음
+    // 문제: 실제 14회차가 예상 13회차와 달라도 REVIEW_REQUIRED로만 남아 INSTALLMENT_MISMATCH 인수조건 미충족
+    // 개선: 정규화된 commission_transaction.installment_no를 실제 회차로 전달
+    private Integer actualInstallmentNo;
     private LocalDate settlementMonth;
     private LocalDate dueDate;
     private BigDecimal actualAmount;

--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaActualSourceRow.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaActualSourceRow.java
@@ -1,0 +1,30 @@
+package com.susukkang.fgc.reconciliation.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 설명 : 보험사→GA 대사의 실제 원수사 명세 귀속 원자행
+ *
+ * @author yslee
+ * @since 2026-08-12
+ * @version 1.2
+ */
+@Getter
+@Setter
+public class InsurerGaActualSourceRow {
+
+    private Long transactionAttributionId;
+    private Long commissionTransactionId;
+    private Long journalHeaderId;
+    private Long contractId;
+    private Long commissionItemId;
+    private LocalDate settlementMonth;
+    private LocalDate dueDate;
+    private BigDecimal actualAmount;
+    private String sourceBusinessKey;
+    private String sourceAgentCode;
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaActualSourceRow.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaActualSourceRow.java
@@ -21,6 +21,12 @@ public class InsurerGaActualSourceRow {
     private Long commissionTransactionId;
     private Long journalHeaderId;
     private Long contractId;
+    // 2026-08-13 yslee - 원수사 설계사코드의 내부 설계사 정규화 결과 추가
+    // 기존 코드: sourceAgentCode 원문만 조회하고 매핑 결과를 전달하지 않음
+    // 문제: 보험회사별 외부 코드를 내부 agent_id와 비교할 수 없음
+    // 개선: 효력기간 내 코드 매핑 결과와 매핑 건수를 함께 전달해 불일치·매핑오류를 구분
+    private Long actualAgentId;
+    private Integer actualAgentMappingCount;
     private Long commissionItemId;
     private LocalDate settlementMonth;
     private LocalDate dueDate;

--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaExpectedSourceRow.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaExpectedSourceRow.java
@@ -20,6 +20,11 @@ public class InsurerGaExpectedSourceRow {
     private Long scheduleLineId;
     private Long journalHeaderId;
     private Long contractId;
+    // 2026-08-13 yslee - 원수사→GA 대사의 예상 모집 설계사 식별값 추가
+    // 기존 코드: 예상 원천 DTO에 설계사 식별값이 없음
+    // 문제: 실제 원수사 설계사코드와 비교할 수 없어 다른 설계사가 MATCHED로 처리될 수 있음
+    // 개선: 계약의 모집 설계사 ID를 예상 수취인 식별값으로 전달
+    private Long expectedAgentId;
     private Long commissionItemId;
     private Integer installmentNo;
     private LocalDate dueDate;

--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaExpectedSourceRow.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaExpectedSourceRow.java
@@ -1,0 +1,28 @@
+package com.susukkang.fgc.reconciliation.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 설명 : 보험사→GA 대사의 예상 스케줄 원자행
+ *
+ * @author yslee
+ * @since 2026-08-12
+ * @version 1.2
+ */
+@Getter
+@Setter
+public class InsurerGaExpectedSourceRow {
+
+    private Long scheduleLineId;
+    private Long journalHeaderId;
+    private Long contractId;
+    private Long commissionItemId;
+    private Integer installmentNo;
+    private LocalDate dueDate;
+    private LocalDate dueMonth;
+    private BigDecimal expectedAmount;
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaMatchCandidate.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaMatchCandidate.java
@@ -1,0 +1,41 @@
+package com.susukkang.fgc.reconciliation.dto;
+
+import com.susukkang.fgc.reconciliation.domain.ReconciliationResultType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 설명 : FUN-048-04 저장 단계에 전달할 보험사→GA 대사 후보
+ *
+ * @author yslee
+ * @since 2026-08-12
+ * @version 1.2
+ */
+public record InsurerGaMatchCandidate(
+        String matchGroupKey,
+        Long contractId,
+        Long commissionItemId,
+        Integer installmentNo,
+        LocalDate dueDate,
+        LocalDate dueMonth,
+        ReconciliationResultType resultType,
+        BigDecimal expectedTotalAmount,
+        BigDecimal actualTotalAmount,
+        BigDecimal differenceAmount,
+        String primaryReasonCode,
+        List<String> secondaryReasonCodes,
+        List<Long> scheduleLineIds,
+        List<Long> transactionAttributionIds,
+        List<Long> expectedJournalHeaderIds,
+        List<Long> actualJournalHeaderIds
+) {
+    public InsurerGaMatchCandidate {
+        secondaryReasonCodes = List.copyOf(secondaryReasonCodes);
+        scheduleLineIds = List.copyOf(scheduleLineIds);
+        transactionAttributionIds = List.copyOf(transactionAttributionIds);
+        expectedJournalHeaderIds = List.copyOf(expectedJournalHeaderIds);
+        actualJournalHeaderIds = List.copyOf(actualJournalHeaderIds);
+    }
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaMatchCandidate.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaMatchCandidate.java
@@ -16,6 +16,13 @@ import java.util.List;
 public record InsurerGaMatchCandidate(
         String matchGroupKey,
         Long contractId,
+        // 2026-08-13 yslee - FUN-048-04 저장 대상의 설계사 추적 필드 추가
+        // 기존 코드: 후보 DTO에 예상·실제 설계사와 원수사 코드가 없어 reconciliation_result에 저장 불가
+        // 문제: AGENT_MISMATCH 결과의 원천 식별값을 후속 저장 단계에서 재현할 수 없음
+        // 개선: 예상·실제 내부 설계사 ID와 실제 원수사 코드를 후보에 보존
+        Long expectedAgentId,
+        Long actualAgentId,
+        String actualSourceAgentCode,
         Long commissionItemId,
         Integer installmentNo,
         LocalDate dueDate,

--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaMatchCandidate.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/InsurerGaMatchCandidate.java
@@ -25,6 +25,7 @@ public record InsurerGaMatchCandidate(
         String actualSourceAgentCode,
         Long commissionItemId,
         Integer installmentNo,
+        Integer actualInstallmentNo,
         LocalDate dueDate,
         LocalDate dueMonth,
         ReconciliationResultType resultType,

--- a/src/main/java/com/susukkang/fgc/reconciliation/mapper/InsurerGaReconciliationMapper.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/mapper/InsurerGaReconciliationMapper.java
@@ -1,0 +1,30 @@
+package com.susukkang.fgc.reconciliation.mapper;
+
+import com.susukkang.fgc.reconciliation.dto.InsurerGaActualSourceRow;
+import com.susukkang.fgc.reconciliation.dto.InsurerGaExpectedSourceRow;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 설명 : 기존 정규화 DB에서 보험사→GA 대사 원자행을 조회하는 Mapper
+ *
+ * @author yslee
+ * @since 2026-08-12
+ * @version 1.2
+ */
+@Mapper
+public interface InsurerGaReconciliationMapper {
+
+    List<InsurerGaExpectedSourceRow> findExpectedSources(
+            @Param("settlementMonth") LocalDate settlementMonth,
+            @Param("insurerId") Long insurerId
+    );
+
+    List<InsurerGaActualSourceRow> findActualSources(
+            @Param("settlementMonth") LocalDate settlementMonth,
+            @Param("insurerId") Long insurerId
+    );
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcher.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcher.java
@@ -1,0 +1,18 @@
+package com.susukkang.fgc.reconciliation.service;
+
+import com.susukkang.fgc.reconciliation.dto.InsurerGaMatchCandidate;
+import com.susukkang.fgc.reconciliation.port.ReconciliationExecutionRequest;
+
+import java.util.List;
+
+/**
+ * 설명 : 보험사→GA 예상 스케줄·실제 명세 매칭 서비스 계약
+ *
+ * @author yslee
+ * @since 2026-08-12
+ * @version 1.2
+ */
+public interface InsurerGaReconciliationMatcher {
+
+    List<InsurerGaMatchCandidate> match(ReconciliationExecutionRequest request);
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImpl.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImpl.java
@@ -1,6 +1,7 @@
 package com.susukkang.fgc.reconciliation.service;
 
 import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.common.util.MoneyUtil;
 import com.susukkang.fgc.reconciliation.domain.ReconciliationResultType;
 import com.susukkang.fgc.reconciliation.dto.InsurerGaActualSourceRow;
 import com.susukkang.fgc.reconciliation.dto.InsurerGaExpectedSourceRow;
@@ -73,18 +74,44 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
             List<InsurerGaExpectedSourceRow> expectedSources,
             List<InsurerGaActualSourceRow> actualSources
     ) {
+        // 2026-08-13 yslee - 대사 상세행 반올림과 수취인·회차 데이터 품질 판정 적용
+        // 기존 코드: numeric 원천값을 그대로 합산하고 회차·수취인 식별값의 누락과 불일치를 판정하지 않음
+        // 문제: 행별 HALF_UP 결과와 합계가 달라지거나 미확정 회차·다른 설계사가 정상일치로 처리될 수 있음
+        // 개선: 상세행을 원 단위 반올림한 뒤 합산하고 회차 및 정규화된 설계사 식별값을 별도 판정
         BigDecimal expectedTotal = expectedSources.stream()
                 .map(InsurerGaExpectedSourceRow::getExpectedAmount)
+                .map(MoneyUtil::roundWon)
                 .reduce(ZERO, BigDecimal::add);
         BigDecimal actualTotal = actualSources.stream()
                 .map(InsurerGaActualSourceRow::getActualAmount)
+                .map(MoneyUtil::roundWon)
                 .reduce(ZERO, BigDecimal::add);
+        boolean hasMissingInstallment = expectedSources.stream()
+                .anyMatch(source -> source.getInstallmentNo() == null);
         List<Integer> installments = expectedSources.stream()
                 .map(InsurerGaExpectedSourceRow::getInstallmentNo)
+                .filter(Objects::nonNull)
                 .distinct()
                 .sorted()
                 .toList();
         Integer installmentNo = installments.size() == 1 ? installments.getFirst() : null;
+        List<Long> expectedAgentIds = distinctLongs(expectedSources.stream()
+                .map(InsurerGaExpectedSourceRow::getExpectedAgentId)
+                .toList());
+        List<Long> actualAgentIds = distinctLongs(actualSources.stream()
+                .map(InsurerGaActualSourceRow::getActualAgentId)
+                .toList());
+        List<String> actualSourceAgentCodes = distinctStrings(actualSources.stream()
+                .map(InsurerGaActualSourceRow::getSourceAgentCode)
+                .toList());
+        boolean agentResolutionIssue = hasAgentResolutionIssue(expectedSources, actualSources);
+        boolean agentMismatch = hasAgentMismatch(
+                expectedSources,
+                actualSources,
+                expectedAgentIds,
+                actualAgentIds,
+                actualSourceAgentCodes
+        );
 
         // 2026-08-12 yslee - 실제 명세에 회차 컬럼이 없는 기존 정규화 모델의 안전한 매칭 경계 적용
         // 기존 코드: 실제 명세의 회차를 임의 계산하거나 JSON 키에서 읽는 규칙이 없음
@@ -94,6 +121,9 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
                 expectedSources,
                 actualSources,
                 installments,
+                hasMissingInstallment,
+                agentResolutionIssue,
+                agentMismatch,
                 expectedTotal,
                 actualTotal
         );
@@ -101,13 +131,31 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
                 resultType,
                 expectedSources,
                 actualSources,
+                installments,
+                hasMissingInstallment,
+                agentResolutionIssue,
+                agentMismatch,
                 expectedTotal,
                 actualTotal
         );
 
+        Long expectedAgentId = singleValue(expectedAgentIds);
+        Long actualAgentId = singleValue(actualAgentIds);
+        String actualSourceAgentCode = singleValue(actualSourceAgentCodes);
+
         return new InsurerGaMatchCandidate(
-                matchGroupKey(request, key, installmentNo),
+                matchGroupKey(
+                        request,
+                        key,
+                        installmentNo,
+                        expectedAgentId,
+                        actualAgentId,
+                        actualSourceAgentCode
+                ),
                 key.contractId(),
+                expectedAgentId,
+                actualAgentId,
+                actualSourceAgentCode,
                 key.commissionItemId(),
                 installmentNo,
                 key.dueDate(),
@@ -129,13 +177,20 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
             List<InsurerGaExpectedSourceRow> expectedSources,
             List<InsurerGaActualSourceRow> actualSources,
             List<Integer> installments,
+            boolean hasMissingInstallment,
+            boolean agentResolutionIssue,
+            boolean agentMismatch,
             BigDecimal expectedTotal,
             BigDecimal actualTotal
     ) {
         if (actualSources.stream().anyMatch(source -> source.getDueDate() == null)) {
             return ReconciliationResultType.REVIEW_REQUIRED;
         }
-        if (!expectedSources.isEmpty() && !actualSources.isEmpty() && installments.size() != 1) {
+        if (hasMissingInstallment
+                || (!expectedSources.isEmpty() && !actualSources.isEmpty() && installments.size() != 1)) {
+            return ReconciliationResultType.REVIEW_REQUIRED;
+        }
+        if (agentResolutionIssue) {
             return ReconciliationResultType.REVIEW_REQUIRED;
         }
         if (expectedSources.size() > 1 || actualSources.size() > 1) {
@@ -147,6 +202,9 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
         if (actualSources.isEmpty()) {
             return ReconciliationResultType.ACTUAL_MISSING;
         }
+        if (agentMismatch) {
+            return ReconciliationResultType.AGENT_MISMATCH;
+        }
         return tolerancePolicy.matches(expectedTotal, actualTotal)
                 ? ReconciliationResultType.MATCHED
                 : ReconciliationResultType.AMOUNT_DIFFERENCE;
@@ -156,12 +214,25 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
             ReconciliationResultType primary,
             List<InsurerGaExpectedSourceRow> expectedSources,
             List<InsurerGaActualSourceRow> actualSources,
+            List<Integer> installments,
+            boolean hasMissingInstallment,
+            boolean agentResolutionIssue,
+            boolean agentMismatch,
             BigDecimal expectedTotal,
             BigDecimal actualTotal
     ) {
         List<String> reasons = new ArrayList<>();
-        if (expectedSources.size() > 1 || actualSources.size() > 1) {
+        boolean installmentMismatch = hasMissingInstallment
+                || (!expectedSources.isEmpty() && !actualSources.isEmpty() && installments.size() != 1);
+        if (installmentMismatch) {
+            reasons.add(ReconciliationResultType.INSTALLMENT_MISMATCH.name());
+        } else if (expectedSources.size() > 1 || actualSources.size() > 1) {
             reasons.add(ReconciliationResultType.DUPLICATE.name());
+        }
+        if (agentResolutionIssue) {
+            reasons.add(ReconciliationResultType.REVIEW_REQUIRED.name());
+        } else if (agentMismatch) {
+            reasons.add(ReconciliationResultType.AGENT_MISMATCH.name());
         }
         if (expectedSources.isEmpty()) {
             reasons.add(ReconciliationResultType.EXPECTED_MISSING.name());
@@ -224,7 +295,10 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
     private static String matchGroupKey(
             ReconciliationExecutionRequest request,
             BaseMatchKey key,
-            Integer installmentNo
+            Integer installmentNo,
+            Long expectedAgentId,
+            Long actualAgentId,
+            String actualSourceAgentCode
     ) {
         return String.join(":",
                 PaymentStage.INSURER_TO_GA.name(),
@@ -232,6 +306,7 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
                 MONTH_FORMATTER.format(key.dueMonth()),
                 String.valueOf(key.contractId()),
                 String.valueOf(key.commissionItemId()),
+                recipientKey(expectedAgentId, actualAgentId, actualSourceAgentCode),
                 installmentNo == null ? "NA" : String.valueOf(installmentNo),
                 key.dueDate() == null ? "NA" : DateTimeFormatter.BASIC_ISO_DATE.format(key.dueDate())
         );
@@ -239,6 +314,58 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
 
     private static List<Long> distinctLongs(List<Long> values) {
         return values.stream().filter(Objects::nonNull).distinct().sorted().toList();
+    }
+
+    private static List<String> distinctStrings(List<String> values) {
+        return values.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    private static boolean hasAgentMismatch(
+            List<InsurerGaExpectedSourceRow> expectedSources,
+            List<InsurerGaActualSourceRow> actualSources,
+            List<Long> expectedAgentIds,
+            List<Long> actualAgentIds,
+            List<String> actualSourceAgentCodes
+    ) {
+        if (expectedSources.isEmpty() || actualSources.isEmpty()) {
+            return false;
+        }
+        if (expectedAgentIds.isEmpty() && actualAgentIds.isEmpty() && actualSourceAgentCodes.isEmpty()) {
+            return false;
+        }
+        return expectedAgentIds.size() != 1
+                || actualAgentIds.size() != 1
+                || !expectedAgentIds.getFirst().equals(actualAgentIds.getFirst());
+    }
+
+    private static boolean hasAgentResolutionIssue(
+            List<InsurerGaExpectedSourceRow> expectedSources,
+            List<InsurerGaActualSourceRow> actualSources
+    ) {
+        return !expectedSources.isEmpty()
+                && !actualSources.isEmpty()
+                && actualSources.stream().anyMatch(source -> source.getActualAgentId() == null
+                || !Objects.equals(source.getActualAgentMappingCount(), 1));
+    }
+
+    private static String recipientKey(
+            Long expectedAgentId,
+            Long actualAgentId,
+            String actualSourceAgentCode
+    ) {
+        return "E" + Objects.toString(expectedAgentId, "NA")
+                + "-A" + Objects.toString(actualAgentId, "NA")
+                + "-S" + Objects.toString(actualSourceAgentCode, "NA");
+    }
+
+    private static <T> T singleValue(List<T> values) {
+        return values.size() == 1 ? values.getFirst() : null;
     }
 
     private record BaseMatchKey(Long contractId, Long commissionItemId, LocalDate dueMonth, LocalDate dueDate) {

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImpl.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImpl.java
@@ -1,0 +1,251 @@
+package com.susukkang.fgc.reconciliation.service;
+
+import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.reconciliation.domain.ReconciliationResultType;
+import com.susukkang.fgc.reconciliation.dto.InsurerGaActualSourceRow;
+import com.susukkang.fgc.reconciliation.dto.InsurerGaExpectedSourceRow;
+import com.susukkang.fgc.reconciliation.dto.InsurerGaMatchCandidate;
+import com.susukkang.fgc.reconciliation.mapper.InsurerGaReconciliationMapper;
+import com.susukkang.fgc.reconciliation.port.ReconciliationExecutionRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * 설명 : FUN-048-02 보험사→GA 예상 스케줄·실제 명세 정규화 매칭
+ *
+ * @author yslee
+ * @since 2026-08-12
+ * @version 1.2
+ */
+@Service
+@RequiredArgsConstructor
+public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliationMatcher {
+
+    private static final BigDecimal ZERO = BigDecimal.ZERO;
+    private static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
+
+    private final InsurerGaReconciliationMapper reconciliationMapper;
+    private final ReconciliationAmountTolerancePolicy tolerancePolicy;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<InsurerGaMatchCandidate> match(ReconciliationExecutionRequest request) {
+        validateRequest(request);
+
+        List<InsurerGaExpectedSourceRow> expectedSources = reconciliationMapper.findExpectedSources(
+                request.settlementMonth(), request.insurerId());
+        List<InsurerGaActualSourceRow> actualSources = reconciliationMapper.findActualSources(
+                request.settlementMonth(), request.insurerId());
+
+        Map<BaseMatchKey, List<InsurerGaExpectedSourceRow>> expectedByKey = groupExpected(expectedSources);
+        Map<BaseMatchKey, List<InsurerGaActualSourceRow>> actualByKey = groupActual(actualSources);
+        Set<BaseMatchKey> keys = new LinkedHashSet<>();
+        keys.addAll(expectedByKey.keySet());
+        keys.addAll(actualByKey.keySet());
+
+        return keys.stream()
+                .sorted(BaseMatchKey.ORDER)
+                .map(key -> createCandidate(
+                        request,
+                        key,
+                        expectedByKey.getOrDefault(key, List.of()),
+                        actualByKey.getOrDefault(key, List.of())
+                ))
+                .toList();
+    }
+
+    private InsurerGaMatchCandidate createCandidate(
+            ReconciliationExecutionRequest request,
+            BaseMatchKey key,
+            List<InsurerGaExpectedSourceRow> expectedSources,
+            List<InsurerGaActualSourceRow> actualSources
+    ) {
+        BigDecimal expectedTotal = expectedSources.stream()
+                .map(InsurerGaExpectedSourceRow::getExpectedAmount)
+                .reduce(ZERO, BigDecimal::add);
+        BigDecimal actualTotal = actualSources.stream()
+                .map(InsurerGaActualSourceRow::getActualAmount)
+                .reduce(ZERO, BigDecimal::add);
+        List<Integer> installments = expectedSources.stream()
+                .map(InsurerGaExpectedSourceRow::getInstallmentNo)
+                .distinct()
+                .sorted()
+                .toList();
+        Integer installmentNo = installments.size() == 1 ? installments.getFirst() : null;
+
+        // 2026-08-12 yslee - 실제 명세에 회차 컬럼이 없는 기존 정규화 모델의 안전한 매칭 경계 적용
+        // 기존 코드: 실제 명세의 회차를 임의 계산하거나 JSON 키에서 읽는 규칙이 없음
+        // 문제: 계약월로 회차를 추정하면 납입주기·지급시점에 따라 다른 스케줄행을 정상으로 오인할 수 있음
+        // 개선: 문서의 due_month=settlement_month 후보에서 예상 회차가 하나일 때만 회차를 확정하고 그 외에는 검토 대상으로 분류
+        ReconciliationResultType resultType = classify(
+                expectedSources,
+                actualSources,
+                installments,
+                expectedTotal,
+                actualTotal
+        );
+        List<String> secondaryReasons = secondaryReasons(
+                resultType,
+                expectedSources,
+                actualSources,
+                expectedTotal,
+                actualTotal
+        );
+
+        return new InsurerGaMatchCandidate(
+                matchGroupKey(request, key, installmentNo),
+                key.contractId(),
+                key.commissionItemId(),
+                installmentNo,
+                key.dueDate(),
+                key.dueMonth(),
+                resultType,
+                expectedTotal,
+                actualTotal,
+                actualTotal.subtract(expectedTotal),
+                resultType.name(),
+                secondaryReasons,
+                distinctLongs(expectedSources.stream().map(InsurerGaExpectedSourceRow::getScheduleLineId).toList()),
+                distinctLongs(actualSources.stream().map(InsurerGaActualSourceRow::getTransactionAttributionId).toList()),
+                distinctLongs(expectedSources.stream().map(InsurerGaExpectedSourceRow::getJournalHeaderId).toList()),
+                distinctLongs(actualSources.stream().map(InsurerGaActualSourceRow::getJournalHeaderId).toList())
+        );
+    }
+
+    private ReconciliationResultType classify(
+            List<InsurerGaExpectedSourceRow> expectedSources,
+            List<InsurerGaActualSourceRow> actualSources,
+            List<Integer> installments,
+            BigDecimal expectedTotal,
+            BigDecimal actualTotal
+    ) {
+        if (actualSources.stream().anyMatch(source -> source.getDueDate() == null)) {
+            return ReconciliationResultType.REVIEW_REQUIRED;
+        }
+        if (!expectedSources.isEmpty() && !actualSources.isEmpty() && installments.size() != 1) {
+            return ReconciliationResultType.REVIEW_REQUIRED;
+        }
+        if (expectedSources.size() > 1 || actualSources.size() > 1) {
+            return ReconciliationResultType.DUPLICATE;
+        }
+        if (expectedSources.isEmpty()) {
+            return ReconciliationResultType.EXPECTED_MISSING;
+        }
+        if (actualSources.isEmpty()) {
+            return ReconciliationResultType.ACTUAL_MISSING;
+        }
+        return tolerancePolicy.matches(expectedTotal, actualTotal)
+                ? ReconciliationResultType.MATCHED
+                : ReconciliationResultType.AMOUNT_DIFFERENCE;
+    }
+
+    private List<String> secondaryReasons(
+            ReconciliationResultType primary,
+            List<InsurerGaExpectedSourceRow> expectedSources,
+            List<InsurerGaActualSourceRow> actualSources,
+            BigDecimal expectedTotal,
+            BigDecimal actualTotal
+    ) {
+        List<String> reasons = new ArrayList<>();
+        if (expectedSources.size() > 1 || actualSources.size() > 1) {
+            reasons.add(ReconciliationResultType.DUPLICATE.name());
+        }
+        if (expectedSources.isEmpty()) {
+            reasons.add(ReconciliationResultType.EXPECTED_MISSING.name());
+        } else if (actualSources.isEmpty()) {
+            reasons.add(ReconciliationResultType.ACTUAL_MISSING.name());
+        } else if (!tolerancePolicy.matches(expectedTotal, actualTotal)) {
+            reasons.add(ReconciliationResultType.AMOUNT_DIFFERENCE.name());
+        }
+        return reasons.stream().filter(reason -> !reason.equals(primary.name())).distinct().toList();
+    }
+
+    private static Map<BaseMatchKey, List<InsurerGaExpectedSourceRow>> groupExpected(
+            List<InsurerGaExpectedSourceRow> rows
+    ) {
+        Map<BaseMatchKey, List<InsurerGaExpectedSourceRow>> grouped = new LinkedHashMap<>();
+        for (InsurerGaExpectedSourceRow row : rows) {
+            requireSource(row.getContractId(), row.getCommissionItemId(), row.getDueMonth(), row.getExpectedAmount());
+            grouped.computeIfAbsent(new BaseMatchKey(
+                    row.getContractId(), row.getCommissionItemId(), row.getDueMonth(), row.getDueDate()), ignored -> new ArrayList<>())
+                    .add(row);
+        }
+        return grouped;
+    }
+
+    private static Map<BaseMatchKey, List<InsurerGaActualSourceRow>> groupActual(
+            List<InsurerGaActualSourceRow> rows
+    ) {
+        Map<BaseMatchKey, List<InsurerGaActualSourceRow>> grouped = new LinkedHashMap<>();
+        for (InsurerGaActualSourceRow row : rows) {
+            requireSource(row.getContractId(), row.getCommissionItemId(), row.getSettlementMonth(), row.getActualAmount());
+            grouped.computeIfAbsent(new BaseMatchKey(
+                    row.getContractId(), row.getCommissionItemId(), row.getSettlementMonth(), row.getDueDate()), ignored -> new ArrayList<>())
+                    .add(row);
+        }
+        return grouped;
+    }
+
+    private static void requireSource(Long contractId, Long commissionItemId, LocalDate month, BigDecimal amount) {
+        if (contractId == null || commissionItemId == null || month == null || amount == null) {
+            throw new IllegalStateException("대사 원자행의 계약·항목·기준월·금액은 필수입니다.");
+        }
+    }
+
+    private static void validateRequest(ReconciliationExecutionRequest request) {
+        Objects.requireNonNull(request, "대사 실행 요청은 필수입니다.");
+        if (request.reconciliationRunId() == null || request.reconciliationRunId() <= 0) {
+            throw new IllegalArgumentException("reconciliationRunId는 1 이상이어야 합니다.");
+        }
+        if (request.paymentStage() != PaymentStage.INSURER_TO_GA) {
+            throw new IllegalArgumentException("FUN-048-02는 INSURER_TO_GA 실행만 처리합니다.");
+        }
+        if (request.settlementMonth() == null || request.settlementMonth().getDayOfMonth() != 1) {
+            throw new IllegalArgumentException("settlementMonth는 월의 1일이어야 합니다.");
+        }
+        if (request.insurerId() == null || request.insurerId() <= 0) {
+            throw new IllegalArgumentException("insurerId는 1 이상이어야 합니다.");
+        }
+    }
+
+    private static String matchGroupKey(
+            ReconciliationExecutionRequest request,
+            BaseMatchKey key,
+            Integer installmentNo
+    ) {
+        return String.join(":",
+                PaymentStage.INSURER_TO_GA.name(),
+                String.valueOf(request.insurerId()),
+                MONTH_FORMATTER.format(key.dueMonth()),
+                String.valueOf(key.contractId()),
+                String.valueOf(key.commissionItemId()),
+                installmentNo == null ? "NA" : String.valueOf(installmentNo),
+                key.dueDate() == null ? "NA" : DateTimeFormatter.BASIC_ISO_DATE.format(key.dueDate())
+        );
+    }
+
+    private static List<Long> distinctLongs(List<Long> values) {
+        return values.stream().filter(Objects::nonNull).distinct().sorted().toList();
+    }
+
+    private record BaseMatchKey(Long contractId, Long commissionItemId, LocalDate dueMonth, LocalDate dueDate) {
+        private static final Comparator<BaseMatchKey> ORDER = Comparator
+                .comparing(BaseMatchKey::contractId)
+                .thenComparing(BaseMatchKey::commissionItemId)
+                .thenComparing(BaseMatchKey::dueMonth)
+                .thenComparing(BaseMatchKey::dueDate, Comparator.nullsLast(Comparator.naturalOrder()));
+    }
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImpl.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImpl.java
@@ -86,15 +86,37 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
                 .map(InsurerGaActualSourceRow::getActualAmount)
                 .map(MoneyUtil::roundWon)
                 .reduce(ZERO, BigDecimal::add);
-        boolean hasMissingInstallment = expectedSources.stream()
+        boolean hasMissingExpectedInstallment = expectedSources.stream()
                 .anyMatch(source -> source.getInstallmentNo() == null);
-        List<Integer> installments = expectedSources.stream()
+        boolean hasMissingActualInstallment = actualSources.stream()
+                .anyMatch(source -> source.getActualInstallmentNo() == null);
+        List<Integer> expectedInstallments = expectedSources.stream()
                 .map(InsurerGaExpectedSourceRow::getInstallmentNo)
                 .filter(Objects::nonNull)
                 .distinct()
                 .sorted()
                 .toList();
-        Integer installmentNo = installments.size() == 1 ? installments.getFirst() : null;
+        List<Integer> actualInstallments = actualSources.stream()
+                .map(InsurerGaActualSourceRow::getActualInstallmentNo)
+                .filter(Objects::nonNull)
+                .distinct()
+                .sorted()
+                .toList();
+        Integer installmentNo = singleValue(expectedInstallments);
+        Integer actualInstallmentNo = singleValue(actualInstallments);
+        boolean hasBothSources = !expectedSources.isEmpty() && !actualSources.isEmpty();
+        // 2026-08-13 yslee - 실제 명세 회차의 누락·불일치 판정 분리
+        // 기존 코드: 예상 회차만 확인해 모호한 경우 REVIEW_REQUIRED, 실제 회차 불일치 판정 경로는 없음
+        // 문제: REC-07의 예상 13회차·실제 14회차가 INSTALLMENT_MISMATCH로 산출되지 않음
+        // 개선: 회차 누락·복수값은 REVIEW_REQUIRED, 양쪽 단일 회차가 다르면 INSTALLMENT_MISMATCH로 구분
+        boolean installmentResolutionIssue = hasBothSources
+                && (hasMissingExpectedInstallment
+                || hasMissingActualInstallment
+                || expectedInstallments.size() != 1
+                || actualInstallments.size() != 1);
+        boolean installmentMismatch = hasBothSources
+                && !installmentResolutionIssue
+                && !Objects.equals(installmentNo, actualInstallmentNo);
         List<Long> expectedAgentIds = distinctLongs(expectedSources.stream()
                 .map(InsurerGaExpectedSourceRow::getExpectedAgentId)
                 .toList());
@@ -120,8 +142,8 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
         ReconciliationResultType resultType = classify(
                 expectedSources,
                 actualSources,
-                installments,
-                hasMissingInstallment,
+                installmentResolutionIssue,
+                installmentMismatch,
                 agentResolutionIssue,
                 agentMismatch,
                 expectedTotal,
@@ -131,8 +153,8 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
                 resultType,
                 expectedSources,
                 actualSources,
-                installments,
-                hasMissingInstallment,
+                installmentResolutionIssue,
+                installmentMismatch,
                 agentResolutionIssue,
                 agentMismatch,
                 expectedTotal,
@@ -148,6 +170,7 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
                         request,
                         key,
                         installmentNo,
+                        actualInstallmentNo,
                         expectedAgentId,
                         actualAgentId,
                         actualSourceAgentCode
@@ -158,6 +181,7 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
                 actualSourceAgentCode,
                 key.commissionItemId(),
                 installmentNo,
+                actualInstallmentNo,
                 key.dueDate(),
                 key.dueMonth(),
                 resultType,
@@ -176,8 +200,8 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
     private ReconciliationResultType classify(
             List<InsurerGaExpectedSourceRow> expectedSources,
             List<InsurerGaActualSourceRow> actualSources,
-            List<Integer> installments,
-            boolean hasMissingInstallment,
+            boolean installmentResolutionIssue,
+            boolean installmentMismatch,
             boolean agentResolutionIssue,
             boolean agentMismatch,
             BigDecimal expectedTotal,
@@ -186,8 +210,7 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
         if (actualSources.stream().anyMatch(source -> source.getDueDate() == null)) {
             return ReconciliationResultType.REVIEW_REQUIRED;
         }
-        if (hasMissingInstallment
-                || (!expectedSources.isEmpty() && !actualSources.isEmpty() && installments.size() != 1)) {
+        if (installmentResolutionIssue) {
             return ReconciliationResultType.REVIEW_REQUIRED;
         }
         if (agentResolutionIssue) {
@@ -202,6 +225,9 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
         if (actualSources.isEmpty()) {
             return ReconciliationResultType.ACTUAL_MISSING;
         }
+        if (installmentMismatch) {
+            return ReconciliationResultType.INSTALLMENT_MISMATCH;
+        }
         if (agentMismatch) {
             return ReconciliationResultType.AGENT_MISMATCH;
         }
@@ -214,17 +240,15 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
             ReconciliationResultType primary,
             List<InsurerGaExpectedSourceRow> expectedSources,
             List<InsurerGaActualSourceRow> actualSources,
-            List<Integer> installments,
-            boolean hasMissingInstallment,
+            boolean installmentResolutionIssue,
+            boolean installmentMismatch,
             boolean agentResolutionIssue,
             boolean agentMismatch,
             BigDecimal expectedTotal,
             BigDecimal actualTotal
     ) {
         List<String> reasons = new ArrayList<>();
-        boolean installmentMismatch = hasMissingInstallment
-                || (!expectedSources.isEmpty() && !actualSources.isEmpty() && installments.size() != 1);
-        if (installmentMismatch) {
+        if (installmentResolutionIssue || installmentMismatch) {
             reasons.add(ReconciliationResultType.INSTALLMENT_MISMATCH.name());
         } else if (expectedSources.size() > 1 || actualSources.size() > 1) {
             reasons.add(ReconciliationResultType.DUPLICATE.name());
@@ -296,6 +320,7 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
             ReconciliationExecutionRequest request,
             BaseMatchKey key,
             Integer installmentNo,
+            Integer actualInstallmentNo,
             Long expectedAgentId,
             Long actualAgentId,
             String actualSourceAgentCode
@@ -307,7 +332,8 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
                 String.valueOf(key.contractId()),
                 String.valueOf(key.commissionItemId()),
                 recipientKey(expectedAgentId, actualAgentId, actualSourceAgentCode),
-                installmentNo == null ? "NA" : String.valueOf(installmentNo),
+                "E" + Objects.toString(installmentNo, "NA")
+                        + "-A" + Objects.toString(actualInstallmentNo, "NA"),
                 key.dueDate() == null ? "NA" : DateTimeFormatter.BASIC_ISO_DATE.format(key.dueDate())
         );
     }

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImpl.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImpl.java
@@ -348,10 +348,16 @@ public class InsurerGaReconciliationMatcherImpl implements InsurerGaReconciliati
             List<InsurerGaExpectedSourceRow> expectedSources,
             List<InsurerGaActualSourceRow> actualSources
     ) {
+        // 2026-08-13 yslee - 예상 설계사 식별값 누락 시 검토필요 판정 적용
+        // 기존 코드: 실제 원수사 설계사코드의 매핑 실패·중복 여부만 확인
+        // 문제: expectedAgentId가 없으면 비교 기준이 없는데도 정상 매핑된 실제 설계사와 AGENT_MISMATCH로 확정됨
+        // 개선: 예상·실제 원천이 모두 있을 때 예상 설계사 누락도 식별 불가로 보고 REVIEW_REQUIRED 게이트에 포함
         return !expectedSources.isEmpty()
                 && !actualSources.isEmpty()
-                && actualSources.stream().anyMatch(source -> source.getActualAgentId() == null
-                || !Objects.equals(source.getActualAgentMappingCount(), 1));
+                && (expectedSources.stream().anyMatch(source -> source.getExpectedAgentId() == null)
+                    || actualSources.stream().anyMatch(source ->
+                        source.getActualAgentId() == null
+                                || !Objects.equals(source.getActualAgentMappingCount(), 1)));
     }
 
     private static String recipientKey(

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationAmountTolerancePolicy.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationAmountTolerancePolicy.java
@@ -1,0 +1,15 @@
+package com.susukkang.fgc.reconciliation.service;
+
+import java.math.BigDecimal;
+
+/**
+ * 설명 : FUN-050 허용오차 정책과 분리된 대사 금액 비교 계약
+ *
+ * @author yslee
+ * @since 2026-08-12
+ * @version 1.2
+ */
+public interface ReconciliationAmountTolerancePolicy {
+
+    boolean matches(BigDecimal expectedAmount, BigDecimal actualAmount);
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/ZeroAmountTolerancePolicy.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/ZeroAmountTolerancePolicy.java
@@ -1,0 +1,21 @@
+package com.susukkang.fgc.reconciliation.service;
+
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+/**
+ * 설명 : 운영정책서 제36조의 1차 금액 허용오차 0원 정책
+ *
+ * @author yslee
+ * @since 2026-08-12
+ * @version 1.2
+ */
+@Component
+public class ZeroAmountTolerancePolicy implements ReconciliationAmountTolerancePolicy {
+
+    @Override
+    public boolean matches(BigDecimal expectedAmount, BigDecimal actualAmount) {
+        return expectedAmount.compareTo(actualAmount) == 0;
+    }
+}

--- a/src/main/resources/db/migration/V18__commission_transaction_installment_no.sql
+++ b/src/main/resources/db/migration/V18__commission_transaction_installment_no.sql
@@ -8,7 +8,7 @@ ALTER TABLE fgc.commission_transaction
 
 ALTER TABLE fgc.commission_transaction
     ADD CONSTRAINT ck_commission_transaction_installment_no
-    CHECK (installment_no IS NULL OR installment_no > 0);
+    CHECK (installment_no IS NULL OR installment_no > 0) NOT VALID;
 
 COMMENT ON COLUMN fgc.commission_transaction.installment_no IS
     '정규화된 실제 원수사 명세 또는 지급 건의 회차. 원천에 회차가 없으면 NULL이며 대사에서 REVIEW_REQUIRED로 처리';

--- a/src/main/resources/db/migration/V18__commission_transaction_installment_no.sql
+++ b/src/main/resources/db/migration/V18__commission_transaction_installment_no.sql
@@ -1,0 +1,32 @@
+-- 2026-08-13 yslee - 실제 명세·지급 건의 회차 원천값 저장
+-- 기존 코드: 예상 schedule_line에만 installment_no가 있고 실제 commission_transaction에는 회차가 없음
+-- 문제: 예상 13회차와 실제 14회차를 비교할 수 없어 INSTALLMENT_MISMATCH 인수조건을 재현하지 못함
+-- 개선: 정규화된 실제 원천 회차를 nullable 컬럼으로 저장하고 확정 이후에는 변경하지 못하도록 보호
+
+ALTER TABLE fgc.commission_transaction
+    ADD COLUMN installment_no integer;
+
+ALTER TABLE fgc.commission_transaction
+    ADD CONSTRAINT ck_commission_transaction_installment_no
+    CHECK (installment_no IS NULL OR installment_no > 0);
+
+COMMENT ON COLUMN fgc.commission_transaction.installment_no IS
+    '정규화된 실제 원수사 명세 또는 지급 건의 회차. 원천에 회차가 없으면 NULL이며 대사에서 REVIEW_REQUIRED로 처리';
+
+CREATE OR REPLACE FUNCTION fgc.guard_commission_transaction_installment_write()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.status IN ('CONFIRMED', 'CANCELLED')
+     AND NEW.installment_no IS DISTINCT FROM OLD.installment_no THEN
+    RAISE EXCEPTION 'Installment number of finalized transaction % is immutable',
+      OLD.commission_transaction_id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_commission_transaction_installment_guard
+BEFORE UPDATE OF installment_no ON fgc.commission_transaction
+FOR EACH ROW EXECUTE FUNCTION fgc.guard_commission_transaction_installment_write();

--- a/src/main/resources/db/migration/V19__validate_commission_transaction_installment_no.sql
+++ b/src/main/resources/db/migration/V19__validate_commission_transaction_installment_no.sql
@@ -1,0 +1,7 @@
+-- 2026-08-13 yslee - 실제 지급 회차 CHECK 제약의 기존 데이터 검증 분리
+-- 기존 코드: V18에서 CHECK 제약 추가와 기존 commission_transaction 행 검증을 한 번에 수행
+-- 문제: 대형 원장에서 기존 행 검사 중 강한 테이블 잠금이 길어져 명세 적재와 거래 확정이 지연될 수 있음
+-- 개선: V18은 신규·변경 행에 제약을 즉시 적용하고 기존 행 검증은 낮은 잠금 수준의 별도 단계로 수행
+
+ALTER TABLE fgc.commission_transaction
+    VALIDATE CONSTRAINT ck_commission_transaction_installment_no;

--- a/src/main/resources/mapper/reconciliation/InsurerGaReconciliationMapper.xml
+++ b/src/main/resources/mapper/reconciliation/InsurerGaReconciliationMapper.xml
@@ -2,15 +2,16 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.susukkang.fgc.reconciliation.mapper.InsurerGaReconciliationMapper">
 
-    <!-- 2026-08-12 yslee - 기존 스케줄·원장 테이블에서 보험사→GA 예상 원자행 조회
+    <!-- 2026-08-13 yslee - 기존 스케줄·원장 테이블에서 보험사→GA 예상 원자행 조회
          기존 코드: 대사 실행이 예상 스케줄을 읽는 SQL이 없음
-         문제: 비교·시뮬레이션 또는 비활성·취소 스케줄까지 섞이면 운영 예상액을 재현할 수 없음
-         개선: 활성 OPERATIONAL 보험사→GA 스케줄과 현재 POSTED 예상분개만 추적 정보로 조회 -->
+         문제: 비교·시뮬레이션 또는 비활성·취소 스케줄과 POSTED 분개가 없는 행은 원장 대사 근거가 될 수 없음
+         개선: 활성 OPERATIONAL 보험사→GA 스케줄 중 POSTED 예상분개가 있는 행과 계약 모집 설계사를 조회 -->
     <select id="findExpectedSources"
             resultType="com.susukkang.fgc.reconciliation.dto.InsurerGaExpectedSourceRow">
         SELECT sl.schedule_line_id AS scheduleLineId,
                jh.journal_header_id AS journalHeaderId,
                sh.contract_id AS contractId,
+               c.agent_id AS expectedAgentId,
                sl.commission_item_id AS commissionItemId,
                sl.installment_no AS installmentNo,
                sl.due_date AS dueDate,
@@ -21,7 +22,7 @@
             ON sl.schedule_header_id = sh.schedule_header_id
           JOIN fgc.insurance_contract c
             ON c.contract_id = sh.contract_id
-          LEFT JOIN fgc.journal_header jh
+          JOIN fgc.journal_header jh
             ON jh.journal_type = 'EXPECTED_INSURER_INCOME'
            AND jh.source_entity_type = 'SCHEDULE_LINE'
            AND jh.source_entity_id = CAST(sl.schedule_line_id AS varchar)
@@ -37,16 +38,25 @@
                   sl.installment_no, sl.schedule_line_id
     </select>
 
-    <!-- 2026-08-12 yslee - 정규화된 원수사 명세 거래·귀속행을 실제 원자행으로 조회
+    <!-- 2026-08-13 yslee - 정규화된 원수사 명세 거래·귀속행을 실제 원자행으로 조회
          기존 코드: 파일 또는 임시 대사 테이블을 전제로 한 실제 원천 조회가 없음
-         문제: REJECTED 명세나 DRAFT·취소·타 단계 거래가 실제 지급액에 섞일 수 있음
-         개선: 기존 statement_batch/commission_transaction/transaction_attribution에서 확정 지급 원자행만 조회 -->
+         문제: POSTED 실제분개가 없거나 원수사 설계사코드가 정규화되지 않은 행은 원장·수취인 대사를 재현할 수 없음
+         개선: POSTED 실제분개가 있는 확정 지급 원자행과 유효기간 내 원수사 설계사코드의 내부 agent_id를 조회 -->
     <select id="findActualSources"
             resultType="com.susukkang.fgc.reconciliation.dto.InsurerGaActualSourceRow">
         SELECT ta.transaction_attribution_id AS transactionAttributionId,
                ct.commission_transaction_id AS commissionTransactionId,
                jh.journal_header_id AS journalHeaderId,
                ta.contract_id AS contractId,
+               CASE
+                   WHEN ta.source_agent_code IS NOT NULL THEN aic.agent_id
+                   ELSE ta.agent_id
+               END AS actualAgentId,
+               CASE
+                   WHEN ta.source_agent_code IS NOT NULL THEN aic.mapping_count
+                   WHEN ta.agent_id IS NOT NULL THEN 1
+                   ELSE 0
+               END AS actualAgentMappingCount,
                ct.commission_item_id AS commissionItemId,
                ct.settlement_month AS settlementMonth,
                ct.due_date AS dueDate,
@@ -58,11 +68,23 @@
             ON ct.statement_batch_id = sb.statement_batch_id
           JOIN fgc.transaction_attribution ta
             ON ta.commission_transaction_id = ct.commission_transaction_id
-          LEFT JOIN fgc.journal_header jh
+          JOIN fgc.journal_header jh
             ON jh.journal_type = 'ACTUAL_INSURER_STATEMENT'
            AND jh.source_entity_type = 'COMMISSION_TRANSACTION'
-           AND jh.source_entity_id = CAST(ct.commission_transaction_id AS varchar)
-           AND jh.status = 'POSTED'
+            AND jh.source_entity_id = CAST(ct.commission_transaction_id AS varchar)
+            AND jh.status = 'POSTED'
+          LEFT JOIN LATERAL (
+              SELECT CASE
+                         WHEN COUNT(DISTINCT code.agent_id) = 1 THEN MIN(code.agent_id)
+                     END AS agent_id,
+                     COUNT(*)::integer AS mapping_count
+                FROM fgc.agent_insurer_code code
+               WHERE code.insurer_id = ct.insurer_id
+                 AND code.insurer_agent_code = ta.source_agent_code
+                 AND code.code_status IN ('ACTIVE', 'REPRESENTATIVE')
+                 AND code.effective_from &lt;= ta.attribution_date
+                 AND (code.effective_to IS NULL OR code.effective_to &gt;= ta.attribution_date)
+          ) aic ON TRUE
          WHERE sb.insurer_id = #{insurerId}
            AND sb.settlement_month = #{settlementMonth}
            AND sb.statement_type = 'INSURER_COMMISSION'

--- a/src/main/resources/mapper/reconciliation/InsurerGaReconciliationMapper.xml
+++ b/src/main/resources/mapper/reconciliation/InsurerGaReconciliationMapper.xml
@@ -58,6 +58,7 @@
                    ELSE 0
                END AS actualAgentMappingCount,
                ct.commission_item_id AS commissionItemId,
+               ct.installment_no AS actualInstallmentNo,
                ct.settlement_month AS settlementMonth,
                ct.due_date AS dueDate,
                ta.attributed_amount AS actualAmount,

--- a/src/main/resources/mapper/reconciliation/InsurerGaReconciliationMapper.xml
+++ b/src/main/resources/mapper/reconciliation/InsurerGaReconciliationMapper.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.susukkang.fgc.reconciliation.mapper.InsurerGaReconciliationMapper">
+
+    <!-- 2026-08-12 yslee - 기존 스케줄·원장 테이블에서 보험사→GA 예상 원자행 조회
+         기존 코드: 대사 실행이 예상 스케줄을 읽는 SQL이 없음
+         문제: 비교·시뮬레이션 또는 비활성·취소 스케줄까지 섞이면 운영 예상액을 재현할 수 없음
+         개선: 활성 OPERATIONAL 보험사→GA 스케줄과 현재 POSTED 예상분개만 추적 정보로 조회 -->
+    <select id="findExpectedSources"
+            resultType="com.susukkang.fgc.reconciliation.dto.InsurerGaExpectedSourceRow">
+        SELECT sl.schedule_line_id AS scheduleLineId,
+               jh.journal_header_id AS journalHeaderId,
+               sh.contract_id AS contractId,
+               sl.commission_item_id AS commissionItemId,
+               sl.installment_no AS installmentNo,
+               sl.due_date AS dueDate,
+               sl.due_month AS dueMonth,
+               sl.expected_amount AS expectedAmount
+          FROM fgc.schedule_header sh
+          JOIN fgc.schedule_line sl
+            ON sl.schedule_header_id = sh.schedule_header_id
+          JOIN fgc.insurance_contract c
+            ON c.contract_id = sh.contract_id
+          LEFT JOIN fgc.journal_header jh
+            ON jh.journal_type = 'EXPECTED_INSURER_INCOME'
+           AND jh.source_entity_type = 'SCHEDULE_LINE'
+           AND jh.source_entity_id = CAST(sl.schedule_line_id AS varchar)
+           AND jh.status = 'POSTED'
+         WHERE sh.payment_stage = 'INSURER_TO_GA'
+           AND sh.schedule_purpose = 'OPERATIONAL'
+           AND sh.active_yn = TRUE
+           AND sh.status NOT IN ('HOLD', 'CANCELLED')
+           AND sl.line_status NOT IN ('HOLD', 'CANCELLED')
+           AND sl.due_month = #{settlementMonth}
+           AND c.insurer_id = #{insurerId}
+         ORDER BY sh.contract_id, sl.commission_item_id, sl.due_month,
+                  sl.installment_no, sl.schedule_line_id
+    </select>
+
+    <!-- 2026-08-12 yslee - 정규화된 원수사 명세 거래·귀속행을 실제 원자행으로 조회
+         기존 코드: 파일 또는 임시 대사 테이블을 전제로 한 실제 원천 조회가 없음
+         문제: REJECTED 명세나 DRAFT·취소·타 단계 거래가 실제 지급액에 섞일 수 있음
+         개선: 기존 statement_batch/commission_transaction/transaction_attribution에서 확정 지급 원자행만 조회 -->
+    <select id="findActualSources"
+            resultType="com.susukkang.fgc.reconciliation.dto.InsurerGaActualSourceRow">
+        SELECT ta.transaction_attribution_id AS transactionAttributionId,
+               ct.commission_transaction_id AS commissionTransactionId,
+               jh.journal_header_id AS journalHeaderId,
+               ta.contract_id AS contractId,
+               ct.commission_item_id AS commissionItemId,
+               ct.settlement_month AS settlementMonth,
+               ct.due_date AS dueDate,
+               ta.attributed_amount AS actualAmount,
+               ct.source_business_key AS sourceBusinessKey,
+               ta.source_agent_code AS sourceAgentCode
+          FROM fgc.statement_batch sb
+          JOIN fgc.commission_transaction ct
+            ON ct.statement_batch_id = sb.statement_batch_id
+          JOIN fgc.transaction_attribution ta
+            ON ta.commission_transaction_id = ct.commission_transaction_id
+          LEFT JOIN fgc.journal_header jh
+            ON jh.journal_type = 'ACTUAL_INSURER_STATEMENT'
+           AND jh.source_entity_type = 'COMMISSION_TRANSACTION'
+           AND jh.source_entity_id = CAST(ct.commission_transaction_id AS varchar)
+           AND jh.status = 'POSTED'
+         WHERE sb.insurer_id = #{insurerId}
+           AND sb.settlement_month = #{settlementMonth}
+           AND sb.statement_type = 'INSURER_COMMISSION'
+           AND sb.status IN ('AVAILABLE', 'VALIDATED', 'RECONCILED')
+           AND ct.insurer_id = #{insurerId}
+           AND ct.settlement_month = #{settlementMonth}
+           AND ct.payment_stage = 'INSURER_TO_GA'
+           AND ct.source_type = 'INSURER_STATEMENT'
+           AND ct.cashflow_type = 'PAYMENT'
+           AND ct.status = 'CONFIRMED'
+           AND ta.attribution_scope = 'CONTRACT'
+         ORDER BY ta.contract_id, ct.commission_item_id,
+                  COALESCE(ct.due_date, ct.settlement_month),
+                  ct.commission_transaction_id, ta.attribution_seq
+    </select>
+
+</mapper>

--- a/src/test/java/com/susukkang/fgc/reconciliation/InsurerGaReconciliationIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/InsurerGaReconciliationIntegrationTest.java
@@ -1,0 +1,289 @@
+package com.susukkang.fgc.reconciliation;
+
+import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.reconciliation.domain.ReconciliationResultType;
+import com.susukkang.fgc.reconciliation.dto.InsurerGaMatchCandidate;
+import com.susukkang.fgc.reconciliation.port.ReconciliationExecutionRequest;
+import com.susukkang.fgc.reconciliation.service.InsurerGaReconciliationMatcher;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 설명 : 실제 PostgreSQL에서 보험사→GA 대사 원천 필터와 매칭 결과를 검증
+ *
+ * @author yslee
+ * @since 2026-08-12
+ * @version 1.2
+ */
+@SpringBootTest
+@Transactional
+class InsurerGaReconciliationIntegrationTest {
+
+    private static final LocalDate TEST_MONTH = LocalDate.of(2098, 8, 1);
+
+    @Autowired
+    private InsurerGaReconciliationMatcher matcher;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void 기존_정규화_DB에서_운영_스케줄과_승인된_원수사_명세만_매칭한다() {
+        Long insurerId = id("SELECT insurer_id FROM fgc.insurer WHERE active_yn = true ORDER BY insurer_id LIMIT 1");
+        Long otherInsurerId = id("SELECT insurer_id FROM fgc.insurer WHERE active_yn = true AND insurer_id <> ? ORDER BY insurer_id LIMIT 1", insurerId);
+        Long contractId = id("SELECT contract_id FROM fgc.insurance_contract WHERE insurer_id = ? ORDER BY contract_id LIMIT 1", insurerId);
+        Long secondContractId = id("SELECT contract_id FROM fgc.insurance_contract WHERE insurer_id = ? AND contract_id <> ? ORDER BY contract_id LIMIT 1", insurerId, contractId);
+        Long otherContractId = id("SELECT contract_id FROM fgc.insurance_contract WHERE insurer_id = ? ORDER BY contract_id LIMIT 1", otherInsurerId);
+        Long policyVersionId = id("SELECT policy_version_id FROM fgc.policy_version ORDER BY policy_version_id LIMIT 1");
+        Long commissionItemId = id("SELECT commission_item_id FROM fgc.commission_item ORDER BY commission_item_id LIMIT 1");
+
+        Long expectedMatched = insertSchedule(contractId, policyVersionId, commissionItemId, "650000", true, "OPERATIONAL", 1);
+        Long expectedMissing = insertSchedule(secondContractId, policyVersionId, commissionItemId, "300000", true, "OPERATIONAL", 2);
+        insertSchedule(contractId, policyVersionId, commissionItemId, "777000", false, "OPERATIONAL", 3);
+        insertSchedule(contractId, policyVersionId, commissionItemId, "888000", true, "COMPARISON", 4);
+        insertSchedule(otherContractId, policyVersionId, commissionItemId, "999000", true, "OPERATIONAL", 1);
+
+        Long statementBatchId = insertStatementBatch(insurerId, TEST_MONTH, "VALIDATED", "VALID");
+        Long actualMatched = insertActual(statementBatchId, insurerId, contractId, commissionItemId,
+                TEST_MONTH, "650000", "MATCHED");
+
+        Long nextMonthBatchId = insertStatementBatch(insurerId, TEST_MONTH.plusMonths(1), "VALIDATED", "NEXT-MONTH");
+        Long nextMonthActual = insertActual(nextMonthBatchId, insurerId, contractId, commissionItemId,
+                TEST_MONTH.plusMonths(1), "100000", "NEXT-MONTH");
+
+        Long rejectedBatchId = insertStatementBatch(insurerId, TEST_MONTH, "REJECTED", "REJECTED");
+        insertActual(rejectedBatchId, insurerId, contractId, commissionItemId,
+                TEST_MONTH, "650000", "REJECTED");
+        Long otherInsurerBatchId = insertStatementBatch(otherInsurerId, TEST_MONTH, "VALIDATED", "OTHER-INSURER");
+        insertActual(otherInsurerBatchId, otherInsurerId, otherContractId, commissionItemId,
+                TEST_MONTH, "999000", "OTHER-INSURER");
+        Long agentId = id("SELECT agent_id FROM fgc.insurance_contract WHERE contract_id = ?", contractId);
+        Long gaToFcActual = insertGaToFcActual(
+                statementBatchId, insurerId, contractId, agentId, commissionItemId, "650000");
+
+        Long expectedJournalId = insertPostedJournal(
+                "EXPECTED_INSURER_INCOME", "SCHEDULE_LINE", expectedMatched,
+                contractId, commissionItemId, "650000", "EXPECTED_RECEIVABLE", "EXPECTED_INCOME");
+        Long actualTransactionId = id("""
+                SELECT commission_transaction_id
+                  FROM fgc.transaction_attribution
+                 WHERE transaction_attribution_id = ?
+                """, actualMatched);
+        Long actualJournalId = insertPostedJournal(
+                "ACTUAL_INSURER_STATEMENT", "COMMISSION_TRANSACTION", actualTransactionId,
+                contractId, commissionItemId, "650000", "ACTUAL_RECEIVABLE", "ACTUAL_INCOME");
+
+        List<InsurerGaMatchCandidate> results = matcher.match(new ReconciliationExecutionRequest(
+                99L, 88L, TEST_MONTH, PaymentStage.INSURER_TO_GA, insurerId, null));
+
+        assertThat(results).hasSize(2);
+        assertThat(results).anySatisfy(result -> {
+            assertThat(result.resultType()).isEqualTo(ReconciliationResultType.MATCHED);
+            assertThat(result.scheduleLineIds()).containsExactly(expectedMatched);
+            assertThat(result.transactionAttributionIds()).containsExactly(actualMatched);
+            assertThat(result.expectedJournalHeaderIds()).containsExactly(expectedJournalId);
+            assertThat(result.actualJournalHeaderIds()).containsExactly(actualJournalId);
+        });
+        assertThat(results).anySatisfy(result -> {
+            assertThat(result.resultType()).isEqualTo(ReconciliationResultType.ACTUAL_MISSING);
+            assertThat(result.scheduleLineIds()).containsExactly(expectedMissing);
+        });
+        assertThat(results).flatExtracting(InsurerGaMatchCandidate::transactionAttributionIds)
+                .doesNotContain(nextMonthActual, gaToFcActual);
+    }
+
+    @Test
+    void 동일_키_실제_귀속행_두개를_합쳐_정상으로_숨기지_않고_DUPLICATE로_표시한다() {
+        Long insurerId = id("SELECT insurer_id FROM fgc.insurer WHERE active_yn = true ORDER BY insurer_id LIMIT 1");
+        Long contractId = id("SELECT contract_id FROM fgc.insurance_contract WHERE insurer_id = ? ORDER BY contract_id LIMIT 1", insurerId);
+        Long policyVersionId = id("SELECT policy_version_id FROM fgc.policy_version ORDER BY policy_version_id LIMIT 1");
+        Long commissionItemId = id("SELECT commission_item_id FROM fgc.commission_item ORDER BY commission_item_id LIMIT 1");
+        Long expected = insertSchedule(contractId, policyVersionId, commissionItemId, "650000", true, "OPERATIONAL", 1);
+        Long statementBatchId = insertStatementBatch(insurerId, TEST_MONTH, "AVAILABLE", "DUPLICATE");
+        Long first = insertActual(statementBatchId, insurerId, contractId, commissionItemId,
+                TEST_MONTH, "300000", "DUP-1");
+        Long second = insertActual(statementBatchId, insurerId, contractId, commissionItemId,
+                TEST_MONTH, "350000", "DUP-2");
+
+        InsurerGaMatchCandidate result = matcher.match(new ReconciliationExecutionRequest(
+                99L, 88L, TEST_MONTH, PaymentStage.INSURER_TO_GA, insurerId, null)).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.DUPLICATE);
+        assertThat(result.expectedTotalAmount()).isEqualByComparingTo("650000");
+        assertThat(result.actualTotalAmount()).isEqualByComparingTo("650000");
+        assertThat(result.scheduleLineIds()).containsExactly(expected);
+        assertThat(result.transactionAttributionIds()).containsExactly(first, second);
+    }
+
+    private Long insertSchedule(
+            Long contractId,
+            Long policyVersionId,
+            Long commissionItemId,
+            String amount,
+            boolean active,
+            String purpose,
+            int installmentNo
+    ) {
+        Long headerId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.schedule_header (
+                    contract_id, payment_stage, policy_version_id, schedule_version_no,
+                    schedule_purpose, scenario_code, schedule_regime, active_yn
+                ) VALUES (?, 'INSURER_TO_GA', ?, ?, ?, ?, 'CURRENT', ?)
+                RETURNING schedule_header_id
+                """, Long.class,
+                contractId,
+                policyVersionId,
+                purpose.equals("OPERATIONAL") ? 100 + installmentNo : 200 + installmentNo,
+                purpose,
+                purpose.equals("OPERATIONAL") ? null : "IT-048-02",
+                active
+        );
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.schedule_line (
+                    schedule_header_id, line_no, installment_no, contract_month_no, due_date,
+                    commission_item_id, basis_code, basis_amount, calculation_type, fixed_amount,
+                    expected_amount
+                ) VALUES (?, 1, ?, ?, ?, ?, 'IT_RECONCILIATION', ?, 'FIXED', ?, ?)
+                RETURNING schedule_line_id
+                """, Long.class,
+                headerId, installmentNo, installmentNo, TEST_MONTH.plusDays(14),
+                commissionItemId, new BigDecimal(amount), new BigDecimal(amount), new BigDecimal(amount)
+        );
+    }
+
+    private Long insertStatementBatch(Long insurerId, LocalDate month, String status, String suffix) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.statement_batch (
+                    insurer_id, settlement_month, statement_type, external_statement_no,
+                    received_on, source_ref, status
+                ) VALUES (?, ?, 'INSURER_COMMISSION', ?, ?, ?, ?)
+                RETURNING statement_batch_id
+                """, Long.class,
+                insurerId, month, "IT-048-02-" + suffix, month.plusDays(20), "IT-048-02", status
+        );
+    }
+
+    private Long insertActual(
+            Long statementBatchId,
+            Long insurerId,
+            Long contractId,
+            Long commissionItemId,
+            LocalDate month,
+            String amount,
+            String suffix
+    ) {
+        Long transactionId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.commission_transaction (
+                    statement_batch_id, payment_stage, source_type, source_business_key,
+                    insurer_id, commission_item_id, settlement_month, due_date,
+                    amount, cashflow_type, status
+                ) VALUES (?, 'INSURER_TO_GA', 'INSURER_STATEMENT', ?, ?, ?, ?, ?, ?, 'PAYMENT', 'DRAFT')
+                RETURNING commission_transaction_id
+                """, Long.class,
+                statementBatchId, "IT-048-02:" + suffix, insurerId, commissionItemId,
+                month, month.plusDays(14), new BigDecimal(amount)
+        );
+        Long attributionId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.transaction_attribution (
+                    commission_transaction_id, attribution_seq, attribution_scope, contract_id,
+                    attribution_date, attribution_month, attributed_amount,
+                    inclusion_status_snapshot, attribution_method
+                ) VALUES (?, 1, 'CONTRACT', ?, ?, ?, ?, 'INCLUDED', 'DIRECT')
+                RETURNING transaction_attribution_id
+                """, Long.class, transactionId, contractId, month.plusDays(14), month, new BigDecimal(amount));
+        jdbcTemplate.update("""
+                UPDATE fgc.commission_transaction
+                   SET status = 'CONFIRMED'
+                 WHERE commission_transaction_id = ?
+                """, transactionId);
+        return attributionId;
+    }
+
+    private Long insertGaToFcActual(
+            Long statementBatchId,
+            Long insurerId,
+            Long contractId,
+            Long agentId,
+            Long commissionItemId,
+            String amount
+    ) {
+        Long transactionId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.commission_transaction (
+                    statement_batch_id, payment_stage, source_type, source_business_key,
+                    insurer_id, recipient_agent_id, commission_item_id, settlement_month,
+                    due_date, amount, cashflow_type, status
+                ) VALUES (?, 'GA_TO_FC', 'GA_CONFIRMED_PAYMENT', 'IT-048-02:GA-TO-FC',
+                          ?, ?, ?, ?, ?, ?, 'PAYMENT', 'DRAFT')
+                RETURNING commission_transaction_id
+                """, Long.class,
+                statementBatchId, insurerId, agentId, commissionItemId, TEST_MONTH,
+                TEST_MONTH.plusDays(14), new BigDecimal(amount)
+        );
+        Long attributionId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.transaction_attribution (
+                    commission_transaction_id, attribution_seq, attribution_scope, contract_id,
+                    agent_id, attribution_date, attribution_month, attributed_amount,
+                    inclusion_status_snapshot, attribution_method
+                ) VALUES (?, 1, 'CONTRACT', ?, ?, ?, ?, ?, 'INCLUDED', 'DIRECT')
+                RETURNING transaction_attribution_id
+                """, Long.class,
+                transactionId, contractId, agentId, TEST_MONTH.plusDays(14), TEST_MONTH,
+                new BigDecimal(amount)
+        );
+        jdbcTemplate.update("UPDATE fgc.commission_transaction SET status = 'CONFIRMED' WHERE commission_transaction_id = ?",
+                transactionId);
+        return attributionId;
+    }
+
+    private Long insertPostedJournal(
+            String journalType,
+            String sourceEntityType,
+            Long sourceEntityId,
+            Long contractId,
+            Long commissionItemId,
+            String amount,
+            String debitAccountCode,
+            String creditAccountCode
+    ) {
+        Long journalHeaderId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.journal_header (
+                    journal_no, journal_date, journal_type, source_entity_type,
+                    source_entity_id, contract_id, status
+                ) VALUES (?, ?, ?, ?, ?, ?, 'DRAFT')
+                RETURNING journal_header_id
+                """, Long.class,
+                "IT-048-02-" + journalType + "-" + sourceEntityId,
+                TEST_MONTH.plusDays(14), journalType, sourceEntityType,
+                String.valueOf(sourceEntityId), contractId
+        );
+        Long debitAccountId = id("SELECT journal_account_id FROM fgc.journal_account WHERE account_code = ?", debitAccountCode);
+        Long creditAccountId = id("SELECT journal_account_id FROM fgc.journal_account WHERE account_code = ?", creditAccountCode);
+        BigDecimal journalAmount = new BigDecimal(amount);
+        jdbcTemplate.update("""
+                INSERT INTO fgc.journal_line (
+                    journal_header_id, line_no, journal_account_id, debit_amount, credit_amount,
+                    contract_id, payment_stage, commission_item_id
+                ) VALUES (?, 1, ?, ?, 0, ?, 'INSURER_TO_GA', ?),
+                         (?, 2, ?, 0, ?, ?, 'INSURER_TO_GA', ?)
+                """,
+                journalHeaderId, debitAccountId, journalAmount, contractId, commissionItemId,
+                journalHeaderId, creditAccountId, journalAmount, contractId, commissionItemId
+        );
+        jdbcTemplate.update("UPDATE fgc.journal_header SET status = 'POSTED' WHERE journal_header_id = ?",
+                journalHeaderId);
+        return journalHeaderId;
+    }
+
+    private Long id(String sql, Object... args) {
+        return jdbcTemplate.queryForObject(sql, Long.class, args);
+    }
+}

--- a/src/test/java/com/susukkang/fgc/reconciliation/InsurerGaReconciliationIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/InsurerGaReconciliationIntegrationTest.java
@@ -193,6 +193,41 @@ class InsurerGaReconciliationIntegrationTest {
         assertThat(result.actualSourceAgentCode()).isEqualTo(otherSourceAgentCode);
     }
 
+    // 2026-08-13 yslee - PostgreSQL 실제 원천 회차 불일치 시나리오 추가
+    // 기존 코드: commission_transaction에 실제 회차가 없어 REC-07을 통합 환경에서 재현할 수 없음
+    // 문제: 예상 13회차·실제 14회차가 REVIEW_REQUIRED로만 남아 회차 불일치 건수 집계가 누락됨
+    // 개선: 정규화된 실제 회차를 조회해 INSTALLMENT_MISMATCH와 양쪽 비교값을 검증
+    @Test
+    void 예상_13회차와_실제_14회차를_INSTALLMENT_MISMATCH로_저장할_후보를_만든다() {
+        Long insurerId = id("SELECT insurer_id FROM fgc.insurer WHERE active_yn = true ORDER BY insurer_id LIMIT 1");
+        Long contractId = id("SELECT contract_id FROM fgc.insurance_contract WHERE insurer_id = ? ORDER BY contract_id LIMIT 1", insurerId);
+        Long policyVersionId = id("SELECT policy_version_id FROM fgc.policy_version ORDER BY policy_version_id LIMIT 1");
+        Long commissionItemId = id("SELECT commission_item_id FROM fgc.commission_item ORDER BY commission_item_id LIMIT 1");
+        Long contractAgentId = id("SELECT agent_id FROM fgc.insurance_contract WHERE contract_id = ?", contractId);
+        String sourceAgentCode = insertAgentInsurerCode(insurerId, contractAgentId, "INSTALLMENT-MISMATCH");
+
+        Long expected = insertSchedule(
+                contractId, policyVersionId, commissionItemId, "650000", true, "OPERATIONAL", 13);
+        Long statementBatchId = insertStatementBatch(
+                insurerId, TEST_MONTH, "VALIDATED", "INSTALLMENT-MISMATCH");
+        Long actual = insertActual(
+                statementBatchId, insurerId, contractId, commissionItemId,
+                TEST_MONTH, "650000", "INSTALLMENT-MISMATCH", sourceAgentCode, 14);
+        insertPostedJournal(
+                "EXPECTED_INSURER_INCOME", "SCHEDULE_LINE", expected,
+                contractId, commissionItemId, "650000", "EXPECTED_RECEIVABLE", "EXPECTED_INCOME");
+        insertPostedJournal(
+                "ACTUAL_INSURER_STATEMENT", "COMMISSION_TRANSACTION", transactionId(actual),
+                contractId, commissionItemId, "650000", "ACTUAL_RECEIVABLE", "ACTUAL_INCOME");
+
+        InsurerGaMatchCandidate result = matcher.match(new ReconciliationExecutionRequest(
+                99L, 88L, TEST_MONTH, PaymentStage.INSURER_TO_GA, insurerId, null)).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.INSTALLMENT_MISMATCH);
+        assertThat(result.installmentNo()).isEqualTo(13);
+        assertThat(result.actualInstallmentNo()).isEqualTo(14);
+    }
+
     private Long insertSchedule(
             Long contractId,
             Long policyVersionId,
@@ -251,16 +286,32 @@ class InsurerGaReconciliationIntegrationTest {
             String suffix,
             String sourceAgentCode
     ) {
+        return insertActual(
+                statementBatchId, insurerId, contractId, commissionItemId,
+                month, amount, suffix, sourceAgentCode, 1);
+    }
+
+    private Long insertActual(
+            Long statementBatchId,
+            Long insurerId,
+            Long contractId,
+            Long commissionItemId,
+            LocalDate month,
+            String amount,
+            String suffix,
+            String sourceAgentCode,
+            Integer installmentNo
+    ) {
         Long transactionId = jdbcTemplate.queryForObject("""
                 INSERT INTO fgc.commission_transaction (
                     statement_batch_id, payment_stage, source_type, source_business_key,
-                    insurer_id, commission_item_id, settlement_month, due_date,
+                    insurer_id, commission_item_id, installment_no, settlement_month, due_date,
                     amount, cashflow_type, status
-                ) VALUES (?, 'INSURER_TO_GA', 'INSURER_STATEMENT', ?, ?, ?, ?, ?, ?, 'PAYMENT', 'DRAFT')
+                ) VALUES (?, 'INSURER_TO_GA', 'INSURER_STATEMENT', ?, ?, ?, ?, ?, ?, ?, 'PAYMENT', 'DRAFT')
                 RETURNING commission_transaction_id
                 """, Long.class,
                 statementBatchId, "IT-048-02:" + suffix, insurerId, commissionItemId,
-                month, month.plusDays(14), new BigDecimal(amount)
+                installmentNo, month, month.plusDays(14), new BigDecimal(amount)
         );
         Long attributionId = jdbcTemplate.queryForObject("""
                 INSERT INTO fgc.transaction_attribution (

--- a/src/test/java/com/susukkang/fgc/reconciliation/InsurerGaReconciliationIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/InsurerGaReconciliationIntegrationTest.java
@@ -45,6 +45,8 @@ class InsurerGaReconciliationIntegrationTest {
         Long otherContractId = id("SELECT contract_id FROM fgc.insurance_contract WHERE insurer_id = ? ORDER BY contract_id LIMIT 1", otherInsurerId);
         Long policyVersionId = id("SELECT policy_version_id FROM fgc.policy_version ORDER BY policy_version_id LIMIT 1");
         Long commissionItemId = id("SELECT commission_item_id FROM fgc.commission_item ORDER BY commission_item_id LIMIT 1");
+        Long contractAgentId = id("SELECT agent_id FROM fgc.insurance_contract WHERE contract_id = ?", contractId);
+        String sourceAgentCode = insertAgentInsurerCode(insurerId, contractAgentId, "MATCHED");
 
         Long expectedMatched = insertSchedule(contractId, policyVersionId, commissionItemId, "650000", true, "OPERATIONAL", 1);
         Long expectedMissing = insertSchedule(secondContractId, policyVersionId, commissionItemId, "300000", true, "OPERATIONAL", 2);
@@ -54,25 +56,27 @@ class InsurerGaReconciliationIntegrationTest {
 
         Long statementBatchId = insertStatementBatch(insurerId, TEST_MONTH, "VALIDATED", "VALID");
         Long actualMatched = insertActual(statementBatchId, insurerId, contractId, commissionItemId,
-                TEST_MONTH, "650000", "MATCHED");
+                TEST_MONTH, "650000", "MATCHED", sourceAgentCode);
 
         Long nextMonthBatchId = insertStatementBatch(insurerId, TEST_MONTH.plusMonths(1), "VALIDATED", "NEXT-MONTH");
         Long nextMonthActual = insertActual(nextMonthBatchId, insurerId, contractId, commissionItemId,
-                TEST_MONTH.plusMonths(1), "100000", "NEXT-MONTH");
+                TEST_MONTH.plusMonths(1), "100000", "NEXT-MONTH", sourceAgentCode);
 
         Long rejectedBatchId = insertStatementBatch(insurerId, TEST_MONTH, "REJECTED", "REJECTED");
         insertActual(rejectedBatchId, insurerId, contractId, commissionItemId,
-                TEST_MONTH, "650000", "REJECTED");
+                TEST_MONTH, "650000", "REJECTED", sourceAgentCode);
         Long otherInsurerBatchId = insertStatementBatch(otherInsurerId, TEST_MONTH, "VALIDATED", "OTHER-INSURER");
         insertActual(otherInsurerBatchId, otherInsurerId, otherContractId, commissionItemId,
-                TEST_MONTH, "999000", "OTHER-INSURER");
-        Long agentId = id("SELECT agent_id FROM fgc.insurance_contract WHERE contract_id = ?", contractId);
+                TEST_MONTH, "999000", "OTHER-INSURER", null);
         Long gaToFcActual = insertGaToFcActual(
-                statementBatchId, insurerId, contractId, agentId, commissionItemId, "650000");
+                statementBatchId, insurerId, contractId, contractAgentId, commissionItemId, "650000");
 
         Long expectedJournalId = insertPostedJournal(
                 "EXPECTED_INSURER_INCOME", "SCHEDULE_LINE", expectedMatched,
                 contractId, commissionItemId, "650000", "EXPECTED_RECEIVABLE", "EXPECTED_INCOME");
+        insertPostedJournal(
+                "EXPECTED_INSURER_INCOME", "SCHEDULE_LINE", expectedMissing,
+                secondContractId, commissionItemId, "300000", "EXPECTED_RECEIVABLE", "EXPECTED_INCOME");
         Long actualTransactionId = id("""
                 SELECT commission_transaction_id
                   FROM fgc.transaction_attribution
@@ -107,12 +111,23 @@ class InsurerGaReconciliationIntegrationTest {
         Long contractId = id("SELECT contract_id FROM fgc.insurance_contract WHERE insurer_id = ? ORDER BY contract_id LIMIT 1", insurerId);
         Long policyVersionId = id("SELECT policy_version_id FROM fgc.policy_version ORDER BY policy_version_id LIMIT 1");
         Long commissionItemId = id("SELECT commission_item_id FROM fgc.commission_item ORDER BY commission_item_id LIMIT 1");
+        Long contractAgentId = id("SELECT agent_id FROM fgc.insurance_contract WHERE contract_id = ?", contractId);
+        String sourceAgentCode = insertAgentInsurerCode(insurerId, contractAgentId, "DUPLICATE");
         Long expected = insertSchedule(contractId, policyVersionId, commissionItemId, "650000", true, "OPERATIONAL", 1);
         Long statementBatchId = insertStatementBatch(insurerId, TEST_MONTH, "AVAILABLE", "DUPLICATE");
         Long first = insertActual(statementBatchId, insurerId, contractId, commissionItemId,
-                TEST_MONTH, "300000", "DUP-1");
+                TEST_MONTH, "300000", "DUP-1", sourceAgentCode);
         Long second = insertActual(statementBatchId, insurerId, contractId, commissionItemId,
-                TEST_MONTH, "350000", "DUP-2");
+                TEST_MONTH, "350000", "DUP-2", sourceAgentCode);
+        insertPostedJournal(
+                "EXPECTED_INSURER_INCOME", "SCHEDULE_LINE", expected,
+                contractId, commissionItemId, "650000", "EXPECTED_RECEIVABLE", "EXPECTED_INCOME");
+        insertPostedJournal(
+                "ACTUAL_INSURER_STATEMENT", "COMMISSION_TRANSACTION", transactionId(first),
+                contractId, commissionItemId, "300000", "ACTUAL_RECEIVABLE", "ACTUAL_INCOME");
+        insertPostedJournal(
+                "ACTUAL_INSURER_STATEMENT", "COMMISSION_TRANSACTION", transactionId(second),
+                contractId, commissionItemId, "350000", "ACTUAL_RECEIVABLE", "ACTUAL_INCOME");
 
         InsurerGaMatchCandidate result = matcher.match(new ReconciliationExecutionRequest(
                 99L, 88L, TEST_MONTH, PaymentStage.INSURER_TO_GA, insurerId, null)).getFirst();
@@ -122,6 +137,60 @@ class InsurerGaReconciliationIntegrationTest {
         assertThat(result.actualTotalAmount()).isEqualByComparingTo("650000");
         assertThat(result.scheduleLineIds()).containsExactly(expected);
         assertThat(result.transactionAttributionIds()).containsExactly(first, second);
+    }
+
+    // 2026-08-13 yslee - POSTED 분개와 원수사 설계사코드 매핑 대사 조건 검증
+    // 기존 코드: LEFT JOIN으로 분개가 없는 원천행도 대사에 포함되고 설계사코드는 판정에서 제외됨
+    // 문제: 원장 추적이 불가능한 결과와 다른 설계사의 동일 금액 결과가 MATCHED로 저장될 수 있음
+    // 개선: POSTED 분개 없는 행은 제외하고 유효한 코드 매핑이 다른 경우 AGENT_MISMATCH로 판정
+    @Test
+    void POSTED_분개가_없는_예상과_실제_원천은_대사대상에서_제외한다() {
+        Long insurerId = id("SELECT insurer_id FROM fgc.insurer WHERE active_yn = true ORDER BY insurer_id LIMIT 1");
+        Long contractId = id("SELECT contract_id FROM fgc.insurance_contract WHERE insurer_id = ? ORDER BY contract_id LIMIT 1", insurerId);
+        Long policyVersionId = id("SELECT policy_version_id FROM fgc.policy_version ORDER BY policy_version_id LIMIT 1");
+        Long commissionItemId = id("SELECT commission_item_id FROM fgc.commission_item ORDER BY commission_item_id LIMIT 1");
+        Long contractAgentId = id("SELECT agent_id FROM fgc.insurance_contract WHERE contract_id = ?", contractId);
+        String sourceAgentCode = insertAgentInsurerCode(insurerId, contractAgentId, "NO-JOURNAL");
+
+        insertSchedule(contractId, policyVersionId, commissionItemId, "650000", true, "OPERATIONAL", 1);
+        Long statementBatchId = insertStatementBatch(insurerId, TEST_MONTH, "VALIDATED", "NO-JOURNAL");
+        insertActual(statementBatchId, insurerId, contractId, commissionItemId,
+                TEST_MONTH, "650000", "NO-JOURNAL", sourceAgentCode);
+
+        List<InsurerGaMatchCandidate> results = matcher.match(new ReconciliationExecutionRequest(
+                99L, 88L, TEST_MONTH, PaymentStage.INSURER_TO_GA, insurerId, null));
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void 실제_원수사코드가_다른_설계사로_매핑되면_AGENT_MISMATCH다() {
+        Long insurerId = id("SELECT insurer_id FROM fgc.insurer WHERE active_yn = true ORDER BY insurer_id LIMIT 1");
+        Long contractId = id("SELECT contract_id FROM fgc.insurance_contract WHERE insurer_id = ? ORDER BY contract_id LIMIT 1", insurerId);
+        Long expectedAgentId = id("SELECT agent_id FROM fgc.insurance_contract WHERE contract_id = ?", contractId);
+        Long otherAgentId = id("SELECT agent_id FROM fgc.agent WHERE agent_id <> ? ORDER BY agent_id LIMIT 1", expectedAgentId);
+        Long policyVersionId = id("SELECT policy_version_id FROM fgc.policy_version ORDER BY policy_version_id LIMIT 1");
+        Long commissionItemId = id("SELECT commission_item_id FROM fgc.commission_item ORDER BY commission_item_id LIMIT 1");
+        String otherSourceAgentCode = insertAgentInsurerCode(insurerId, otherAgentId, "AGENT-MISMATCH");
+
+        Long expected = insertSchedule(contractId, policyVersionId, commissionItemId, "650000", true, "OPERATIONAL", 1);
+        Long statementBatchId = insertStatementBatch(insurerId, TEST_MONTH, "VALIDATED", "AGENT-MISMATCH");
+        Long actual = insertActual(statementBatchId, insurerId, contractId, commissionItemId,
+                TEST_MONTH, "650000", "AGENT-MISMATCH", otherSourceAgentCode);
+        insertPostedJournal(
+                "EXPECTED_INSURER_INCOME", "SCHEDULE_LINE", expected,
+                contractId, commissionItemId, "650000", "EXPECTED_RECEIVABLE", "EXPECTED_INCOME");
+        insertPostedJournal(
+                "ACTUAL_INSURER_STATEMENT", "COMMISSION_TRANSACTION", transactionId(actual),
+                contractId, commissionItemId, "650000", "ACTUAL_RECEIVABLE", "ACTUAL_INCOME");
+
+        InsurerGaMatchCandidate result = matcher.match(new ReconciliationExecutionRequest(
+                99L, 88L, TEST_MONTH, PaymentStage.INSURER_TO_GA, insurerId, null)).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.AGENT_MISMATCH);
+        assertThat(result.expectedAgentId()).isEqualTo(expectedAgentId);
+        assertThat(result.actualAgentId()).isEqualTo(otherAgentId);
+        assertThat(result.actualSourceAgentCode()).isEqualTo(otherSourceAgentCode);
     }
 
     private Long insertSchedule(
@@ -179,7 +248,8 @@ class InsurerGaReconciliationIntegrationTest {
             Long commissionItemId,
             LocalDate month,
             String amount,
-            String suffix
+            String suffix,
+            String sourceAgentCode
     ) {
         Long transactionId = jdbcTemplate.queryForObject("""
                 INSERT INTO fgc.commission_transaction (
@@ -195,17 +265,37 @@ class InsurerGaReconciliationIntegrationTest {
         Long attributionId = jdbcTemplate.queryForObject("""
                 INSERT INTO fgc.transaction_attribution (
                     commission_transaction_id, attribution_seq, attribution_scope, contract_id,
-                    attribution_date, attribution_month, attributed_amount,
+                    source_agent_code, attribution_date, attribution_month, attributed_amount,
                     inclusion_status_snapshot, attribution_method
-                ) VALUES (?, 1, 'CONTRACT', ?, ?, ?, ?, 'INCLUDED', 'DIRECT')
+                ) VALUES (?, 1, 'CONTRACT', ?, ?, ?, ?, ?, 'INCLUDED', 'DIRECT')
                 RETURNING transaction_attribution_id
-                """, Long.class, transactionId, contractId, month.plusDays(14), month, new BigDecimal(amount));
+                """, Long.class, transactionId, contractId, sourceAgentCode,
+                month.plusDays(14), month, new BigDecimal(amount));
         jdbcTemplate.update("""
                 UPDATE fgc.commission_transaction
                    SET status = 'CONFIRMED'
                  WHERE commission_transaction_id = ?
                 """, transactionId);
         return attributionId;
+    }
+
+    private Long transactionId(Long attributionId) {
+        return id("""
+                SELECT commission_transaction_id
+                  FROM fgc.transaction_attribution
+                 WHERE transaction_attribution_id = ?
+                """, attributionId);
+    }
+
+    private String insertAgentInsurerCode(Long insurerId, Long agentId, String suffix) {
+        String sourceAgentCode = "IT-048-02-" + suffix + "-" + agentId;
+        jdbcTemplate.update("""
+                INSERT INTO fgc.agent_insurer_code (
+                    insurer_id, agent_id, insurer_agent_code, code_status,
+                    effective_from, effective_to, source_ref
+                ) VALUES (?, ?, ?, 'ACTIVE', ?, NULL, 'IT-048-02')
+                """, insurerId, agentId, sourceAgentCode, TEST_MONTH);
+        return sourceAgentCode;
     }
 
     private Long insertGaToFcActual(

--- a/src/test/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImplTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImplTest.java
@@ -132,6 +132,63 @@ class InsurerGaReconciliationMatcherImplTest {
         assertThat(result.resultType()).isEqualTo(ReconciliationResultType.REVIEW_REQUIRED);
         assertThat(result.installmentNo()).isNull();
         assertThat(result.scheduleLineIds()).containsExactly(11L, 12L);
+        assertThat(result.secondaryReasonCodes())
+                .containsExactly(ReconciliationResultType.INSTALLMENT_MISMATCH.name());
+    }
+
+    // 2026-08-13 yslee - 미확정 회차와 행별 반올림 회귀 검증
+    // 기존 코드: null 회차가 정렬 중 예외를 내거나 금액이 같으면 MATCHED로 처리될 수 있었음
+    // 문제: 회차 정확일치와 상세행 단위 HALF_UP 규칙을 테스트가 보장하지 못함
+    // 개선: null 회차는 REVIEW_REQUIRED, 0.5원 상세행은 1원으로 반올림된 금액으로 판정
+    @Test
+    void 예상_회차가_null이면_금액이_같아도_REVIEW_REQUIRED다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, null, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, "650000", null)));
+
+        InsurerGaMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.REVIEW_REQUIRED);
+        assertThat(result.secondaryReasonCodes())
+                .containsExactly(ReconciliationResultType.INSTALLMENT_MISMATCH.name());
+    }
+
+    @Test
+    void 상세행_금액은_합산_전에_원단위_HALF_UP으로_반올림한다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 1, "0.5", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, "1", null)));
+
+        InsurerGaMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.MATCHED);
+        assertThat(result.expectedTotalAmount()).isEqualByComparingTo("1");
+        assertThat(result.actualTotalAmount()).isEqualByComparingTo("1");
+        assertThat(result.differenceAmount()).isEqualByComparingTo("0");
+    }
+
+    // 2026-08-13 yslee - 원수사 설계사코드 정규화 결과의 수취인 불일치 판정 검증
+    // 기존 코드: 실제 sourceAgentCode와 정규화된 agent_id를 읽고도 판정에 사용하지 않음
+    // 문제: 다른 설계사의 동일 금액 명세가 MATCHED로 숨겨질 수 있음
+    // 개선: 예상 계약 설계사와 실제 원수사코드 매핑 설계사가 다르면 AGENT_MISMATCH로 분류
+    @Test
+    void 예상과_실제_설계사가_다르면_금액이_같아도_AGENT_MISMATCH다() {
+        InsurerGaActualSourceRow actual = actual(21L, "650000", null);
+        actual.setActualAgentId(502L);
+        actual.setActualAgentMappingCount(1);
+        actual.setSourceAgentCode("INSURER-FC-502");
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 1, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L)).willReturn(List.of(actual));
+
+        InsurerGaMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.AGENT_MISMATCH);
+        assertThat(result.expectedAgentId()).isEqualTo(501L);
+        assertThat(result.actualAgentId()).isEqualTo(502L);
+        assertThat(result.actualSourceAgentCode()).isEqualTo("INSURER-FC-502");
     }
 
     @Test
@@ -177,7 +234,7 @@ class InsurerGaReconciliationMatcherImplTest {
 
     private static InsurerGaExpectedSourceRow expected(
             Long scheduleLineId,
-            int installmentNo,
+            Integer installmentNo,
             String amount,
             Long journalHeaderId
     ) {
@@ -185,6 +242,7 @@ class InsurerGaReconciliationMatcherImplTest {
         row.setScheduleLineId(scheduleLineId);
         row.setJournalHeaderId(journalHeaderId);
         row.setContractId(100L);
+        row.setExpectedAgentId(501L);
         row.setCommissionItemId(200L);
         row.setInstallmentNo(installmentNo);
         row.setDueDate(MONTH.plusDays(14));
@@ -203,11 +261,14 @@ class InsurerGaReconciliationMatcherImplTest {
         row.setCommissionTransactionId(attributionId + 1000);
         row.setJournalHeaderId(journalHeaderId);
         row.setContractId(100L);
+        row.setActualAgentId(501L);
+        row.setActualAgentMappingCount(1);
         row.setCommissionItemId(200L);
         row.setSettlementMonth(MONTH);
         row.setDueDate(MONTH.plusDays(14));
         row.setActualAmount(new BigDecimal(amount));
         row.setSourceBusinessKey("INSURER:TEST:" + attributionId);
+        row.setSourceAgentCode("INSURER-FC-501");
         return row;
     }
 }

--- a/src/test/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImplTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImplTest.java
@@ -191,6 +191,25 @@ class InsurerGaReconciliationMatcherImplTest {
         assertThat(result.actualSourceAgentCode()).isEqualTo("INSURER-FC-502");
     }
 
+    // 2026-08-13 yslee - 예상 설계사 식별값 누락 시 검토필요 회귀 테스트 추가
+    // 기존 코드: 실제 설계사가 정상 매핑되면 누락된 예상 설계사와 비교해 AGENT_MISMATCH로 판정
+    // 문제: 비교 기준이 없는 상태를 확정 불일치로 분류하여 수동 확인이 필요한 원천 오류를 숨김
+    // 개선: expectedAgentId가 없으면 실제 매핑이 정상이어도 REVIEW_REQUIRED로 분류되는지 검증
+    @Test
+    void 예상_설계사_식별값이_없으면_실제_매핑이_정상이어도_REVIEW_REQUIRED다() {
+        InsurerGaExpectedSourceRow expected = expected(11L, 1, "650000", null);
+        expected.setExpectedAgentId(null);
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L)).willReturn(List.of(expected));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, "650000", null)));
+
+        InsurerGaMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.REVIEW_REQUIRED);
+        assertThat(result.expectedAgentId()).isNull();
+        assertThat(result.actualAgentId()).isEqualTo(501L);
+    }
+
     @Test
     void 같은_월이어도_지급예정일이_다르면_정확일치로_합치지_않는다() {
         InsurerGaActualSourceRow actual = actual(21L, "650000", null);

--- a/src/test/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImplTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImplTest.java
@@ -1,0 +1,213 @@
+package com.susukkang.fgc.reconciliation.service;
+
+import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.reconciliation.domain.ReconciliationResultType;
+import com.susukkang.fgc.reconciliation.dto.InsurerGaActualSourceRow;
+import com.susukkang.fgc.reconciliation.dto.InsurerGaExpectedSourceRow;
+import com.susukkang.fgc.reconciliation.dto.InsurerGaMatchCandidate;
+import com.susukkang.fgc.reconciliation.mapper.InsurerGaReconciliationMapper;
+import com.susukkang.fgc.reconciliation.port.ReconciliationExecutionRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * 설명 : 보험사→GA 예상 스케줄·실제 명세 매칭 단위 테스트
+ *
+ * @author yslee
+ * @since 2026-08-12
+ * @version 1.2
+ */
+@ExtendWith(MockitoExtension.class)
+class InsurerGaReconciliationMatcherImplTest {
+
+    private static final LocalDate MONTH = LocalDate.of(2026, 8, 1);
+
+    @Mock
+    private InsurerGaReconciliationMapper reconciliationMapper;
+
+    private InsurerGaReconciliationMatcherImpl matcher;
+
+    @BeforeEach
+    void setUp() {
+        matcher = new InsurerGaReconciliationMatcherImpl(
+                reconciliationMapper,
+                new ZeroAmountTolerancePolicy()
+        );
+    }
+
+    @Test
+    void 같은_계약_항목_월의_예상과_실제_금액이_같으면_MATCHED다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 1, "650000", 101L)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, "650000", 201L)));
+
+        InsurerGaMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.MATCHED);
+        assertThat(result.installmentNo()).isEqualTo(1);
+        assertThat(result.differenceAmount()).isEqualByComparingTo("0");
+        assertThat(result.scheduleLineIds()).containsExactly(11L);
+        assertThat(result.transactionAttributionIds()).containsExactly(21L);
+        assertThat(result.expectedJournalHeaderIds()).containsExactly(101L);
+        assertThat(result.actualJournalHeaderIds()).containsExactly(201L);
+    }
+
+    @Test
+    void 실제가_1원_작으면_AMOUNT_DIFFERENCE이고_차액은_실제_빼기_예상이다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 1, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, "649999", null)));
+
+        InsurerGaMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.AMOUNT_DIFFERENCE);
+        assertThat(result.differenceAmount()).isEqualByComparingTo("-1");
+    }
+
+    @Test
+    void 실제가_없으면_ACTUAL_MISSING이고_예상이_없으면_EXPECTED_MISSING이다() {
+        InsurerGaExpectedSourceRow expected = expected(11L, 1, "650000", null);
+        InsurerGaActualSourceRow actual = actual(21L, "100000", null);
+        actual.setContractId(999L);
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L)).willReturn(List.of(expected));
+        given(reconciliationMapper.findActualSources(MONTH, 3L)).willReturn(List.of(actual));
+
+        List<InsurerGaMatchCandidate> results = matcher.match(request());
+
+        assertThat(results).extracting(InsurerGaMatchCandidate::resultType)
+                .containsExactly(ReconciliationResultType.ACTUAL_MISSING, ReconciliationResultType.EXPECTED_MISSING);
+    }
+
+    @Test
+    void 같은_키의_실제_명세가_둘이면_DUPLICATE이고_모든_ID를_보존한다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 1, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, "325000", null), actual(22L, "325000", null)));
+
+        InsurerGaMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.DUPLICATE);
+        assertThat(result.actualTotalAmount()).isEqualByComparingTo("650000");
+        assertThat(result.transactionAttributionIds()).containsExactly(21L, 22L);
+    }
+
+    @Test
+    void 예상이_없는_실제_명세도_둘이면_DUPLICATE이고_EXPECTED_MISSING을_보조사유로_남긴다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L)).willReturn(List.of());
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, "100000", null), actual(22L, "100000", null)));
+
+        InsurerGaMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.DUPLICATE);
+        assertThat(result.secondaryReasonCodes()).containsExactly(ReconciliationResultType.EXPECTED_MISSING.name());
+    }
+
+    @Test
+    void 같은_월에_예상_회차가_둘이면_회차를_추정하지_않고_REVIEW_REQUIRED다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(
+                        expected(11L, 1, "300000", null),
+                        expected(12L, 2, "350000", null)
+                ));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, "650000", null)));
+
+        InsurerGaMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.REVIEW_REQUIRED);
+        assertThat(result.installmentNo()).isNull();
+        assertThat(result.scheduleLineIds()).containsExactly(11L, 12L);
+    }
+
+    @Test
+    void 같은_월이어도_지급예정일이_다르면_정확일치로_합치지_않는다() {
+        InsurerGaActualSourceRow actual = actual(21L, "650000", null);
+        actual.setDueDate(MONTH.plusDays(15));
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 1, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L)).willReturn(List.of(actual));
+
+        List<InsurerGaMatchCandidate> results = matcher.match(request());
+
+        assertThat(results).extracting(InsurerGaMatchCandidate::resultType)
+                .containsExactly(ReconciliationResultType.ACTUAL_MISSING, ReconciliationResultType.EXPECTED_MISSING);
+    }
+
+    @Test
+    void 실제_명세의_지급예정일이_없으면_임의로_추정하지_않고_REVIEW_REQUIRED다() {
+        InsurerGaActualSourceRow actual = actual(21L, "650000", null);
+        actual.setDueDate(null);
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L)).willReturn(List.of());
+        given(reconciliationMapper.findActualSources(MONTH, 3L)).willReturn(List.of(actual));
+
+        InsurerGaMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.REVIEW_REQUIRED);
+        assertThat(result.matchGroupKey()).endsWith(":NA:NA");
+    }
+
+    @Test
+    void GA_TO_FC_요청은_FUN_048_02_범위가_아니므로_거절한다() {
+        ReconciliationExecutionRequest wrongStage = new ReconciliationExecutionRequest(
+                7L, 9L, MONTH, PaymentStage.GA_TO_FC, 3L, 5L);
+
+        assertThatThrownBy(() -> matcher.match(wrongStage))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("INSURER_TO_GA");
+    }
+
+    private static ReconciliationExecutionRequest request() {
+        return new ReconciliationExecutionRequest(7L, 9L, MONTH, PaymentStage.INSURER_TO_GA, 3L, 5L);
+    }
+
+    private static InsurerGaExpectedSourceRow expected(
+            Long scheduleLineId,
+            int installmentNo,
+            String amount,
+            Long journalHeaderId
+    ) {
+        InsurerGaExpectedSourceRow row = new InsurerGaExpectedSourceRow();
+        row.setScheduleLineId(scheduleLineId);
+        row.setJournalHeaderId(journalHeaderId);
+        row.setContractId(100L);
+        row.setCommissionItemId(200L);
+        row.setInstallmentNo(installmentNo);
+        row.setDueDate(MONTH.plusDays(14));
+        row.setDueMonth(MONTH);
+        row.setExpectedAmount(new BigDecimal(amount));
+        return row;
+    }
+
+    private static InsurerGaActualSourceRow actual(
+            Long attributionId,
+            String amount,
+            Long journalHeaderId
+    ) {
+        InsurerGaActualSourceRow row = new InsurerGaActualSourceRow();
+        row.setTransactionAttributionId(attributionId);
+        row.setCommissionTransactionId(attributionId + 1000);
+        row.setJournalHeaderId(journalHeaderId);
+        row.setContractId(100L);
+        row.setCommissionItemId(200L);
+        row.setSettlementMonth(MONTH);
+        row.setDueDate(MONTH.plusDays(14));
+        row.setActualAmount(new BigDecimal(amount));
+        row.setSourceBusinessKey("INSURER:TEST:" + attributionId);
+        return row;
+    }
+}

--- a/src/test/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImplTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/service/InsurerGaReconciliationMatcherImplTest.java
@@ -154,6 +154,41 @@ class InsurerGaReconciliationMatcherImplTest {
                 .containsExactly(ReconciliationResultType.INSTALLMENT_MISMATCH.name());
     }
 
+    // 2026-08-13 yslee - 예상·실제 회차 불일치 주 결과유형 회귀 테스트 추가
+    // 기존 코드: 실제 원천 회차가 없어 회차 관련 결과는 REVIEW_REQUIRED의 보조 사유로만 기록
+    // 문제: REC-07 예상 13회차·실제 14회차가 INSTALLMENT_MISMATCH로 집계되지 않음
+    // 개선: 양쪽 단일 회차가 명확하고 서로 다르면 INSTALLMENT_MISMATCH를 주 결과로 검증
+    @Test
+    void 예상_13회차와_실제_14회차는_INSTALLMENT_MISMATCH다() {
+        InsurerGaActualSourceRow actual = actual(21L, "650000", null);
+        actual.setActualInstallmentNo(14);
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 13, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L)).willReturn(List.of(actual));
+
+        InsurerGaMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.INSTALLMENT_MISMATCH);
+        assertThat(result.installmentNo()).isEqualTo(13);
+        assertThat(result.actualInstallmentNo()).isEqualTo(14);
+        assertThat(result.matchGroupKey()).contains("E13-A14");
+    }
+
+    @Test
+    void 실제_회차가_없으면_불일치로_단정하지_않고_REVIEW_REQUIRED다() {
+        InsurerGaActualSourceRow actual = actual(21L, "650000", null);
+        actual.setActualInstallmentNo(null);
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 13, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L)).willReturn(List.of(actual));
+
+        InsurerGaMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.REVIEW_REQUIRED);
+        assertThat(result.installmentNo()).isEqualTo(13);
+        assertThat(result.actualInstallmentNo()).isNull();
+    }
+
     @Test
     void 상세행_금액은_합산_전에_원단위_HALF_UP으로_반올림한다() {
         given(reconciliationMapper.findExpectedSources(MONTH, 3L))
@@ -234,7 +269,7 @@ class InsurerGaReconciliationMatcherImplTest {
         InsurerGaMatchCandidate result = matcher.match(request()).getFirst();
 
         assertThat(result.resultType()).isEqualTo(ReconciliationResultType.REVIEW_REQUIRED);
-        assertThat(result.matchGroupKey()).endsWith(":NA:NA");
+        assertThat(result.matchGroupKey()).endsWith(":ENA-A1:NA");
     }
 
     @Test
@@ -283,6 +318,7 @@ class InsurerGaReconciliationMatcherImplTest {
         row.setActualAgentId(501L);
         row.setActualAgentMappingCount(1);
         row.setCommissionItemId(200L);
+        row.setActualInstallmentNo(1);
         row.setSettlementMonth(MONTH);
         row.setDueDate(MONTH.plusDays(14));
         row.setActualAmount(new BigDecimal(amount));


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* FUN-048-02 보험사→GA 예상 스케줄과 원수사 실제 명세의 정규화 매칭을 구현했습니다.
* 기존 정규화 DB와 원장 구조를 재사용하고, 실제 회차 저장·검증을 위한 V18·V19 Flyway를 추가했습니다. 별도 API 문서는 추가하지 않았습니다.

## 🔗 2. 관련 이슈

* Closes #115

## 🛠 3. 구현 내용

* 활성 `OPERATIONAL` 보험사→GA 스케줄과 정상 상태의 원수사 명세·계약 귀속행만 조회합니다.
* 계약·수수료 항목·기준월·지급예정일을 기준으로 후보를 묶고 정규화된 예상·실제 회차를 직접 비교합니다. 회차 누락·복수 후보는 `REVIEW_REQUIRED`, 명확한 회차 차이는 `INSTALLMENT_MISMATCH`로 판정합니다.
* `MATCHED`, `AMOUNT_DIFFERENCE`, `EXPECTED_MISSING`, `ACTUAL_MISSING`, `DUPLICATE`, `REVIEW_REQUIRED`를 판정합니다.
* FUN-050 1차 정책에 따라 금액 허용오차를 0원으로 적용하고 정책 인터페이스와 구현체를 분리했습니다.
* 스케줄행·실제 귀속행·POSTED 예상/실제 분개 ID를 매칭 후보에 보존해 FUN-048-04 저장 단계에서 추적할 수 있게 했습니다.

## 🧪 4. 테스트 방법

1. 로컬 PostgreSQL을 실행합니다: `docker compose up -d db`
2. 관련 테스트를 실행합니다: `.\gradlew.bat test --tests com.susukkang.fgc.reconciliation.service.InsurerGaReconciliationMatcherImplTest --tests com.susukkang.fgc.reconciliation.InsurerGaReconciliationIntegrationTest`
3. 전체 빌드를 실행합니다: `.\gradlew.bat clean build`

## 🗄️ 5. DB / Flyway 변경

* [ ] DB 변경 없음
* [x] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* `V18__commission_transaction_installment_no.sql`
  * `commission_transaction.installment_no` nullable 컬럼 추가
  * 양수 CHECK를 `NOT VALID`로 등록하고 확정·취소 후 회차 변경 방지 트리거 추가
* `V19__validate_commission_transaction_installment_no.sql`
  * V18 CHECK 제약의 기존 데이터 검증을 별도 수행해 강한 잠금 시간을 최소화

## 📋 6. 리뷰 요구사항

* 실제 원수사 명세 회차를 `commission_transaction.installment_no`에 정규화해 저장하고 예상 회차와 직접 비교합니다. 회차 누락·복수 후보를 `REVIEW_REQUIRED`, 예상·실제 단일 회차 차이를 `INSTALLMENT_MISMATCH`로 나누는 경계를 확인해 주세요.
* 동일 키의 여러 원자행을 합산해 정상으로 숨기지 않고 `DUPLICATE`로 판정하면서 전체 원천 ID를 보존하는지 확인해 주세요.
* 이 PR은 매칭 후보 산출까지입니다. `reconciliation_result/reconciliation_match` 저장과 실행 상태 종결, `ReconciliationExecutionRequestPort` 실제 어댑터 연결은 FUN-048-04 범위입니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음

## 💬 9. 참고 사항

* 선행 PR #114가 아직 열려 있어 이번 변경만 분리해 검토할 수 있도록 base를 `feature/100-reconciliation-run-create-api`로 설정했습니다. #114 병합 후 base를 `develop`으로 변경해야 합니다.
* API 엔드포인트와 Swagger/API 명세 문서 변경은 없습니다. DB 변경은 위 V18·V19 마이그레이션에 한정됩니다.
* 최종 검증: 관련 단위·PostgreSQL 통합 테스트 성공, `.\gradlew.bat clean build` 성공.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 보험사와 GA 간 정산 데이터를 자동 대사합니다.
  * 계약, 회차, 지급일, 금액, 설계사 정보를 비교해 일치·누락·중복·불일치를 분류합니다.
  * 금액 차이와 주요 사유, 예상·실제 정산 정보를 제공합니다.
  * 회차나 설계사 매핑이 불명확한 건은 검토 대상으로 분류합니다.
  * 유효한 스케줄과 확정·게시된 거래 및 전표만 대사합니다.
  * 실제 분할 납부 회차를 관리하고 변경을 제한합니다.

* **테스트**
  * 정상 일치, 누락, 중복, 금액·지급일·설계사·회차 불일치 등 주요 시나리오를 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->