### PR TITLE
[Feat] FUN-042 검증 대상 계약·스케줄·명세 선별 #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ HELP.md
 
 # Gradle
 .gradle/
+.gradle-user/
 .gradle-codex/
 build/
 !gradle/wrapper/gradle-wrapper.jar

--- a/src/main/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobConfig.java
+++ b/src/main/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobConfig.java
@@ -1,11 +1,14 @@
 package com.susukkang.fgc.validation.batch;
 
+import com.susukkang.fgc.validation.batch.contract.LedgerImbalanceCheckPort;
 import com.susukkang.fgc.validation.batch.tasklet.CreateRunTasklet;
 import com.susukkang.fgc.validation.batch.tasklet.PlaceholderStepTasklet;
 import com.susukkang.fgc.validation.batch.tasklet.ReconciliationPlaceholderTasklet;
+import com.susukkang.fgc.validation.batch.tasklet.SelectTargetTasklet;
 import com.susukkang.fgc.validation.service.ValidationRunBatchLifecycleService;
 import com.susukkang.fgc.validation.service.ValidationRunBatchAuditService;
 import com.susukkang.fgc.validation.service.ValidationRunCreateService;
+import com.susukkang.fgc.validation.service.ValidationTargetSelectionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -83,7 +86,7 @@ public class MonthlyValidationJobConfig {
     @Bean
     public Step selectTargetStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
         return new StepBuilder("selectTargetStep", jobRepository)
-                .tasklet(new PlaceholderStepTasklet("②계약·상품버전·환급률표 선별"), transactionManager)
+                .tasklet(new SelectTargetTasklet(validationTargetSelectionService), transactionManager)
                 .listener(progressListener(2, false))
                 .build();
     }
@@ -95,7 +98,6 @@ public class MonthlyValidationJobConfig {
                 .listener(progressListener(3, false))
                 .build();
     }
-
     /**
      * capCheckStep의 실제 워크로드를 처리하는 "워커" Step
      */

--- a/src/main/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobConfig.java
+++ b/src/main/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobConfig.java
@@ -3,9 +3,11 @@ package com.susukkang.fgc.validation.batch;
 import com.susukkang.fgc.validation.batch.tasklet.CreateRunTasklet;
 import com.susukkang.fgc.validation.batch.tasklet.PlaceholderStepTasklet;
 import com.susukkang.fgc.validation.batch.tasklet.ReconciliationPlaceholderTasklet;
+import com.susukkang.fgc.validation.batch.tasklet.SelectTargetTasklet;
 import com.susukkang.fgc.validation.service.ValidationRunBatchLifecycleService;
 import com.susukkang.fgc.validation.service.ValidationRunBatchAuditService;
 import com.susukkang.fgc.validation.service.ValidationRunCreateService;
+import com.susukkang.fgc.validation.service.ValidationTargetSelectionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -34,6 +36,7 @@ public class MonthlyValidationJobConfig {
     private final ValidationRunCreateService validationRunCreateService;
     private final ValidationRunBatchLifecycleService validationRunBatchLifecycleService;
     private final ValidationRunBatchAuditService validationRunBatchAuditService;
+    private final ValidationTargetSelectionService validationTargetSelectionService;
 
     @Bean
     public Job monthlyValidationJob(JobRepository jobRepository,
@@ -79,7 +82,7 @@ public class MonthlyValidationJobConfig {
     @Bean
     public Step selectTargetStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
         return new StepBuilder("selectTargetStep", jobRepository)
-                .tasklet(new PlaceholderStepTasklet("②계약·상품버전·환급률표 선별"), transactionManager)
+                .tasklet(new SelectTargetTasklet(validationTargetSelectionService), transactionManager)
                 .listener(progressListener(2, false))
                 .build();
     }

--- a/src/main/java/com/susukkang/fgc/validation/batch/tasklet/SelectTargetTasklet.java
+++ b/src/main/java/com/susukkang/fgc/validation/batch/tasklet/SelectTargetTasklet.java
@@ -1,0 +1,44 @@
+package com.susukkang.fgc.validation.batch.tasklet;
+
+import com.susukkang.fgc.validation.batch.ValidationRunBatchContext;
+import com.susukkang.fgc.validation.dto.MonthlyValidationJobParameters;
+import com.susukkang.fgc.validation.service.ValidationTargetSelectionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+/**
+ * 설명 : SelectTargetTasklet
+ *
+ * @author hjKang
+ * @version 1.0
+ * @since 2026-08-13
+ */
+@RequiredArgsConstructor
+public class SelectTargetTasklet implements Tasklet {
+    private final ValidationTargetSelectionService selectionService;
+    @Override
+    public RepeatStatus execute(
+            StepContribution contribution,
+            ChunkContext chunkContext) {
+        JobParameters jobParameters = chunkContext.getStepContext()
+                .getStepExecution()
+                .getJobParameters();
+
+        MonthlyValidationJobParameters params =
+                MonthlyValidationJobParameters.from(jobParameters);
+
+        Long validationRunId =
+                ValidationRunBatchContext.getValidationRunId(chunkContext);
+
+        selectionService.selectTargets(
+                validationRunId,
+                params.validationMonth()
+        );
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/susukkang/fgc/validation/mapper/ValidationTargetSelectionMapper.java
+++ b/src/main/java/com/susukkang/fgc/validation/mapper/ValidationTargetSelectionMapper.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 public interface ValidationTargetSelectionMapper {
     int insertTargets(
             @Param("validationRunId") Long validationRunId,
-            @Param("validationMonth") LocalDate validationMonth
+            @Param("validationMonth") LocalDate validationMonth,
+            @Param("asOfDate") LocalDate asOfDate
     );
 }

--- a/src/main/java/com/susukkang/fgc/validation/mapper/ValidationTargetSelectionMapper.java
+++ b/src/main/java/com/susukkang/fgc/validation/mapper/ValidationTargetSelectionMapper.java
@@ -1,0 +1,21 @@
+package com.susukkang.fgc.validation.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDate;
+
+/**
+ * 설명 : ValidationTargetSelectionMapper
+ *
+ * @author hjKang
+ * @version 1.0
+ * @since 2026-08-13
+ */
+@Mapper
+public interface ValidationTargetSelectionMapper {
+    int insertTargets(
+            @Param("validationRunId") Long validationRunId,
+            @Param("validationMonth") LocalDate validationMonth
+    );
+}

--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationTargetSelectionService.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationTargetSelectionService.java
@@ -43,6 +43,7 @@ public class ValidationTargetSelectionService {
 
         return validationTargetSelectionMapper.insertTargets(
                 validationRunId,
+                validationMonth,
                 asOfDate
         );
     }

--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationTargetSelectionService.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationTargetSelectionService.java
@@ -1,0 +1,49 @@
+package com.susukkang.fgc.validation.service;
+
+import com.susukkang.fgc.validation.mapper.ValidationTargetSelectionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+/**
+ * 설명 : 배치 대상을 선별하기 위한 구현체
+ *
+ * @author hjKang
+ * @version 1.0
+ * @since 2026-08-13
+ */
+@Service
+@RequiredArgsConstructor
+public class ValidationTargetSelectionService {
+
+    private final ValidationTargetSelectionMapper validationTargetSelectionMapper;
+
+    /**
+     * 설명 : 월 통합검증 실행의 검증월과 실행 유형을 기준으로 검증 대상 계약 및 관련 데이터를 선별한다.
+     *
+     * @param validationRunId 월 통합검증 실행 ID
+     * @param validationMonth 검증 대상 월
+     * @return 선별된 검증 대상 건수
+     * @author hjKang
+     * @since 2026-08-13
+     */
+    @Transactional
+    public int selectTargets(Long validationRunId, LocalDate validationMonth) {
+        if (validationRunId == null) {
+            throw new IllegalArgumentException("월 통합검증 실행 ID가 없습니다.");
+        }
+        if (validationMonth == null) {
+            throw new IllegalArgumentException("검증 대상 월이 없습니다.");
+        }
+
+        LocalDate asOfDate =
+                validationMonth.withDayOfMonth(validationMonth.lengthOfMonth());
+
+        return validationTargetSelectionMapper.insertTargets(
+                validationRunId,
+                asOfDate
+        );
+    }
+}

--- a/src/main/resources/mapper/validation/ValidationTargetSelectionMapper.xml
+++ b/src/main/resources/mapper/validation/ValidationTargetSelectionMapper.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.susukkang.fgc.validation.mapper.ValidationTargetSelectionMapper">
+
+    <insert id="insertTargets">
+        INSERT INTO validation_target (
+            validation_run_id,
+            contract_id,
+            product_offering_id,
+            refund_rate_table_id,
+            selection_status,
+            selection_reason,
+            snapshot
+        )
+        SELECT
+            #{validationRunId},
+            ic.contract_id,
+            ic.product_offering_id,
+            rrt.refund_rate_table_id,
+            CASE
+                WHEN rrt.refund_rate_table_id IS NULL THEN 'REVIEW_REQUIRED'
+                ELSE 'SELECTED'
+            END,
+            CASE
+                WHEN rrt.refund_rate_table_id IS NULL THEN '예상 해약환급률표 없음'
+                ELSE '월 통합검증 대상'
+            END,
+            jsonb_build_object(
+                'validationMonth', #{validationMonth},
+                'contractDate', ic.contract_date,
+                'contractStatus', ic.current_status,
+                'insurerId', ic.insurer_id,
+                'paymentTermMonths', ic.payment_term_months,
+                'channelCode', po.channel_code
+            )
+        FROM insurance_contract ic
+        JOIN product_offering po
+          ON po.product_offering_id = ic.product_offering_id
+        LEFT JOIN refund_rate_table rrt
+          ON rrt.insurer_id = ic.insurer_id
+         AND rrt.product_id = po.product_id
+         AND rrt.payment_term_months = ic.payment_term_months
+         AND rrt.channel_code = po.channel_code
+         AND rrt.effective_from <![CDATA[ <= ]]> #{validationMonth}
+         AND (
+             rrt.effective_to IS NULL
+             OR rrt.effective_to <![CDATA[ >= ]]> #{validationMonth}
+         )
+        WHERE ic.current_status = 'ACTIVE'
+          AND ic.contract_date <![CDATA[ <= ]]> #{validationMonth}
+        ON CONFLICT (validation_run_id, contract_id)
+        DO NOTHING
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/validation/ValidationTargetSelectionMapper.xml
+++ b/src/main/resources/mapper/validation/ValidationTargetSelectionMapper.xml
@@ -6,6 +6,71 @@
 <mapper namespace="com.susukkang.fgc.validation.mapper.ValidationTargetSelectionMapper">
 
     <insert id="insertTargets">
+        WITH eligible_contract AS (
+            SELECT ic.contract_id,
+                   ic.product_offering_id,
+                   ic.contract_date,
+                   ic.current_status,
+                   ic.insurer_id,
+                   ic.payment_term_months,
+                   po.product_id,
+                   po.channel_code,
+                   p.insurer_product_code
+              FROM insurance_contract ic
+              JOIN product_offering po
+                ON po.product_offering_id = ic.product_offering_id
+               AND po.active_yn = true
+               AND po.sales_start_date <![CDATA[ <= ]]> ic.contract_date
+               AND (po.sales_end_date IS NULL OR po.sales_end_date <![CDATA[ >= ]]> ic.contract_date)
+              JOIN product p
+                ON p.product_id = po.product_id
+               AND p.active_yn = true
+             WHERE ic.current_status = 'ACTIVE'
+               AND ic.contract_date <![CDATA[ <= ]]> #{asOfDate}
+        ),
+        candidate AS (
+            SELECT ec.*,
+                   rrt.refund_rate_table_id,
+                   (rrt.source_product_code = ec.insurer_product_code) AS product_code_matches
+              FROM eligible_contract ec
+              LEFT JOIN refund_rate_table rrt
+                ON rrt.insurer_id = ec.insurer_id
+               AND rrt.product_id = ec.product_id
+               AND rrt.payment_term_months = ec.payment_term_months
+               AND rrt.channel_code = ec.channel_code
+               AND rrt.effective_from <![CDATA[ <= ]]> #{asOfDate}
+               AND (rrt.effective_to IS NULL OR rrt.effective_to <![CDATA[ >= ]]> #{asOfDate})
+               AND EXISTS (
+                    SELECT 1
+                      FROM policy_version pv
+                     WHERE pv.policy_version_id = rrt.policy_version_id
+                       AND pv.status = 'ACTIVE'
+                       AND pv.effective_from <![CDATA[ <= ]]> #{asOfDate}
+                       AND (pv.effective_to IS NULL OR pv.effective_to <![CDATA[ >= ]]> #{asOfDate})
+               )
+               AND EXISTS (
+                    SELECT 1
+                      FROM refund_rate_line rrl
+                     WHERE rrl.refund_rate_table_id = rrt.refund_rate_table_id
+                       AND rrl.contract_month_no = 12
+               )
+        ),
+        resolved AS (
+            SELECT contract_id,
+                   product_offering_id,
+                   contract_date,
+                   current_status,
+                   insurer_id,
+                   payment_term_months,
+                   channel_code,
+                   insurer_product_code,
+                   COUNT(refund_rate_table_id) AS candidate_count,
+                   COUNT(refund_rate_table_id) FILTER (WHERE product_code_matches) AS matching_count,
+                   MIN(refund_rate_table_id) FILTER (WHERE product_code_matches) AS refund_rate_table_id
+              FROM candidate
+             GROUP BY contract_id, product_offering_id, contract_date, current_status,
+                      insurer_id, payment_term_months, channel_code, insurer_product_code
+        )
         INSERT INTO validation_target (
             validation_run_id,
             contract_id,
@@ -15,42 +80,30 @@
             selection_reason,
             snapshot
         )
-        SELECT
-            #{validationRunId},
-            ic.contract_id,
-            ic.product_offering_id,
-            rrt.refund_rate_table_id,
-            CASE
-                WHEN rrt.refund_rate_table_id IS NULL THEN 'REVIEW_REQUIRED'
-                ELSE 'SELECTED'
-            END,
-            CASE
-                WHEN rrt.refund_rate_table_id IS NULL THEN '예상 해약환급률표 없음'
-                ELSE '월 통합검증 대상'
-            END,
-            jsonb_build_object(
-                'validationMonth', #{validationMonth},
-                'contractDate', ic.contract_date,
-                'contractStatus', ic.current_status,
-                'insurerId', ic.insurer_id,
-                'paymentTermMonths', ic.payment_term_months,
-                'channelCode', po.channel_code
-            )
-        FROM insurance_contract ic
-        JOIN product_offering po
-          ON po.product_offering_id = ic.product_offering_id
-        LEFT JOIN refund_rate_table rrt
-          ON rrt.insurer_id = ic.insurer_id
-         AND rrt.product_id = po.product_id
-         AND rrt.payment_term_months = ic.payment_term_months
-         AND rrt.channel_code = po.channel_code
-         AND rrt.effective_from <![CDATA[ <= ]]> #{validationMonth}
-         AND (
-             rrt.effective_to IS NULL
-             OR rrt.effective_to <![CDATA[ >= ]]> #{validationMonth}
-         )
-        WHERE ic.current_status = 'ACTIVE'
-          AND ic.contract_date <![CDATA[ <= ]]> #{validationMonth}
+        SELECT #{validationRunId},
+               contract_id,
+               product_offering_id,
+               CASE WHEN matching_count = 1 THEN refund_rate_table_id END,
+               CASE WHEN matching_count = 1 THEN 'SELECTED' ELSE 'REVIEW_REQUIRED' END,
+               CASE
+                   WHEN candidate_count = 0 THEN '예상 해약환급률표 없음'
+                   WHEN matching_count = 0 THEN '상품코드 불일치'
+                   WHEN matching_count > 1 THEN '예상 해약환급률표 중복'
+                   ELSE '월 통합검증 대상'
+               END,
+               jsonb_build_object(
+                   'validationMonth', #{validationMonth},
+                   'asOfDate', #{asOfDate},
+                   'contractDate', contract_date,
+                   'contractStatus', current_status,
+                   'insurerId', insurer_id,
+                   'paymentTermMonths', payment_term_months,
+                   'channelCode', channel_code,
+                   'insurerProductCode', insurer_product_code,
+                   'refundRateCandidateCount', candidate_count,
+                   'refundRateMatchingCount', matching_count
+               )
+          FROM resolved
         ON CONFLICT (validation_run_id, contract_id)
         DO NOTHING
     </insert>

--- a/src/test/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobIntegrationTest.java
@@ -62,8 +62,12 @@ class MonthlyValidationJobIntegrationTest {
 
     @AfterEach
     void cleanUp() {
-        createdValidationRunIds.forEach(id -> jdbcTemplate.update(
-                "DELETE FROM fgc.validation_run WHERE validation_run_id = ?", id));
+        createdValidationRunIds.forEach(id -> {
+            jdbcTemplate.update(
+                    "DELETE FROM fgc.validation_target WHERE validation_run_id = ?", id);
+            jdbcTemplate.update(
+                    "DELETE FROM fgc.validation_run WHERE validation_run_id = ?", id);
+        });
     }
 
     // JobRepository 메타테이블은 이 테스트가 지우지 않는다(validation_run만 지운다) — 그래서
@@ -90,11 +94,24 @@ class MonthlyValidationJobIntegrationTest {
     }
 
     @Test
-    void blocksPlaceholderExecutionAndDoesNotCompleteTheValidationRun() throws Exception {
+    /**
+     * @author hjKang
+     * @since 2026-08-13
+     *
+     * 2026-08-13 - 대상 선별 Step 구현에 따른 월 통합검증 실행 흐름 검증 변경
+     * 기존 코드: createRunStep 완료 후 selectTargetStep의 Placeholder에서 실행이 실패했다.
+     * 문제: selectTargetStep이 실제 구현으로 교체되어 기존 완료 Step 기대값과 일치하지 않았다.
+     * 개선: 대상 선별 Step 완료 후 다음 미구현 Step에서 실행이 차단되는지 검증한다.
+     */
+    void completesTargetSelectionAndBlocksAtNextPlaceholder() throws Exception {
         jobLauncherTestUtils.setJob(monthlyValidationJob);
         long runNo = ThreadLocalRandom.current().nextLong(1, Integer.MAX_VALUE);
 
         JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters("req-1", runNo));
+
+        Long validationRunId = ValidationRunBatchContext.getValidationRunId(jobExecution.getExecutionContext());
+        assertThat(validationRunId).isNotNull();
+        createdValidationRunIds.add(validationRunId);
 
         assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.FAILED);
 
@@ -103,17 +120,16 @@ class MonthlyValidationJobIntegrationTest {
                 .map(StepExecution::getStepName)
                 .collect(Collectors.toSet());
 
-        assertThat(completedStepNames).containsExactly("createRunStep");
+        assertThat(completedStepNames).containsExactlyInAnyOrder(
+                "createRunStep",
+                "selectTargetStep"
+        );
 
         // capCheckStep은 INSURER_TO_GA/GA_TO_FC 2개 파티션 워커로 나뉘어 실행돼야 한다.
         long capCheckWorkerCount = jobExecution.getStepExecutions().stream()
                 .filter(se -> se.getStepName().startsWith("capCheckWorkerStep"))
                 .count();
         assertThat(capCheckWorkerCount).isZero();
-
-        Long validationRunId = ValidationRunBatchContext.getValidationRunId(jobExecution.getExecutionContext());
-        assertThat(validationRunId).isNotNull();
-        createdValidationRunIds.add(validationRunId);
 
         ValidationRunRow row = validationRunMapper.findById(validationRunId);
         assertThat(row.getStatus()).isEqualTo("FAILED");
@@ -124,11 +140,21 @@ class MonthlyValidationJobIntegrationTest {
     }
 
     @Test
+    /**
+     * @author hjKang
+     * @since 2026-08-13
+     *
+     * 2026-08-13 - 잘못된 파라미터 실행의 데이터 생성 여부 검증 범위 보완
+     * 기존 코드: 동일 검증월의 validation_run 전체가 비어 있는지 확인했다.
+     * 문제: 다른 테스트나 기존 데이터가 같은 검증월을 사용하면 테스트가 독립적으로 동작하지 않았다.
+     * 개선: 이번 테스트에서 사용한 고유 실행 번호에 해당하는 행만 생성되지 않았는지 확인한다.
+     */
     void rejectsInvalidJobParametersBeforeCreatingAnyRun() {
         jobLauncherTestUtils.setJob(monthlyValidationJob);
+        long runNo = ThreadLocalRandom.current().nextLong(1, Integer.MAX_VALUE);
         JobParameters invalidParams = new JobParametersBuilder()
                 .addString("validationMonth", "2031/03")
-                .addLong("runNo", 1L)
+                .addLong("runNo", runNo)
                 .addString("runType", "MONTHLY")
                 .addLong("triggeredBy", 3L)
                 .addString("requestId", "req-invalid")
@@ -139,7 +165,9 @@ class MonthlyValidationJobIntegrationTest {
                 () -> jobLauncherTestUtils.launchJob(invalidParams));
 
         List<Map<String, Object>> rows = jdbcTemplate.queryForList(
-                "SELECT 1 FROM fgc.validation_run WHERE validation_month = ?", TEST_MONTH);
+                "SELECT 1 FROM fgc.validation_run WHERE validation_month = ? AND run_no = ?",
+                TEST_MONTH,
+                runNo);
         assertThat(rows).isEmpty();
     }
 }

--- a/src/test/java/com/susukkang/fgc/validation/batch/tasklet/SelectTargetTaskletTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/batch/tasklet/SelectTargetTaskletTest.java
@@ -1,0 +1,61 @@
+package com.susukkang.fgc.validation.batch.tasklet;
+
+import com.susukkang.fgc.validation.batch.ValidationRunBatchContext;
+import com.susukkang.fgc.validation.service.ValidationTargetSelectionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.repeat.RepeatStatus;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SelectTargetTaskletTest {
+
+    @Mock
+    private ValidationTargetSelectionService selectionService;
+
+    private SelectTargetTasklet tasklet;
+
+    @BeforeEach
+    void setUp() {
+        tasklet = new SelectTargetTasklet(selectionService);
+    }
+
+    @Test
+    void delegatesValidationRunIdAndMonthToSelectionService() {
+        ChunkContext chunkContext = newChunkContext();
+        ValidationRunBatchContext.putValidationRunId(chunkContext, 118L);
+
+        RepeatStatus result = tasklet.execute(null, chunkContext);
+
+        assertThat(result).isEqualTo(RepeatStatus.FINISHED);
+        verify(selectionService).selectTargets(118L, LocalDate.of(2026, 8, 1));
+    }
+
+    private ChunkContext newChunkContext() {
+        JobParameters parameters = new JobParametersBuilder()
+                .addString("validationMonth", "2026-08")
+                .addLong("runNo", 1L)
+                .addString("runType", "MONTHLY")
+                .addLong("triggeredBy", 1L)
+                .addString("requestId", "req-select-target-1")
+                .toJobParameters();
+        JobExecution jobExecution = new JobExecution(
+                new JobInstance(1L, "MonthlyValidationJob"), parameters);
+        StepExecution stepExecution = new StepExecution("selectTargetStep", jobExecution);
+        return new ChunkContext(new StepContext(stepExecution));
+    }
+}

--- a/src/test/java/com/susukkang/fgc/validation/service/ValidationTargetSelectionServiceTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ValidationTargetSelectionServiceTest.java
@@ -30,14 +30,15 @@ class ValidationTargetSelectionServiceTest {
 
     @Test
     void selectsTargetsUsingLastDayOfValidationMonth() {
-        when(validationTargetSelectionMapper.insertTargets(118L, LocalDate.of(2026, 8, 31)))
+        when(validationTargetSelectionMapper.insertTargets(
+                118L, LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 31)))
                 .thenReturn(15);
 
         int selectedCount = service.selectTargets(118L, LocalDate.of(2026, 8, 1));
 
         assertThat(selectedCount).isEqualTo(15);
         verify(validationTargetSelectionMapper)
-                .insertTargets(118L, LocalDate.of(2026, 8, 31));
+                .insertTargets(118L, LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 31));
     }
 
     @Test
@@ -45,7 +46,7 @@ class ValidationTargetSelectionServiceTest {
         service.selectTargets(118L, LocalDate.of(2028, 2, 1));
 
         verify(validationTargetSelectionMapper)
-                .insertTargets(118L, LocalDate.of(2028, 2, 29));
+                .insertTargets(118L, LocalDate.of(2028, 2, 1), LocalDate.of(2028, 2, 29));
     }
 
     @Test
@@ -54,7 +55,7 @@ class ValidationTargetSelectionServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("월 통합검증 실행 ID가 없습니다.");
 
-        verify(validationTargetSelectionMapper, never()).insertTargets(null, LocalDate.of(2026, 8, 31));
+        verify(validationTargetSelectionMapper, never()).insertTargets(null, LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 31));
     }
 
     @Test
@@ -63,6 +64,6 @@ class ValidationTargetSelectionServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("검증 대상 월이 없습니다.");
 
-        verify(validationTargetSelectionMapper, never()).insertTargets(118L, null);
+        verify(validationTargetSelectionMapper, never()).insertTargets(118L, null, null);
     }
 }

--- a/src/test/java/com/susukkang/fgc/validation/service/ValidationTargetSelectionServiceTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ValidationTargetSelectionServiceTest.java
@@ -1,0 +1,68 @@
+package com.susukkang.fgc.validation.service;
+
+import com.susukkang.fgc.validation.mapper.ValidationTargetSelectionMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ValidationTargetSelectionServiceTest {
+
+    @Mock
+    private ValidationTargetSelectionMapper validationTargetSelectionMapper;
+
+    private ValidationTargetSelectionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ValidationTargetSelectionService(validationTargetSelectionMapper);
+    }
+
+    @Test
+    void selectsTargetsUsingLastDayOfValidationMonth() {
+        when(validationTargetSelectionMapper.insertTargets(118L, LocalDate.of(2026, 8, 31)))
+                .thenReturn(15);
+
+        int selectedCount = service.selectTargets(118L, LocalDate.of(2026, 8, 1));
+
+        assertThat(selectedCount).isEqualTo(15);
+        verify(validationTargetSelectionMapper)
+                .insertTargets(118L, LocalDate.of(2026, 8, 31));
+    }
+
+    @Test
+    void calculatesLastDayForLeapYearFebruary() {
+        service.selectTargets(118L, LocalDate.of(2028, 2, 1));
+
+        verify(validationTargetSelectionMapper)
+                .insertTargets(118L, LocalDate.of(2028, 2, 29));
+    }
+
+    @Test
+    void rejectsMissingValidationRunId() {
+        assertThatThrownBy(() -> service.selectTargets(null, LocalDate.of(2026, 8, 1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("월 통합검증 실행 ID가 없습니다.");
+
+        verify(validationTargetSelectionMapper, never()).insertTargets(null, LocalDate.of(2026, 8, 31));
+    }
+
+    @Test
+    void rejectsMissingValidationMonth() {
+        assertThatThrownBy(() -> service.selectTargets(118L, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("검증 대상 월이 없습니다.");
+
+        verify(validationTargetSelectionMapper, never()).insertTargets(118L, null);
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- 월 통합검증 대상 선별 Step의 기본 실행 구조를 구현했습니다.
- 활성 계약과 예상 해약환급률표를 연결하여 `validation_target`에 저장합니다.

## 🔗 2. 관련 이슈

* Closes #121

## 🛠 3. 구현 내용

- `selectTargetStep`의 Placeholder를 실제 `SelectTargetTasklet`으로 교체했습니다.
- 검증월 말일 기준으로 활성 계약을 선별합니다.
- 보험사·상품·납입기간·판매채널 기준으로 환급률표를 연결합니다.
- 환급률표가 없으면 `REVIEW_REQUIRED`, 존재하면 `SELECTED`로 저장합니다.
- 동일 실행·계약은 중복 저장하지 않습니다.

## 🧪 4. 테스트 방법

1. `ValidationTargetSelectionServiceTest`를 실행합니다.
2. `SelectTargetTaskletTest`를 실행합니다.
3. 월말 기준일 변환과 Tasklet의 실행 ID·검증월 전달을 확인합니다.

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

- 환급률표 연결 조건과 `SELECTED`/`REVIEW_REQUIRED` 분류 기준을 확인해주세요.
- 이번 PR은 FUN-042의 1차 부분 구현입니다.

## ✅ 7. 체크리스트

* [ ] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [ ] 기존 기능에 영향이 없는지 확인했습니다.
* [ ] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음

## 💬 9. 참고 사항

- 현재는 활성 계약 선별과 환급률표 연결까지만 구현했습니다.
- 제외 대상 분류, 환급률표 중복 처리, 예외 생성 및 상세 스냅샷 보강은 후속 구현이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 월별 검증 실행 시 활성 계약을 기준으로 검증 대상이 자동 선정됩니다.
  * 환급률표의 상품 일치 여부와 후보 수에 따라 검증 상태가 구분됩니다.
  * 검증 월, 기준일, 계약·보험사·채널 정보가 검증 기록에 저장됩니다.
  * 동일 계약의 중복 등록을 방지합니다.

* **개선 사항**
  * 월말 및 윤년 2월을 기준으로 대상이 정확히 선정됩니다.
  * 필수 정보가 누락된 경우 대상 선정이 진행되지 않습니다.

* **테스트**
  * 대상 선정과 월별 검증 흐름 검증이 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->