### PR TITLE
[Feat] FUN-046 #4 계약 원장 및 거래 조회 Projection

### DIFF
--- a/src/main/java/com/susukkang/fgc/common/code/CommissionPaymentStatus.java
+++ b/src/main/java/com/susukkang/fgc/common/code/CommissionPaymentStatus.java
@@ -10,5 +10,14 @@ package com.susukkang.fgc.common.code;
 public enum CommissionPaymentStatus {
     DRAFT,
     CONFIRMED,
-    CANCELLED
+    CANCELLED;
+
+    /** 화면정의서 "지급 건 상태" 코드-표기 매핑표(docs/FGC_화면정의서_v2_0.md:250-256)와 일치시킨다. */
+    public String label() {
+        return switch (this) {
+            case DRAFT -> "작성중";
+            case CONFIRMED -> "확정";
+            case CANCELLED -> "취소";
+        };
+    }
 }

--- a/src/main/java/com/susukkang/fgc/common/code/InclusionDecisionStatus.java
+++ b/src/main/java/com/susukkang/fgc/common/code/InclusionDecisionStatus.java
@@ -12,13 +12,14 @@ public enum InclusionDecisionStatus {
     EXCLUDED,
     REVIEW_REQUIRED;
 
-    // 화면정의서에 이 컬럼(transaction_attribution.inclusion_status_snapshot) 전용 표기
-    // 매핑표가 따로 없어서, 같은 문서의 "1,200% 판정" REVIEW_REQUIRED="검토필요"
-    // (docs/FGC_화면정의서_v2_0.md:277)와 같은 용어를 그대로 맞췄다 — 확정 표기가 필요하면
-    // 화면 담당자 확인 필요.
+    // 화면정의서 TRAN-W02 "산입 판정" 필드(transaction_attribution.inclusion_status_snapshot을
+    // 그대로 채움, docs/FGC_화면정의서_v2_0.md:736)와 용어집(:1751 "산입/제외 | 한도 계산에
+    // 넣음/넣지 않음"), 1,200% 상세내역 표기(:986-1000)가 모두 "산입/제외/검토필요"를 쓴다 —
+    // CapCheckDetailResponse 관련 테스트(CapCheckServiceImplTest, CapCheckControllerTest)도
+    // 같은 값 도메인에 "산입"을 쓰고 있어 맞춘다(코드리뷰 반영, 이전 "포함"은 오표기였다).
     public String label() {
         return switch (this) {
-            case INCLUDED -> "포함";
+            case INCLUDED -> "산입";
             case EXCLUDED -> "제외";
             case REVIEW_REQUIRED -> "검토필요";
         };

--- a/src/main/java/com/susukkang/fgc/common/code/InclusionDecisionStatus.java
+++ b/src/main/java/com/susukkang/fgc/common/code/InclusionDecisionStatus.java
@@ -10,5 +10,17 @@ package com.susukkang.fgc.common.code;
 public enum InclusionDecisionStatus {
     INCLUDED,
     EXCLUDED,
-    REVIEW_REQUIRED
+    REVIEW_REQUIRED;
+
+    // 화면정의서에 이 컬럼(transaction_attribution.inclusion_status_snapshot) 전용 표기
+    // 매핑표가 따로 없어서, 같은 문서의 "1,200% 판정" REVIEW_REQUIRED="검토필요"
+    // (docs/FGC_화면정의서_v2_0.md:277)와 같은 용어를 그대로 맞췄다 — 확정 표기가 필요하면
+    // 화면 담당자 확인 필요.
+    public String label() {
+        return switch (this) {
+            case INCLUDED -> "포함";
+            case EXCLUDED -> "제외";
+            case REVIEW_REQUIRED -> "검토필요";
+        };
+    }
 }

--- a/src/main/java/com/susukkang/fgc/common/code/JournalHeaderStatus.java
+++ b/src/main/java/com/susukkang/fgc/common/code/JournalHeaderStatus.java
@@ -1,0 +1,20 @@
+package com.susukkang.fgc.common.code;
+
+/**
+ * journal_header.status CHECK 제약과 값이 같아야 한다
+ * (CHECK (status IN ('DRAFT','POSTED','REVERSED')), V1__baseline_v2_1_2.sql:1212-1213).
+ */
+public enum JournalHeaderStatus {
+    DRAFT,
+    POSTED,
+    REVERSED;
+
+    /** 화면정의서 "상태 | 작성중 / 기표됨 / 역분개됨"(docs/FGC_화면정의서_v2_0.md:1115)과 일치시킨다. */
+    public String label() {
+        return switch (this) {
+            case DRAFT -> "작성중";
+            case POSTED -> "기표됨";
+            case REVERSED -> "역분개됨";
+        };
+    }
+}

--- a/src/main/java/com/susukkang/fgc/common/code/ReconResultType.java
+++ b/src/main/java/com/susukkang/fgc/common/code/ReconResultType.java
@@ -1,4 +1,36 @@
 package com.susukkang.fgc.common.code;
 
+/**
+ * reconciliation_result.result_type CHECK 제약과 값이 같아야 한다
+ * (V1__baseline_v2_1_2.sql:1458-1462).
+ */
 public enum ReconResultType {
+    MATCHED,
+    AMOUNT_DIFFERENCE,
+    EXPECTED_MISSING,
+    ACTUAL_MISSING,
+    DUPLICATE,
+    AGENT_MISMATCH,
+    INSTALLMENT_MISMATCH,
+    INVALID_CONTRACT_PAYMENT,
+    POLICY_VERSION_ERROR,
+    JOURNAL_IMBALANCE,
+    REVIEW_REQUIRED;
+
+    /** 화면정의서 "대사 결과" 코드-표기 매핑표(docs/FGC_화면정의서_v2_0.md:287-301)와 일치시킨다. */
+    public String label() {
+        return switch (this) {
+            case MATCHED -> "일치";
+            case AMOUNT_DIFFERENCE -> "금액 차이";
+            case EXPECTED_MISSING -> "예상 없음(실제만 있음)";
+            case ACTUAL_MISSING -> "실제 없음(누락)";
+            case DUPLICATE -> "중복 지급";
+            case AGENT_MISMATCH -> "설계사 불일치";
+            case INSTALLMENT_MISMATCH -> "회차 불일치";
+            case INVALID_CONTRACT_PAYMENT -> "비유효 계약 지급";
+            case POLICY_VERSION_ERROR -> "정책버전 오류";
+            case JOURNAL_IMBALANCE -> "원장 불균형";
+            case REVIEW_REQUIRED -> "검토필요";
+        };
+    }
 }

--- a/src/main/java/com/susukkang/fgc/common/util/PersonalInfoMasker.java
+++ b/src/main/java/com/susukkang/fgc/common/util/PersonalInfoMasker.java
@@ -1,0 +1,30 @@
+package com.susukkang.fgc.common.util;
+
+/**
+ * 화면 공통 마스킹 규칙. 목업 FGC.mask()(FGC_화면_MVP/assets/fgc-seed.js:49, 주석
+ * "계약자 이름 마스킹 (§4-11). 홍길동 → 홍*동")를 그대로 자바로 옮긴 것이다 —
+ * 첫 글자 + 가운데를 전부 *로 + 마지막 글자, 2글자 이하는 첫 글자 + * 하나.
+ *
+ * 화면정의서(docs/FGC_화면정의서_v2_0.md:219)는 "계약자" 개인정보는 아예 저장하지
+ * 않아 마스킹 규칙 자체가 필요 없다고 명시한다 — 이 유틸이 마스킹하는 대상은 계약자가
+ * 아니라 agent.agent_name(설계사명, 실제로 DB에 저장·표시되는 이름)이다. 계약자용
+ * 마스킹 함수를 그대로 재사용하는 이유는 이 프로젝트에 이름을 가리는 규칙이 이거
+ * 하나뿐이고, 화면마다 다른 마스킹 방식을 쓸 이유가 없기 때문이다.
+ */
+public final class PersonalInfoMasker {
+
+    private PersonalInfoMasker() {
+    }
+
+    public static String maskName(String name) {
+        if (name == null || name.isBlank()) {
+            return name;
+        }
+        if (name.length() <= 2) {
+            return name.charAt(0) + "*";
+        }
+        return name.charAt(0)
+                + "*".repeat(name.length() - 2)
+                + name.charAt(name.length() - 1);
+    }
+}

--- a/src/main/java/com/susukkang/fgc/contract/controller/ContractLedgerProjectionController.java
+++ b/src/main/java/com/susukkang/fgc/contract/controller/ContractLedgerProjectionController.java
@@ -1,0 +1,35 @@
+package com.susukkang.fgc.contract.controller;
+
+import com.susukkang.fgc.common.web.ApiResponse;
+import com.susukkang.fgc.contract.dto.ContractJournalResponse;
+import com.susukkang.fgc.contract.dto.ContractTransactionResponse;
+import com.susukkang.fgc.contract.service.ContractJournalProjectionService;
+import com.susukkang.fgc.contract.service.ContractTransactionProjectionService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "계약", description = "계약 상세 - 검증원장/지급 건 조회 Projection API")
+@RestController
+@RequestMapping("/api/v1/contracts")
+@RequiredArgsConstructor
+public class ContractLedgerProjectionController {
+
+    private final ContractJournalProjectionService contractJournalProjectionService;
+    private final ContractTransactionProjectionService contractTransactionProjectionService;
+
+    @GetMapping("/{id}/journals")
+    public ApiResponse<List<ContractJournalResponse>> getContractJournals(@PathVariable Long id) {
+        return ApiResponse.success(contractJournalProjectionService.findJournalsByContractId(id));
+    }
+
+    @GetMapping("/{id}/transactions")
+    public ApiResponse<List<ContractTransactionResponse>> getContractTransactions(@PathVariable Long id) {
+        return ApiResponse.success(contractTransactionProjectionService.findTransactionsByContractId(id));
+    }
+}

--- a/src/main/java/com/susukkang/fgc/contract/controller/ContractLedgerProjectionController.java
+++ b/src/main/java/com/susukkang/fgc/contract/controller/ContractLedgerProjectionController.java
@@ -2,7 +2,7 @@ package com.susukkang.fgc.contract.controller;
 
 import com.susukkang.fgc.common.web.ApiResponse;
 import com.susukkang.fgc.contract.dto.ContractJournalResponse;
-import com.susukkang.fgc.contract.dto.ContractTransactionResponse;
+import com.susukkang.fgc.contract.dto.ContractTransactionTabResponse;
 import com.susukkang.fgc.contract.service.ContractJournalProjectionService;
 import com.susukkang.fgc.contract.service.ContractTransactionProjectionService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,7 +29,7 @@ public class ContractLedgerProjectionController {
     }
 
     @GetMapping("/{id}/transactions")
-    public ApiResponse<List<ContractTransactionResponse>> getContractTransactions(@PathVariable Long id) {
+    public ApiResponse<ContractTransactionTabResponse> getContractTransactions(@PathVariable Long id) {
         return ApiResponse.success(contractTransactionProjectionService.findTransactionsByContractId(id));
     }
 }

--- a/src/main/java/com/susukkang/fgc/contract/dto/ContractJournalLineResponse.java
+++ b/src/main/java/com/susukkang/fgc/contract/dto/ContractJournalLineResponse.java
@@ -1,0 +1,40 @@
+package com.susukkang.fgc.contract.dto;
+
+import com.susukkang.fgc.common.code.PaymentStage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+/** GET /api/v1/contracts/{id}/journals 응답의 분개 라인 1건. */
+@Getter
+@Builder
+public class ContractJournalLineResponse {
+    private final Integer lineNo;
+    private final String accountCode;
+    private final String accountName;
+    private final BigDecimal debitAmount;
+    private final BigDecimal creditAmount;
+    private final Long agentId;
+    private final String paymentStage;
+    private final String paymentStageLabel;
+    private final Long commissionItemId;
+    private final String memo;
+
+    public static ContractJournalLineResponse from(ContractJournalLineRow row) {
+        PaymentStage paymentStage = row.getPaymentStage() == null
+                ? null : PaymentStage.valueOf(row.getPaymentStage());
+        return ContractJournalLineResponse.builder()
+                .lineNo(row.getLineNo())
+                .accountCode(row.getAccountCode())
+                .accountName(row.getAccountName())
+                .debitAmount(row.getDebitAmount())
+                .creditAmount(row.getCreditAmount())
+                .agentId(row.getAgentId())
+                .paymentStage(row.getPaymentStage())
+                .paymentStageLabel(paymentStage == null ? null : paymentStage.label())
+                .commissionItemId(row.getCommissionItemId())
+                .memo(row.getMemo())
+                .build();
+    }
+}

--- a/src/main/java/com/susukkang/fgc/contract/dto/ContractJournalLineRow.java
+++ b/src/main/java/com/susukkang/fgc/contract/dto/ContractJournalLineRow.java
@@ -1,0 +1,36 @@
+package com.susukkang.fgc.contract.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 계약 기준 journal_header + journal_line + journal_account 조인 조회 결과 1행.
+ * 라인 하나당 한 행이라, 같은 journalHeaderId를 가진 행이 보통 2개(차변 1·대변 1)씩 묶여서 나옴
+ */
+@Getter
+@Setter
+public class ContractJournalLineRow {
+    private Long journalHeaderId;
+    private String journalNo;
+    private LocalDate journalDate;
+    private String journalType;
+    private String sourceEntityType;
+    private String sourceEntityId;
+    private Integer revisionNo;
+    private Long policyVersionId;
+    private Long validationRunId;
+    private String status;
+    private String description;
+    private Integer lineNo;
+    private String accountCode;
+    private String accountName;
+    private BigDecimal debitAmount;
+    private BigDecimal creditAmount;
+    private Long agentId;
+    private String paymentStage;
+    private Long commissionItemId;
+    private String memo;
+}

--- a/src/main/java/com/susukkang/fgc/contract/dto/ContractJournalResponse.java
+++ b/src/main/java/com/susukkang/fgc/contract/dto/ContractJournalResponse.java
@@ -1,0 +1,38 @@
+package com.susukkang.fgc.contract.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * GET /api/v1/contracts/{id}/journals 응답의 분개 헤더 1건
+ * 그 헤더에 속한 라인 전체(lines)와 차변·대변 합계·차액을 함께 담는다.
+ */
+@Getter
+@Builder
+public class ContractJournalResponse {
+    private final Long journalHeaderId;
+    private final String journalNo;
+    private final LocalDate journalDate;
+    private final String journalType;
+    private final String sourceEntityType;
+    private final String sourceEntityId;
+    private final Integer revisionNo;
+    private final Long policyVersionId;
+    private final Long validationRunId;
+    private final String status;
+    private final String statusLabel;
+    private final String description;
+    private final BigDecimal debitTotal;
+    private final BigDecimal creditTotal;
+    private final BigDecimal differenceAmount;
+    // 이슈 #108 요구사항 "차변 합계, 대변 합계, 차액, 지급단계"에 지급단계도 헤더 응답
+    // 필드로 명시돼 있다 — payment_stage는 journal_line 컬럼이지만, 한 헤더의 모든
+    // 라인이 같은 값을 가지므로(#85/#93 설계) 첫 라인 값을 헤더 대표값으로 올린다.
+    private final String paymentStage;
+    private final String paymentStageLabel;
+    private final List<ContractJournalLineResponse> lines;
+}

--- a/src/main/java/com/susukkang/fgc/contract/dto/ContractReconciliationResponse.java
+++ b/src/main/java/com/susukkang/fgc/contract/dto/ContractReconciliationResponse.java
@@ -1,0 +1,31 @@
+package com.susukkang.fgc.contract.dto;
+
+import com.susukkang.fgc.common.code.ReconResultType;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+/** CONT-W02 탭6 "지급·대사" 응답의 대사 결과 1건. */
+public record ContractReconciliationResponse(
+        Long reconciliationResultId,
+        String matchGroupKey,
+        ReconResultType resultType,
+        String resultTypeLabel,
+        BigDecimal expectedTotalAmount,
+        BigDecimal actualTotalAmount,
+        BigDecimal differenceAmount,
+        String primaryReasonCode,
+        Integer installmentNo,
+        Long commissionItemId,
+        OffsetDateTime createdAt
+) {
+    public static ContractReconciliationResponse from(ContractReconciliationRow row) {
+        ReconResultType resultType = ReconResultType.valueOf(row.getResultType());
+        return new ContractReconciliationResponse(
+                row.getReconciliationResultId(), row.getMatchGroupKey(),
+                resultType, resultType.label(),
+                row.getExpectedTotalAmount(), row.getActualTotalAmount(), row.getDifferenceAmount(),
+                row.getPrimaryReasonCode(), row.getInstallmentNo(), row.getCommissionItemId(),
+                row.getCreatedAt());
+    }
+}

--- a/src/main/java/com/susukkang/fgc/contract/dto/ContractReconciliationRow.java
+++ b/src/main/java/com/susukkang/fgc/contract/dto/ContractReconciliationRow.java
@@ -1,0 +1,26 @@
+package com.susukkang.fgc.contract.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+/**
+ * 계약 기준 reconciliation_result 조회 결과 1행(CONT-W02 탭6 "지급·대사" —
+ * 화면정의서 :565가 이 탭의 데이터소스로 commission_transaction과 함께 명시).
+ */
+@Getter
+@Setter
+public class ContractReconciliationRow {
+    private Long reconciliationResultId;
+    private String matchGroupKey;
+    private String resultType;
+    private BigDecimal expectedTotalAmount;
+    private BigDecimal actualTotalAmount;
+    private BigDecimal differenceAmount;
+    private String primaryReasonCode;
+    private Integer installmentNo;
+    private Long commissionItemId;
+    private OffsetDateTime createdAt;
+}

--- a/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionAttributionResponse.java
+++ b/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionAttributionResponse.java
@@ -1,0 +1,23 @@
+package com.susukkang.fgc.contract.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * GET /api/v1/contracts/{id}/transactions 응답의 귀속행 1건.
+ */
+@Getter
+@Builder
+public class ContractTransactionAttributionResponse {
+    private final Long transactionAttributionId;
+    private final BigDecimal attributedAmount;
+    private final LocalDate attributionDate;
+    private final String inclusionStatus;
+    private final String inclusionStatusLabel;
+    private final Long agentId;
+    private final String agentName;
+    private final String agentCode;
+}

--- a/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionAttributionResponse.java
+++ b/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionAttributionResponse.java
@@ -8,6 +8,11 @@ import java.time.LocalDate;
 
 /**
  * GET /api/v1/contracts/{id}/transactions 응답의 귀속행 1건.
+ *
+ * agentName은 마스킹하지 않는다(코드리뷰 반영) — 화면정의서 §4-11 개인정보 규칙은
+ * "계약자" 전용이고, GET /api/v1/base/agents·CONT-W03 "모집 설계사"는 agent_name을
+ * 원문 그대로 노출한다. 마스킹 정책이 정해지면 com.susukkang.fgc.common.util.
+ * PersonalInfoMasker를 다시 적용한다.
  */
 @Getter
 @Builder

--- a/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionAttributionRow.java
+++ b/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionAttributionRow.java
@@ -1,0 +1,28 @@
+package com.susukkang.fgc.contract.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 계약 기준 commission_transaction + transaction_attribution(+ agent) 조인 조회 결과 1행
+ */
+@Getter
+@Setter
+public class ContractTransactionAttributionRow {
+    private Long commissionTransactionId;
+    private LocalDate settlementMonth;
+    private String paymentStage;
+    private BigDecimal amount;
+    private String status;
+    private String sourceType;
+    private Long transactionAttributionId;
+    private BigDecimal attributedAmount;
+    private LocalDate attributionDate;
+    private String inclusionStatus;
+    private Long agentId;
+    private String agentName;
+    private String agentCode;
+}

--- a/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionAttributionRow.java
+++ b/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionAttributionRow.java
@@ -25,4 +25,7 @@ public class ContractTransactionAttributionRow {
     private Long agentId;
     private String agentName;
     private String agentCode;
+    // 이 지급 건 전체(계약 무관)의 귀속 합계 — differenceAmount 계산용(코드리뷰 반영,
+    // Mapper XML의 상관 서브쿼리 주석 참고). attributedAmount 합계(이 계약 몫)와는 다르다.
+    private BigDecimal transactionAttributedTotal;
 }

--- a/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionResponse.java
+++ b/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionResponse.java
@@ -1,0 +1,27 @@
+package com.susukkang.fgc.contract.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * GET /api/v1/contracts/{id}/transactions 응답의 지급 건 1건
+ */
+@Getter
+@Builder
+public class ContractTransactionResponse {
+    private final Long commissionTransactionId;
+    private final LocalDate settlementMonth;
+    private final String paymentStage;
+    private final String paymentStageLabel;
+    private final BigDecimal amount;
+    private final String status;
+    private final String statusLabel;
+    private final String sourceType;
+    private final BigDecimal attributionTotal;
+    private final BigDecimal differenceAmount;
+    private final List<ContractTransactionAttributionResponse> attributions;
+}

--- a/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionResponse.java
+++ b/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionResponse.java
@@ -8,7 +8,12 @@ import java.time.LocalDate;
 import java.util.List;
 
 /**
- * GET /api/v1/contracts/{id}/transactions 응답의 지급 건 1건
+ * GET /api/v1/contracts/{id}/transactions 응답의 지급 건 1건.
+ *
+ * attributionTotal은 "이 계약"에 귀속된 금액 합계(attributions 리스트의 합)이고,
+ * differenceAmount는 이 지급 건 "전체"(계약 무관) 귀속 합계와 amount의 차액이다 —
+ * 정착지원금·공통비처럼 한 지급 건이 여러 계약에 나뉘어 귀속되는 경우 attributionTotal이
+ * amount보다 작은 게 정상이라, 그 둘을 직접 빼면 안 된다(코드리뷰 반영).
  */
 @Getter
 @Builder

--- a/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionTabResponse.java
+++ b/src/main/java/com/susukkang/fgc/contract/dto/ContractTransactionTabResponse.java
@@ -1,0 +1,15 @@
+package com.susukkang.fgc.contract.dto;
+
+import java.util.List;
+
+/**
+ * GET /api/v1/contracts/{id}/transactions 전체 응답 — CONT-W02 탭6 "지급·대사"가 읽는
+ * 두 데이터소스(commission_transaction+transaction_attribution, reconciliation_result,
+ * 화면정의서:565)를 함께 담는다(코드리뷰 반영 — IF-API-17 정의만으로는 대사 결과가
+ * 빠져 있었다).
+ */
+public record ContractTransactionTabResponse(
+        List<ContractTransactionResponse> transactions,
+        List<ContractReconciliationResponse> reconciliations
+) {
+}

--- a/src/main/java/com/susukkang/fgc/contract/mapper/ContractJournalProjectionMapper.java
+++ b/src/main/java/com/susukkang/fgc/contract/mapper/ContractJournalProjectionMapper.java
@@ -1,0 +1,12 @@
+package com.susukkang.fgc.contract.mapper;
+
+import com.susukkang.fgc.contract.dto.ContractJournalLineRow;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface ContractJournalProjectionMapper {
+    List<ContractJournalLineRow> findJournalLinesByContractId(@Param("contractId") Long contractId);
+}

--- a/src/main/java/com/susukkang/fgc/contract/mapper/ContractTransactionProjectionMapper.java
+++ b/src/main/java/com/susukkang/fgc/contract/mapper/ContractTransactionProjectionMapper.java
@@ -1,0 +1,13 @@
+package com.susukkang.fgc.contract.mapper;
+
+import com.susukkang.fgc.contract.dto.ContractTransactionAttributionRow;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface ContractTransactionProjectionMapper {
+    List<ContractTransactionAttributionRow> findTransactionAttributionsByContractId(
+            @Param("contractId") Long contractId);
+}

--- a/src/main/java/com/susukkang/fgc/contract/mapper/ContractTransactionProjectionMapper.java
+++ b/src/main/java/com/susukkang/fgc/contract/mapper/ContractTransactionProjectionMapper.java
@@ -1,5 +1,6 @@
 package com.susukkang.fgc.contract.mapper;
 
+import com.susukkang.fgc.contract.dto.ContractReconciliationRow;
 import com.susukkang.fgc.contract.dto.ContractTransactionAttributionRow;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -10,4 +11,6 @@ import java.util.List;
 public interface ContractTransactionProjectionMapper {
     List<ContractTransactionAttributionRow> findTransactionAttributionsByContractId(
             @Param("contractId") Long contractId);
+
+    List<ContractReconciliationRow> findReconciliationResultsByContractId(@Param("contractId") Long contractId);
 }

--- a/src/main/java/com/susukkang/fgc/contract/service/ContractJournalProjectionService.java
+++ b/src/main/java/com/susukkang/fgc/contract/service/ContractJournalProjectionService.java
@@ -1,0 +1,17 @@
+package com.susukkang.fgc.contract.service;
+
+import com.susukkang.fgc.contract.dto.ContractJournalResponse;
+
+import java.util.List;
+
+/**
+ * 계약 상세 화면(CONT-W02)의 검증원장 탭
+ */
+public interface ContractJournalProjectionService {
+
+    /**
+     * contractId에 연결된 모든 분개(DRAFT/POSTED/REVERSED 전부)를 헤더 단위로 묶어 돌려준다.
+     * 연결된 분개가 없으면 빈 리스트를 돌려준다
+     */
+    List<ContractJournalResponse> findJournalsByContractId(Long contractId);
+}

--- a/src/main/java/com/susukkang/fgc/contract/service/ContractJournalProjectionServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/contract/service/ContractJournalProjectionServiceImpl.java
@@ -74,7 +74,13 @@ public class ContractJournalProjectionServiceImpl implements ContractJournalProj
             // 상태 코드(DRAFT/POSTED/REVERSED)를 화면 표시 라벨로 변환
             JournalHeaderStatus status = JournalHeaderStatus.valueOf(first.getStatus());
             // 지급단계도 같은 방식으로 라벨을 만든다 — journal_line.payment_stage는
-            // nullable이라 null 방어(ContractJournalLineResponse.from()과 같은 처리)
+            // nullable이라 null 방어(ContractJournalLineResponse.from()과 같은 처리).
+            // 첫 라인 값을 헤더 대표값으로 쓴다 — 현재 구현된 4개 분개유형
+            // (JournalEntryDraftServiceImpl)은 실제로 한 헤더의 모든 라인이 같은
+            // payment_stage를 갖지만, DB 제약으로 강제되는 건 아니다(V1__baseline_v2_1_2.sql:
+            // 1243). ADJUSTMENT/CLAWBACK/RECOVERY/REVERSAL(2차, 아직 미구현) 유형이
+            // 라인마다 다른 payment_stage를 가질 수 있다면 이 가정이 깨진다 — 그 유형을
+            // 구현할 때 재검토 필요(코드리뷰 반영).
             PaymentStage paymentStage = first.getPaymentStage() == null
                     ? null : PaymentStage.valueOf(first.getPaymentStage());
 

--- a/src/main/java/com/susukkang/fgc/contract/service/ContractJournalProjectionServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/contract/service/ContractJournalProjectionServiceImpl.java
@@ -1,0 +1,107 @@
+package com.susukkang.fgc.contract.service;
+
+import com.susukkang.fgc.common.code.JournalHeaderStatus;
+import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.contract.dto.ContractJournalLineResponse;
+import com.susukkang.fgc.contract.dto.ContractJournalLineRow;
+import com.susukkang.fgc.contract.dto.ContractJournalResponse;
+import com.susukkang.fgc.contract.mapper.ContractJournalProjectionMapper;
+import com.susukkang.fgc.contract.mapper.ContractMapper;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 계약 상세 화면(CONT-W02) 검증원장 탭 — journal_header/journal_line을 계약 기준으로
+ * 조회해 헤더 단위로 묶어 돌려주는 조회 전용 서비스.
+ */
+@Service
+public class ContractJournalProjectionServiceImpl implements ContractJournalProjectionService {
+
+    private final ContractJournalProjectionMapper contractJournalProjectionMapper;
+    private final ContractMapper contractMapper;
+
+    public ContractJournalProjectionServiceImpl(ContractJournalProjectionMapper contractJournalProjectionMapper,
+                                                  ContractMapper contractMapper) {
+        this.contractJournalProjectionMapper = contractJournalProjectionMapper;
+        this.contractMapper = contractMapper;
+    }
+
+    @Override
+    public List<ContractJournalResponse> findJournalsByContractId(Long contractId) {
+        // 1. 계약 존재 확인
+        if (contractMapper.selectContractById(contractId) == null) {
+            throw new FgcBusinessException(FgcErrorCode.COMMON_004, Map.of("id", contractId));
+        }
+
+        // 2. 이 계약에 연결된 모든 분개 라인을 한 번에 조회(journal_header_id, line_no 순 정렬)
+        List<ContractJournalLineRow> rows = contractJournalProjectionMapper.findJournalLinesByContractId(contractId);
+
+        // 3. 연결된 분개가 없으면 빈 목록 반환
+        if (rows.isEmpty()) {
+            return List.of();
+        }
+
+        // 4. 라인들을 journalHeaderId 기준으로 묶는다 — 분개 하나(차변 1줄+대변 1줄
+        // 이상)가 여러 행으로 흩어져 있던 것을 헤더 단위 그룹으로 되돌림
+        LinkedHashMap<Long, List<ContractJournalLineRow>> grouped = new LinkedHashMap<>();
+        for (ContractJournalLineRow row : rows) {
+            grouped.computeIfAbsent(row.getJournalHeaderId(), key -> new ArrayList<>()).add(row);
+        }
+
+        // 5. 그룹(=분개 헤더 하나)마다 응답 1건을 조립
+        List<ContractJournalResponse> result = new ArrayList<>();
+        for (List<ContractJournalLineRow> group : grouped.values()) {
+            // 헤더 공통 필드는 같은 그룹의 아무 행에서나 꺼내도 동일하다(journal_header 컬럼이라)
+            ContractJournalLineRow first = group.get(0);
+
+            // 그룹 안의 각 라인을 응답용 라인 DTO로 바꾸면서 차변·대변 합계를 같이 누적
+            List<ContractJournalLineResponse> lines = new ArrayList<>();
+            BigDecimal debitTotal = BigDecimal.ZERO;
+            BigDecimal creditTotal = BigDecimal.ZERO;
+            for (ContractJournalLineRow row : group) {
+                lines.add(ContractJournalLineResponse.from(row));
+                debitTotal = debitTotal.add(row.getDebitAmount());
+                creditTotal = creditTotal.add(row.getCreditAmount());
+            }
+
+            // 상태 코드(DRAFT/POSTED/REVERSED)를 화면 표시 라벨로 변환
+            JournalHeaderStatus status = JournalHeaderStatus.valueOf(first.getStatus());
+            // 지급단계도 같은 방식으로 라벨을 만든다 — journal_line.payment_stage는
+            // nullable이라 null 방어(ContractJournalLineResponse.from()과 같은 처리)
+            PaymentStage paymentStage = first.getPaymentStage() == null
+                    ? null : PaymentStage.valueOf(first.getPaymentStage());
+
+            // 헤더 + 합계 + 차액 + 지급단계 + 라인 리스트를 하나의 응답으로 조립
+            result.add(ContractJournalResponse.builder()
+                    .journalHeaderId(first.getJournalHeaderId())
+                    .journalNo(first.getJournalNo())
+                    .journalDate(first.getJournalDate())
+                    .journalType(first.getJournalType())
+                    .sourceEntityType(first.getSourceEntityType())
+                    .sourceEntityId(first.getSourceEntityId())
+                    .revisionNo(first.getRevisionNo())
+                    .policyVersionId(first.getPolicyVersionId())
+                    .validationRunId(first.getValidationRunId())
+                    .status(first.getStatus())
+                    .statusLabel(status.label())
+                    .debitTotal(debitTotal)
+                    .creditTotal(creditTotal)
+                    .differenceAmount(debitTotal.subtract(creditTotal).abs())
+                    .description(first.getDescription())
+                    .paymentStage(first.getPaymentStage())
+                    .paymentStageLabel(paymentStage == null ? null : paymentStage.label())
+                    .lines(lines)
+                    .build());
+        }
+
+        // 6. 헤더 등장 순서(Mapper 정렬 그대로) 그대로 반환
+        return result;
+    }
+}

--- a/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionService.java
+++ b/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionService.java
@@ -1,17 +1,16 @@
 package com.susukkang.fgc.contract.service;
 
-import com.susukkang.fgc.contract.dto.ContractTransactionResponse;
-
-import java.util.List;
+import com.susukkang.fgc.contract.dto.ContractTransactionTabResponse;
 
 /**
- * 계약 상세 화면(CONT-W02)의 지급 건 탭
+ * 계약 상세 화면(CONT-W02)의 지급·대사 탭(탭6). 지급 건(commission_transaction+
+ * transaction_attribution)과 대사 결과(reconciliation_result)를 함께 돌려준다
  */
 public interface ContractTransactionProjectionService {
 
     /**
-     * contractId에 귀속된 모든 지급 건(DRAFT/CONFIRMED/CANCELLED 전부)을 지급 건 단위로 묶어 돌려준다
-     * 귀속된 지급 건이 없으면 빈 리스트를 돌려준다
+     * contractId 기준 지급 건 목록(DRAFT/CONFIRMED/CANCELLED 전부, 귀속행 없으면 빈 리스트)과
+     * 대사 결과 목록(없으면 빈 리스트)을 함께 조회한다.
      */
-    List<ContractTransactionResponse> findTransactionsByContractId(Long contractId);
+    ContractTransactionTabResponse findTransactionsByContractId(Long contractId);
 }

--- a/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionService.java
+++ b/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionService.java
@@ -1,0 +1,17 @@
+package com.susukkang.fgc.contract.service;
+
+import com.susukkang.fgc.contract.dto.ContractTransactionResponse;
+
+import java.util.List;
+
+/**
+ * 계약 상세 화면(CONT-W02)의 지급 건 탭
+ */
+public interface ContractTransactionProjectionService {
+
+    /**
+     * contractId에 귀속된 모든 지급 건(DRAFT/CONFIRMED/CANCELLED 전부)을 지급 건 단위로 묶어 돌려준다
+     * 귀속된 지급 건이 없으면 빈 리스트를 돌려준다
+     */
+    List<ContractTransactionResponse> findTransactionsByContractId(Long contractId);
+}

--- a/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImpl.java
@@ -5,7 +5,6 @@ import com.susukkang.fgc.common.code.InclusionDecisionStatus;
 import com.susukkang.fgc.common.code.PaymentStage;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.common.exception.FgcErrorCode;
-import com.susukkang.fgc.common.util.PersonalInfoMasker;
 import com.susukkang.fgc.contract.dto.ContractTransactionAttributionResponse;
 import com.susukkang.fgc.contract.dto.ContractTransactionAttributionRow;
 import com.susukkang.fgc.contract.dto.ContractTransactionResponse;
@@ -78,7 +77,13 @@ public class ContractTransactionProjectionServiceImpl implements ContractTransac
                         .inclusionStatus(row.getInclusionStatus())
                         .inclusionStatusLabel(inclusionStatus.label())
                         .agentId(row.getAgentId())
-                        .agentName(PersonalInfoMasker.maskName(row.getAgentName()))
+                        // 마스킹하지 않는다(코드리뷰 반영) — 화면정의서 §4-11 개인정보
+                        // 규칙은 "계약자" 전용이고 설계사명 마스킹 근거가 없다. 오히려
+                        // GET /api/v1/base/agents와 CONT-W03 "모집 설계사"는 agent_name을
+                        // 원문 그대로 노출한다 — 여기만 마스킹하면 같은 데이터가 화면마다
+                        // 다르게 보이는 불일치가 생긴다. 실제 마스킹 정책이 정해지면 그때
+                        // PersonalInfoMasker를 다시 적용한다.
+                        .agentName(row.getAgentName())
                         .agentCode(row.getAgentCode())
                         .build());
                 attributionTotal = attributionTotal.add(row.getAttributedAmount());

--- a/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImpl.java
@@ -1,0 +1,114 @@
+package com.susukkang.fgc.contract.service;
+
+import com.susukkang.fgc.common.code.CommissionPaymentStatus;
+import com.susukkang.fgc.common.code.InclusionDecisionStatus;
+import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.util.PersonalInfoMasker;
+import com.susukkang.fgc.contract.dto.ContractTransactionAttributionResponse;
+import com.susukkang.fgc.contract.dto.ContractTransactionAttributionRow;
+import com.susukkang.fgc.contract.dto.ContractTransactionResponse;
+import com.susukkang.fgc.contract.mapper.ContractMapper;
+import com.susukkang.fgc.contract.mapper.ContractTransactionProjectionMapper;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 계약 상세 화면(CONT-W02) 지급 건 탭 — commission_transaction/transaction_attribution을
+ * 계약 기준으로 조회해 지급 건 단위로 묶어 돌려주는 조회 전용 서비스.
+ */
+@Service
+public class ContractTransactionProjectionServiceImpl implements ContractTransactionProjectionService {
+
+    private final ContractTransactionProjectionMapper contractTransactionProjectionMapper;
+    private final ContractMapper contractMapper;
+
+    public ContractTransactionProjectionServiceImpl(
+            ContractTransactionProjectionMapper contractTransactionProjectionMapper,
+            ContractMapper contractMapper) {
+        this.contractTransactionProjectionMapper = contractTransactionProjectionMapper;
+        this.contractMapper = contractMapper;
+    }
+
+    @Override
+    public List<ContractTransactionResponse> findTransactionsByContractId(Long contractId) {
+        // 1. 계약 존재 확인
+        if (contractMapper.selectContractById(contractId) == null) {
+            throw new FgcBusinessException(FgcErrorCode.COMMON_004, Map.of("id", contractId));
+        }
+
+        // 2. 이 계약에 귀속된 모든 귀속행을 한 번에 조회(commission_transaction_id, attribution_seq 순 정렬)
+        List<ContractTransactionAttributionRow> rows =
+                contractTransactionProjectionMapper.findTransactionAttributionsByContractId(contractId);
+
+        // 3. 귀속된 지급 건이 없으면 빈 목록 반환 — 오류 아님
+        if (rows.isEmpty()) {
+            return List.of();
+        }
+
+        // 4. 귀속행들을 commissionTransactionId 기준으로 묶는다 — 지급 건 하나가
+        // 여러 귀속행(분할 귀속)으로 흩어져 있던 것을 지급 건 단위 그룹으로 되돌림
+        LinkedHashMap<Long, List<ContractTransactionAttributionRow>> grouped = new LinkedHashMap<>();
+        for (ContractTransactionAttributionRow row : rows) {
+            grouped.computeIfAbsent(row.getCommissionTransactionId(), key -> new ArrayList<>()).add(row);
+        }
+
+        // 5. 그룹(=지급 건 하나)마다 응답 1건을 조립
+        List<ContractTransactionResponse> result = new ArrayList<>();
+        for (List<ContractTransactionAttributionRow> group : grouped.values()) {
+            // 지급 건 공통 필드는 같은 그룹의 아무 행에서나 꺼내도 동일하다
+            // (commission_transaction 컬럼이라)
+            ContractTransactionAttributionRow first = group.get(0);
+
+            // 그룹 안의 각 귀속행을 응답용 DTO로 바꾸면서 귀속 합계를 같이 누적
+            List<ContractTransactionAttributionResponse> attributions = new ArrayList<>();
+            BigDecimal attributionTotal = BigDecimal.ZERO;
+            for (ContractTransactionAttributionRow row : group) {
+                InclusionDecisionStatus inclusionStatus = InclusionDecisionStatus.valueOf(row.getInclusionStatus());
+                attributions.add(ContractTransactionAttributionResponse.builder()
+                        .transactionAttributionId(row.getTransactionAttributionId())
+                        .attributedAmount(row.getAttributedAmount())
+                        .attributionDate(row.getAttributionDate())
+                        .inclusionStatus(row.getInclusionStatus())
+                        .inclusionStatusLabel(inclusionStatus.label())
+                        .agentId(row.getAgentId())
+                        .agentName(PersonalInfoMasker.maskName(row.getAgentName()))
+                        .agentCode(row.getAgentCode())
+                        .build());
+                attributionTotal = attributionTotal.add(row.getAttributedAmount());
+            }
+
+            // 상태(DRAFT/CONFIRMED/CANCELLED)·지급단계 코드를 화면 표시 라벨로 변환
+            CommissionPaymentStatus status = CommissionPaymentStatus.valueOf(first.getStatus());
+            PaymentStage paymentStage = PaymentStage.valueOf(first.getPaymentStage());
+
+            // "귀속 합계와 지급 금액의 차액" — 지급액에서 귀속 합계를 뺀 값(부호 유지,
+            // 초과/부족 방향을 화면에서 구분할 수 있게 abs()를 씌우지 않는다)
+            BigDecimal differenceAmount = first.getAmount().subtract(attributionTotal);
+
+            // 지급 건 + 귀속 합계 + 차액 + 귀속행 리스트를 하나의 응답으로 조립
+            result.add(ContractTransactionResponse.builder()
+                    .commissionTransactionId(first.getCommissionTransactionId())
+                    .settlementMonth(first.getSettlementMonth())
+                    .paymentStage(first.getPaymentStage())
+                    .paymentStageLabel(paymentStage.label())
+                    .sourceType(first.getSourceType())
+                    .attributions(attributions)
+                    .differenceAmount(differenceAmount)
+                    .attributionTotal(attributionTotal)
+                    .amount(first.getAmount())
+                    .status(first.getStatus())
+                    .statusLabel(status.label())
+                    .build());
+        }
+
+        // 6. 지급 건 등장 순서(Mapper 정렬 그대로) 그대로 반환
+        return result;
+    }
+}

--- a/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImpl.java
@@ -5,9 +5,11 @@ import com.susukkang.fgc.common.code.InclusionDecisionStatus;
 import com.susukkang.fgc.common.code.PaymentStage;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.contract.dto.ContractReconciliationResponse;
 import com.susukkang.fgc.contract.dto.ContractTransactionAttributionResponse;
 import com.susukkang.fgc.contract.dto.ContractTransactionAttributionRow;
 import com.susukkang.fgc.contract.dto.ContractTransactionResponse;
+import com.susukkang.fgc.contract.dto.ContractTransactionTabResponse;
 import com.susukkang.fgc.contract.mapper.ContractMapper;
 import com.susukkang.fgc.contract.mapper.ContractTransactionProjectionMapper;
 import org.springframework.stereotype.Service;
@@ -19,8 +21,8 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * 계약 상세 화면(CONT-W02) 지급 건 탭 — commission_transaction/transaction_attribution을
- * 계약 기준으로 조회해 지급 건 단위로 묶어 돌려주는 조회 전용 서비스.
+ * 계약 상세 화면(CONT-W02) 지급·대사 탭 — commission_transaction/transaction_attribution을
+ * 계약 기준으로 조회해 지급 건 단위로 묶고, reconciliation_result도 함께 조회하는 조회 전용 서비스.
  */
 @Service
 public class ContractTransactionProjectionServiceImpl implements ContractTransactionProjectionService {
@@ -36,7 +38,7 @@ public class ContractTransactionProjectionServiceImpl implements ContractTransac
     }
 
     @Override
-    public List<ContractTransactionResponse> findTransactionsByContractId(Long contractId) {
+    public ContractTransactionTabResponse findTransactionsByContractId(Long contractId) {
         // 1. 계약 존재 확인
         if (contractMapper.selectContractById(contractId) == null) {
             throw new FgcBusinessException(FgcErrorCode.COMMON_004, Map.of("id", contractId));
@@ -46,9 +48,15 @@ public class ContractTransactionProjectionServiceImpl implements ContractTransac
         List<ContractTransactionAttributionRow> rows =
                 contractTransactionProjectionMapper.findTransactionAttributionsByContractId(contractId);
 
-        // 3. 귀속된 지급 건이 없으면 빈 목록 반환 — 오류 아님
+        // 2-1. 이 계약의 대사 결과 목록도 함께 조회(reconciliation_result, 최신순)
+        List<ContractReconciliationResponse> reconciliations =
+                contractTransactionProjectionMapper.findReconciliationResultsByContractId(contractId).stream()
+                        .map(ContractReconciliationResponse::from)
+                        .toList();
+
+        // 3. 귀속된 지급 건이 없으면 지급 건 목록은 빈 리스트로 반환 — 오류 아님
         if (rows.isEmpty()) {
-            return List.of();
+            return new ContractTransactionTabResponse(List.of(), reconciliations);
         }
 
         // 4. 귀속행들을 commissionTransactionId 기준으로 묶는다 — 지급 건 하나가
@@ -77,12 +85,6 @@ public class ContractTransactionProjectionServiceImpl implements ContractTransac
                         .inclusionStatus(row.getInclusionStatus())
                         .inclusionStatusLabel(inclusionStatus.label())
                         .agentId(row.getAgentId())
-                        // 마스킹하지 않는다(코드리뷰 반영) — 화면정의서 §4-11 개인정보
-                        // 규칙은 "계약자" 전용이고 설계사명 마스킹 근거가 없다. 오히려
-                        // GET /api/v1/base/agents와 CONT-W03 "모집 설계사"는 agent_name을
-                        // 원문 그대로 노출한다 — 여기만 마스킹하면 같은 데이터가 화면마다
-                        // 다르게 보이는 불일치가 생긴다. 실제 마스킹 정책이 정해지면 그때
-                        // PersonalInfoMasker를 다시 적용한다.
                         .agentName(row.getAgentName())
                         .agentCode(row.getAgentCode())
                         .build());
@@ -93,12 +95,6 @@ public class ContractTransactionProjectionServiceImpl implements ContractTransac
             CommissionPaymentStatus status = CommissionPaymentStatus.valueOf(first.getStatus());
             PaymentStage paymentStage = PaymentStage.valueOf(first.getPaymentStage());
 
-            // "귀속 합계와 지급 금액의 차액" — attributionTotal(이 계약 몫만)이 아니라
-            // transactionAttributedTotal(이 지급 건 전체, 계약 무관)을 amount와 비교해야
-            // 한다. 정착지원금·공통비처럼 지급 건 하나가 여러 계약에 나뉘어 귀속되는 게
-            // 정상이라, 이 계약 몫만으로 차액을 내면 정상 귀속 건도 큰 미귀속처럼
-            // 잘못 표시된다(코드리뷰 반영 — Mapper XML의 서브쿼리 주석 참고).
-            // 부호는 유지한다(초과/부족 방향을 화면에서 구분할 수 있게 abs()를 씌우지 않는다).
             BigDecimal differenceAmount = first.getAmount().subtract(first.getTransactionAttributedTotal());
 
             // 지급 건 + 귀속 합계 + 차액 + 귀속행 리스트를 하나의 응답으로 조립
@@ -117,7 +113,7 @@ public class ContractTransactionProjectionServiceImpl implements ContractTransac
                     .build());
         }
 
-        // 6. 지급 건 등장 순서(Mapper 정렬 그대로) 그대로 반환
-        return result;
+        // 6. 지급 건 등장 순서(Mapper 정렬 그대로)와 대사 결과를 함께 반환
+        return new ContractTransactionTabResponse(result, reconciliations);
     }
 }

--- a/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImpl.java
@@ -95,6 +95,9 @@ public class ContractTransactionProjectionServiceImpl implements ContractTransac
             CommissionPaymentStatus status = CommissionPaymentStatus.valueOf(first.getStatus());
             PaymentStage paymentStage = PaymentStage.valueOf(first.getPaymentStage());
 
+            // JournalBalanceSummary.differenceAmount()(차변·대변 불균형 감지용, 항상 0이어야
+            // 정상이라 크기만 중요해 abs()를 씌움)와 달리, 여기는 "귀속이 지급액보다 많은지
+            // 적은지" 방향이 화면에 의미가 있는 값이라 부호를 그대로 유지한다(코드리뷰 반영).
             BigDecimal differenceAmount = first.getAmount().subtract(first.getTransactionAttributedTotal());
 
             // 지급 건 + 귀속 합계 + 차액 + 귀속행 리스트를 하나의 응답으로 조립

--- a/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImpl.java
@@ -88,9 +88,13 @@ public class ContractTransactionProjectionServiceImpl implements ContractTransac
             CommissionPaymentStatus status = CommissionPaymentStatus.valueOf(first.getStatus());
             PaymentStage paymentStage = PaymentStage.valueOf(first.getPaymentStage());
 
-            // "귀속 합계와 지급 금액의 차액" — 지급액에서 귀속 합계를 뺀 값(부호 유지,
-            // 초과/부족 방향을 화면에서 구분할 수 있게 abs()를 씌우지 않는다)
-            BigDecimal differenceAmount = first.getAmount().subtract(attributionTotal);
+            // "귀속 합계와 지급 금액의 차액" — attributionTotal(이 계약 몫만)이 아니라
+            // transactionAttributedTotal(이 지급 건 전체, 계약 무관)을 amount와 비교해야
+            // 한다. 정착지원금·공통비처럼 지급 건 하나가 여러 계약에 나뉘어 귀속되는 게
+            // 정상이라, 이 계약 몫만으로 차액을 내면 정상 귀속 건도 큰 미귀속처럼
+            // 잘못 표시된다(코드리뷰 반영 — Mapper XML의 서브쿼리 주석 참고).
+            // 부호는 유지한다(초과/부족 방향을 화면에서 구분할 수 있게 abs()를 씌우지 않는다).
+            BigDecimal differenceAmount = first.getAmount().subtract(first.getTransactionAttributedTotal());
 
             // 지급 건 + 귀속 합계 + 차액 + 귀속행 리스트를 하나의 응답으로 조립
             result.add(ContractTransactionResponse.builder()

--- a/src/main/resources/mapper/contract/ContractJournalProjectionMapper.xml
+++ b/src/main/resources/mapper/contract/ContractJournalProjectionMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.susukkang.fgc.contract.mapper.ContractJournalProjectionMapper">
+    <select id="findJournalLinesByContractId" resultType="com.susukkang.fgc.contract.dto.ContractJournalLineRow">
+        SELECT h.journal_header_id, h.journal_no, h.journal_date, h.journal_type,
+               h.source_entity_type, h.source_entity_id, h.revision_no,
+               h.policy_version_id, h.validation_run_id, h.status, h.description,
+               l.line_no, a.account_code, a.account_name,
+               l.debit_amount, l.credit_amount, l.agent_id, l.payment_stage,
+               l.commission_item_id, l.memo
+        FROM fgc.journal_header h
+        JOIN fgc.journal_line l ON l.journal_header_id = h.journal_header_id
+        JOIN fgc.journal_account a ON a.journal_account_id = l.journal_account_id
+        WHERE h.contract_id = #{contractId}
+        ORDER BY h.journal_header_id, l.line_no
+    </select>
+</mapper>

--- a/src/main/resources/mapper/contract/ContractTransactionProjectionMapper.xml
+++ b/src/main/resources/mapper/contract/ContractTransactionProjectionMapper.xml
@@ -3,13 +3,7 @@
 <mapper namespace="com.susukkang.fgc.contract.mapper.ContractTransactionProjectionMapper">
     <!--
       transaction_attributed_total: 이 지급 건(commission_transaction) 전체의 귀속 합계다
-      (계약으로 좁히지 않고 모든 attribution_scope를 합산) — 정착지원금·공통비 귀속은
-      지급 건 하나가 여러 계약에 나뉘어 귀속되는 게 정상이라(예: 2,400,000원이 5개
-      계약에 300,000/300,000/600,000/900,000/300,000으로 귀속), 이 계약 하나에 필터링된
-      attributed_amount 합계만으로 ct.amount와 차액을 내면 실제로는 정상 귀속인 지급
-      건도 큰 미귀속 차액이 있는 것처럼 잘못 계산된다(코드리뷰 반영). 서비스 계층은
-      이 값으로 differenceAmount를 계산하고, "attributions" 목록 자체는 여전히 이
-      계약(#{contractId}) 몫만 보여준다.
+      (계약으로 좁히지 않고 모든 attribution_scope를 합산)
     -->
     <select id="findTransactionAttributionsByContractId" resultType="com.susukkang.fgc.contract.dto.ContractTransactionAttributionRow">
         SELECT ct.commission_transaction_id, ct.settlement_month, ct.payment_stage,
@@ -26,5 +20,15 @@
         LEFT JOIN fgc.agent ag ON ag.agent_id = ta.agent_id
         WHERE ta.contract_id = #{contractId}
         ORDER BY ct.commission_transaction_id, ta.attribution_seq
+    </select>
+
+    <!-- CONT-W02 탭6 "지급·대사" -->
+    <select id="findReconciliationResultsByContractId" resultType="com.susukkang.fgc.contract.dto.ContractReconciliationRow">
+        SELECT reconciliation_result_id, match_group_key, result_type,
+               expected_total_amount, actual_total_amount, difference_amount,
+               primary_reason_code, installment_no, commission_item_id, created_at
+        FROM fgc.reconciliation_result
+        WHERE contract_id = #{contractId}
+        ORDER BY created_at DESC, reconciliation_result_id DESC
     </select>
 </mapper>

--- a/src/main/resources/mapper/contract/ContractTransactionProjectionMapper.xml
+++ b/src/main/resources/mapper/contract/ContractTransactionProjectionMapper.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.susukkang.fgc.contract.mapper.ContractTransactionProjectionMapper">
+    <select id="findTransactionAttributionsByContractId" resultType="com.susukkang.fgc.contract.dto.ContractTransactionAttributionRow">
+        SELECT ct.commission_transaction_id, ct.settlement_month, ct.payment_stage,
+               ct.amount, ct.status, ct.source_type,
+               ta.transaction_attribution_id, ta.attributed_amount, ta.attribution_date,
+               ta.inclusion_status_snapshot AS inclusion_status,
+               ag.agent_id, ag.agent_name, ag.agent_code
+        FROM fgc.transaction_attribution ta
+        JOIN fgc.commission_transaction ct ON ct.commission_transaction_id = ta.commission_transaction_id
+        LEFT JOIN fgc.agent ag ON ag.agent_id = ta.agent_id
+        WHERE ta.contract_id = #{contractId}
+        ORDER BY ct.commission_transaction_id, ta.attribution_seq
+    </select>
+</mapper>

--- a/src/main/resources/mapper/contract/ContractTransactionProjectionMapper.xml
+++ b/src/main/resources/mapper/contract/ContractTransactionProjectionMapper.xml
@@ -1,12 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.susukkang.fgc.contract.mapper.ContractTransactionProjectionMapper">
+    <!--
+      transaction_attributed_total: 이 지급 건(commission_transaction) 전체의 귀속 합계다
+      (계약으로 좁히지 않고 모든 attribution_scope를 합산) — 정착지원금·공통비 귀속은
+      지급 건 하나가 여러 계약에 나뉘어 귀속되는 게 정상이라(예: 2,400,000원이 5개
+      계약에 300,000/300,000/600,000/900,000/300,000으로 귀속), 이 계약 하나에 필터링된
+      attributed_amount 합계만으로 ct.amount와 차액을 내면 실제로는 정상 귀속인 지급
+      건도 큰 미귀속 차액이 있는 것처럼 잘못 계산된다(코드리뷰 반영). 서비스 계층은
+      이 값으로 differenceAmount를 계산하고, "attributions" 목록 자체는 여전히 이
+      계약(#{contractId}) 몫만 보여준다.
+    -->
     <select id="findTransactionAttributionsByContractId" resultType="com.susukkang.fgc.contract.dto.ContractTransactionAttributionRow">
         SELECT ct.commission_transaction_id, ct.settlement_month, ct.payment_stage,
                ct.amount, ct.status, ct.source_type,
                ta.transaction_attribution_id, ta.attributed_amount, ta.attribution_date,
                ta.inclusion_status_snapshot AS inclusion_status,
-               ag.agent_id, ag.agent_name, ag.agent_code
+               ag.agent_id, ag.agent_name, ag.agent_code,
+               (SELECT COALESCE(SUM(ta2.attributed_amount), 0)
+                  FROM fgc.transaction_attribution ta2
+                 WHERE ta2.commission_transaction_id = ct.commission_transaction_id
+               ) AS transaction_attributed_total
         FROM fgc.transaction_attribution ta
         JOIN fgc.commission_transaction ct ON ct.commission_transaction_id = ta.commission_transaction_id
         LEFT JOIN fgc.agent ag ON ag.agent_id = ta.agent_id

--- a/src/test/java/com/susukkang/fgc/common/util/PersonalInfoMaskerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/util/PersonalInfoMaskerTest.java
@@ -1,0 +1,30 @@
+package com.susukkang.fgc.common.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PersonalInfoMaskerTest {
+
+    @Test
+    void masksThreeCharacterNameKeepingFirstAndLast() {
+        assertThat(PersonalInfoMasker.maskName("홍길동")).isEqualTo("홍*동");
+    }
+
+    @Test
+    void masksLongerNameWithRepeatedAsterisks() {
+        assertThat(PersonalInfoMasker.maskName("김정산")).isEqualTo("김*산");
+        assertThat(PersonalInfoMasker.maskName("남궁민수")).isEqualTo("남**수");
+    }
+
+    @Test
+    void twoCharacterNameKeepsFirstCharacterOnly() {
+        assertThat(PersonalInfoMasker.maskName("이일")).isEqualTo("이*");
+    }
+
+    @Test
+    void nullAndBlankPassThroughUnchanged() {
+        assertThat(PersonalInfoMasker.maskName(null)).isNull();
+        assertThat(PersonalInfoMasker.maskName("")).isEmpty();
+    }
+}

--- a/src/test/java/com/susukkang/fgc/contract/service/ContractJournalProjectionServiceImplIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/service/ContractJournalProjectionServiceImplIntegrationTest.java
@@ -1,0 +1,217 @@
+package com.susukkang.fgc.contract.service;
+
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.contract.dto.ContractJournalResponse;
+import com.susukkang.fgc.journal.domain.ConfirmedFcPayoutJournalCommand;
+import com.susukkang.fgc.journal.domain.ExpectedInsurerIncomeJournalCommand;
+import com.susukkang.fgc.journal.dto.JournalHeaderDraft;
+import com.susukkang.fgc.journal.service.JournalEntryDraftService;
+import com.susukkang.fgc.journal.service.JournalPersistenceService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * #108 이슈 To-do "계약 없음, 데이터 없음, 예상·실제 분개 분리, POSTED·REVERSED 이력 조회
+ * 테스트".
+ *
+ * 분개 데이터는 이 테스트가 직접 JournalEntryDraftService(#85) + JournalPersistenceService
+ * (#93)로 만든다 — saveDraft()가 REQUIRES_NEW로 커밋하므로 여기도 @Transactional을 쓰지
+ * 않고(JournalPersistenceServiceImplIntegrationTest에서 겪은 @Transactional 롤백 버그와
+ * 같은 함정을 피한다), @AfterEach에서 description 마커로 직접 커밋된 DELETE를 한다.
+ *
+ * POSTED 테스트만 예외다 — journal_header/journal_line은 status가 POSTED/REVERSED로
+ * 바뀌는 순간 DB 트리거(guard_journal_header_write/guard_journal_line_write)가 DELETE는
+ * 물론 DRAFT로의 역전이까지 막아버려서(V1__baseline_v2_1_2.sql:1309-1368), 한 번 POSTED로
+ * 만들면 이 DB에서 영원히 못 지운다 — 실제로 처음 이 테스트를 REQUIRES_NEW 경로(saveDraft)로
+ * 짰다가 journal_header_id=60이 그렇게 영구 고착됐다(#108 작업 중 발견). 그래서 그 테스트만
+ * 메서드 단위 @Transactional + 순수 raw SQL INSERT로 만들어 롤백으로만 정리한다
+ * (FinalizedValidationRunImmutabilityIntegrationTest와 같은 패턴).
+ *
+ * FGC-FGL02-202611-0001(contract_id=14)을 쓴다 — 확인 시점 기준 journal_header/
+ * transaction_attribution이 전혀 없는 계약이라 "데이터 없음" 테스트와, 이 테스트가 만드는
+ * 분개만 깨끗하게 담기는 "정상 조회" 테스트 둘 다에 적합하다. POSTED 테스트는 같은 이유로
+ * 아직 안 쓴 FGC-FGL03-202608-0002(contract_id=18)를 따로 쓴다 — 트랜잭션이 롤백되긴
+ * 하지만, 혹시 모를 상황에도 다른 테스트의 조회 결과와 절대 안 섞이게 하기 위해서다.
+ */
+@SpringBootTest
+class ContractJournalProjectionServiceImplIntegrationTest {
+
+    private static final String TEST_MARKER = "#108 통합테스트";
+    private static final String EMPTY_CONTRACT_NO = "FGC-FGL02-202611-0001";
+    private static final String POSTED_TEST_CONTRACT_NO = "FGC-FGL03-202608-0002";
+
+    @Autowired
+    private ContractJournalProjectionService contractJournalProjectionService;
+    @Autowired
+    private JournalEntryDraftService journalEntryDraftService;
+    @Autowired
+    private JournalPersistenceService journalPersistenceService;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private final LocalDate journalDate = LocalDate.of(2026, 8, 1);
+
+    @AfterEach
+    void cleanUp() {
+        // status='DRAFT' 조건이 반드시 있어야 한다 — POSTED/REVERSED로 바뀐 행이 섞여
+        // 있으면 DELETE 자체가 트리거에 막혀 예외가 나고, 그러면 DRAFT로 남은 나머지도
+        // 하나도 못 지운다(#108 작업 중 실제로 이 문제로 journal_header_id=60이
+        // "#108 통합테스트" 마커를 단 채 영구 고착됐다 — status 필터 없이 만들었던
+        // 예전 버전의 흔적). postedJournalIsStillReturnedForHistory()는 그래서
+        // @Transactional로 따로 격리해 여기 정리 대상에 아예 안 걸리게 한다.
+        jdbcTemplate.update("""
+                DELETE FROM fgc.journal_line WHERE journal_header_id IN (
+                    SELECT journal_header_id FROM fgc.journal_header
+                     WHERE description = ? AND status = 'DRAFT'
+                )
+                """, TEST_MARKER);
+        jdbcTemplate.update(
+                "DELETE FROM fgc.journal_header WHERE description = ? AND status = 'DRAFT'", TEST_MARKER);
+    }
+
+    private Long emptyContractId() {
+        return jdbcTemplate.queryForObject(
+                "SELECT contract_id FROM fgc.insurance_contract WHERE contract_no = ?",
+                Long.class, EMPTY_CONTRACT_NO);
+    }
+
+    @Test
+    void unknownContractIdThrowsNotFound() {
+        assertThatThrownBy(() -> contractJournalProjectionService.findJournalsByContractId(999_999_999L))
+                .isInstanceOf(FgcBusinessException.class)
+                .satisfies(ex -> assertThat(((FgcBusinessException) ex).getErrorCode())
+                        .isEqualTo(FgcErrorCode.COMMON_004));
+    }
+
+    @Test
+    void contractWithNoJournalsReturnsEmptyList() {
+        List<ContractJournalResponse> result =
+                contractJournalProjectionService.findJournalsByContractId(emptyContractId());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void journalIsGroupedIntoOneResponseWithCorrectTotalsAndLines() {
+        Long contractId = emptyContractId();
+        ExpectedInsurerIncomeJournalCommand command = ExpectedInsurerIncomeJournalCommand.builder()
+                .scheduleLineId(System.nanoTime())
+                .contractId(contractId)
+                .journalDate(journalDate)
+                .expectedAmount(BigDecimal.valueOf(50_000))
+                .description(TEST_MARKER)
+                .build();
+        JournalHeaderDraft draft = journalEntryDraftService.draftExpectedInsurerIncome(command);
+        journalPersistenceService.saveDraft(draft, 3L, "req-108-journal");
+
+        List<ContractJournalResponse> result = contractJournalProjectionService.findJournalsByContractId(contractId);
+
+        assertThat(result).hasSize(1);
+        ContractJournalResponse response = result.get(0);
+        assertThat(response.getJournalType()).isEqualTo("EXPECTED_INSURER_INCOME");
+        assertThat(response.getSourceEntityType()).isEqualTo("SCHEDULE_LINE");
+        assertThat(response.getStatus()).isEqualTo("DRAFT");
+        assertThat(response.getStatusLabel()).isEqualTo("작성중");
+        assertThat(response.getDebitTotal()).isEqualByComparingTo(BigDecimal.valueOf(50_000));
+        assertThat(response.getCreditTotal()).isEqualByComparingTo(BigDecimal.valueOf(50_000));
+        assertThat(response.getDifferenceAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        // 이슈 #108 요구사항에 지급단계가 헤더 응답 필드로 명시돼 있다 — line 값이
+        // 헤더로 그대로 올라오는지 확인.
+        assertThat(response.getPaymentStage()).isEqualTo("INSURER_TO_GA");
+        assertThat(response.getPaymentStageLabel()).isEqualTo("원수사→GA");
+        assertThat(response.getLines()).hasSize(2);
+        assertThat(response.getLines()).extracting("accountCode")
+                .containsExactlyInAnyOrder("EXPECTED_RECEIVABLE", "EXPECTED_INCOME");
+    }
+
+    @Test
+    void expectedAndConfirmedJournalsAreKeptAsSeparateEntriesNotMerged() {
+        Long contractId = emptyContractId();
+
+        ExpectedInsurerIncomeJournalCommand expectedCommand = ExpectedInsurerIncomeJournalCommand.builder()
+                .scheduleLineId(System.nanoTime())
+                .contractId(contractId)
+                .journalDate(journalDate)
+                .expectedAmount(BigDecimal.valueOf(50_000))
+                .description(TEST_MARKER)
+                .build();
+        journalPersistenceService.saveDraft(
+                journalEntryDraftService.draftExpectedInsurerIncome(expectedCommand), 3L, "req-108-expected");
+
+        ConfirmedFcPayoutJournalCommand confirmedCommand = ConfirmedFcPayoutJournalCommand.builder()
+                .commissionTransactionId(System.nanoTime())
+                .contractId(contractId)
+                .beneficiaryAgentId(7L)
+                .journalDate(journalDate)
+                .confirmedAmount(BigDecimal.valueOf(30_000))
+                .description(TEST_MARKER)
+                .build();
+        journalPersistenceService.saveDraft(
+                journalEntryDraftService.draftConfirmedFcPayout(confirmedCommand), 3L, "req-108-confirmed");
+
+        List<ContractJournalResponse> result = contractJournalProjectionService.findJournalsByContractId(contractId);
+
+        // 두 유형이 하나로 합산되지 않고 각각 별개의 헤더(별도 응답 항목)로 남아야 한다 —
+        // 합산됐다면 size가 1이 되거나 금액이 80,000으로 섞였을 것이다.
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting("journalType")
+                .containsExactlyInAnyOrder("EXPECTED_INSURER_INCOME", "CONFIRMED_FC_PAYOUT");
+        assertThat(result).allSatisfy(r -> assertThat(r.getDebitTotal()).isEqualByComparingTo(r.getCreditTotal()));
+    }
+
+    @Test
+    @Transactional
+    void postedJournalIsStillReturnedForHistory() {
+        Long contractId = jdbcTemplate.queryForObject(
+                "SELECT contract_id FROM fgc.insurance_contract WHERE contract_no = ?",
+                Long.class, POSTED_TEST_CONTRACT_NO);
+        Long expectedReceivableAccountId = jdbcTemplate.queryForObject(
+                "SELECT journal_account_id FROM fgc.journal_account WHERE account_code = 'EXPECTED_RECEIVABLE'",
+                Long.class);
+        Long expectedIncomeAccountId = jdbcTemplate.queryForObject(
+                "SELECT journal_account_id FROM fgc.journal_account WHERE account_code = 'EXPECTED_INCOME'",
+                Long.class);
+
+        // journal_header/journal_line은 INSERT는 반드시 DRAFT로만 허용되고(guard_journal_
+        // header_write), 트랜잭션이 살아있는 동안은 같은 트랜잭션 안에서 DRAFT→POSTED로
+        // UPDATE할 수 있다 — 이 메서드 전체가 @Transactional이라 테스트가 끝나면 이 INSERT·
+        // UPDATE가 전부 롤백된다(DELETE를 쓰지 않으므로 POSTED 불변성 트리거에 걸리지 않는다).
+        Long journalHeaderId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.journal_header
+                    (journal_no, journal_date, journal_type, source_entity_type, source_entity_id,
+                     revision_no, contract_id, description)
+                VALUES ('JV-TEST-POSTED-0001', ?, 'EXPECTED_INSURER_INCOME', 'SCHEDULE_LINE', ?, 1, ?, ?)
+                RETURNING journal_header_id
+                """, Long.class, journalDate, String.valueOf(System.nanoTime()), contractId, TEST_MARKER);
+        jdbcTemplate.update("""
+                INSERT INTO fgc.journal_line
+                    (journal_header_id, line_no, journal_account_id, debit_amount, credit_amount)
+                VALUES (?, 1, ?, 50000, 0)
+                """, journalHeaderId, expectedReceivableAccountId);
+        jdbcTemplate.update("""
+                INSERT INTO fgc.journal_line
+                    (journal_header_id, line_no, journal_account_id, debit_amount, credit_amount)
+                VALUES (?, 2, ?, 0, 50000)
+                """, journalHeaderId, expectedIncomeAccountId);
+        jdbcTemplate.update(
+                "UPDATE fgc.journal_header SET status = 'POSTED' WHERE journal_header_id = ?", journalHeaderId);
+
+        List<ContractJournalResponse> result = contractJournalProjectionService.findJournalsByContractId(contractId);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getStatus()).isEqualTo("POSTED");
+        assertThat(result.get(0).getStatusLabel()).isEqualTo("기표됨");
+    }
+}

--- a/src/test/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImplIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImplIntegrationTest.java
@@ -53,7 +53,7 @@ class ContractTransactionProjectionServiceImplIntegrationTest {
     }
 
     @Test
-    void seededTransactionsAreGroupedWithFullyAttributedZeroDifferenceAndMaskedAgentNames() {
+    void seededTransactionsAreGroupedWithFullyAttributedZeroDifferenceAndUnmaskedAgentNames() {
         Long contractId = contractId("FGC-FGL01-202607-0001");
 
         List<ContractTransactionResponse> result =
@@ -70,12 +70,12 @@ class ContractTransactionProjectionServiceImplIntegrationTest {
             assertThat(r.getDifferenceAmount()).isEqualByComparingTo(BigDecimal.ZERO);
         });
 
-        // 시드 설계사 이름(김정산·정팀장·한지사·서본부)이 원문 그대로 노출되면 안 된다 —
-        // PersonalInfoMasker.maskName()을 거쳐야 한다("홍길동" 규칙과 같은 첫+*+끝 형태).
+        // 설계사명은 마스킹하지 않는다(코드리뷰 반영 — 화면정의서에 설계사명 마스킹
+        // 근거가 없고, 다른 화면(agents API·CONT-W03)은 원문을 그대로 노출한다).
+        // 시드 이름 중 하나(김정산)가 원문 그대로 나오는지 확인.
         assertThat(result).flatExtracting(ContractTransactionResponse::getAttributions)
                 .extracting("agentName")
-                .allSatisfy(name -> assertThat((String) name)
-                        .doesNotContain("김정산", "정팀장", "한지사", "서본부"));
+                .contains("김정산");
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImplIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImplIntegrationTest.java
@@ -2,11 +2,14 @@ package com.susukkang.fgc.contract.service;
 
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.contract.dto.ContractReconciliationResponse;
 import com.susukkang.fgc.contract.dto.ContractTransactionResponse;
+import com.susukkang.fgc.contract.dto.ContractTransactionTabResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -46,10 +49,11 @@ class ContractTransactionProjectionServiceImplIntegrationTest {
     void contractWithNoAttributedTransactionsReturnsEmptyList() {
         Long emptyContractId = contractId("FGC-FGL01-202703-0001");
 
-        List<ContractTransactionResponse> result =
+        ContractTransactionTabResponse response =
                 contractTransactionProjectionService.findTransactionsByContractId(emptyContractId);
 
-        assertThat(result).isEmpty();
+        assertThat(response.transactions()).isEmpty();
+        assertThat(response.reconciliations()).isEmpty();
     }
 
     @Test
@@ -57,7 +61,7 @@ class ContractTransactionProjectionServiceImplIntegrationTest {
         Long contractId = contractId("FGC-FGL01-202607-0001");
 
         List<ContractTransactionResponse> result =
-                contractTransactionProjectionService.findTransactionsByContractId(contractId);
+                contractTransactionProjectionService.findTransactionsByContractId(contractId).transactions();
 
         // 시드 데이터: commission_transaction 7건, 각각 attribution 1건씩 100% 귀속
         // (transaction_attribution.attributed_amount == commission_transaction.amount).
@@ -89,7 +93,7 @@ class ContractTransactionProjectionServiceImplIntegrationTest {
         Long contractId = contractId("FGC-FGL01-202607-0005");
 
         List<ContractTransactionResponse> result =
-                contractTransactionProjectionService.findTransactionsByContractId(contractId);
+                contractTransactionProjectionService.findTransactionsByContractId(contractId).transactions();
 
         ContractTransactionResponse splitTransaction = result.stream()
                 .filter(r -> r.getCommissionTransactionId() == 37L)
@@ -103,5 +107,39 @@ class ContractTransactionProjectionServiceImplIntegrationTest {
         // 하지만 차액은 지급 건 전체 기준으로 0이어야 한다 — 고치기 전 코드였다면
         // 210,000 - 105,000 = 105,000으로 잘못 나왔을 것이다.
         assertThat(splitTransaction.getDifferenceAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    // 시드 데이터에는 reconciliation_result가 하나도 없어서, 여기서만 CREATED 상태의
+    // reconciliation_run + reconciliation_result 1건을 만들어 확인한다. 클래스 전체가
+    // @Transactional이 아니라 이 테스트에만 걸어서 커밋 없이 롤백으로 정리한다
+    // (FinalizedValidationRunImmutabilityIntegrationTest와 같은 패턴).
+    @Test
+    @Transactional
+    void reconciliationResultsForContractAreIncludedInResponse() {
+        Long contractId = contractId("FGC-FGL01-202607-0001");
+
+        Long runId = jdbcTemplate.queryForObject(
+                """
+                INSERT INTO fgc.reconciliation_run (settlement_month, payment_stage, status)
+                VALUES ('2026-07-01', 'GA_TO_FC', 'CREATED')
+                RETURNING reconciliation_run_id
+                """, Long.class);
+
+        jdbcTemplate.update(
+                """
+                INSERT INTO fgc.reconciliation_result
+                    (reconciliation_run_id, match_group_key, contract_id, result_type,
+                     expected_total_amount, actual_total_amount, difference_amount, primary_reason_code)
+                VALUES (?, 'test-match-group', ?, 'AMOUNT_DIFFERENCE', 100000, 90000, 10000, 'TEST_REASON')
+                """, runId, contractId);
+
+        ContractTransactionTabResponse response =
+                contractTransactionProjectionService.findTransactionsByContractId(contractId);
+
+        assertThat(response.reconciliations()).hasSize(1);
+        ContractReconciliationResponse reconciliation = response.reconciliations().get(0);
+        assertThat(reconciliation.resultType().name()).isEqualTo("AMOUNT_DIFFERENCE");
+        assertThat(reconciliation.resultTypeLabel()).isEqualTo("금액 차이");
+        assertThat(reconciliation.differenceAmount()).isEqualByComparingTo(BigDecimal.valueOf(10000));
     }
 }

--- a/src/test/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImplIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImplIntegrationTest.java
@@ -1,0 +1,80 @@
+package com.susukkang.fgc.contract.service;
+
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.contract.dto.ContractTransactionResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * #108 이슈 To-do 테스트 — 지급 건 쪽. FGC-FGL01-202607-0001(contract_id=5)에 이미
+ * 시드돼 있는 실제 CONFIRMED 지급 건 7건(각 건이 정확히 1개 귀속행으로 100% 귀속됨,
+ * 확인 시점 기준)을 그대로 활용한다 — 이 프로젝션은 조회 전용이라 테스트가 데이터를
+ * 새로 만들 필요가 없고, 만들지 않으니 정리(@AfterEach)도 필요 없다.
+ */
+@SpringBootTest
+class ContractTransactionProjectionServiceImplIntegrationTest {
+
+    @Autowired
+    private ContractTransactionProjectionService contractTransactionProjectionService;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private Long contractId(String contractNo) {
+        return jdbcTemplate.queryForObject(
+                "SELECT contract_id FROM fgc.insurance_contract WHERE contract_no = ?",
+                Long.class, contractNo);
+    }
+
+    @Test
+    void unknownContractIdThrowsNotFound() {
+        assertThatThrownBy(() -> contractTransactionProjectionService.findTransactionsByContractId(999_999_999L))
+                .isInstanceOf(FgcBusinessException.class)
+                .satisfies(ex -> assertThat(((FgcBusinessException) ex).getErrorCode())
+                        .isEqualTo(FgcErrorCode.COMMON_004));
+    }
+
+    @Test
+    void contractWithNoAttributedTransactionsReturnsEmptyList() {
+        Long emptyContractId = contractId("FGC-FGL01-202703-0001");
+
+        List<ContractTransactionResponse> result =
+                contractTransactionProjectionService.findTransactionsByContractId(emptyContractId);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void seededTransactionsAreGroupedWithFullyAttributedZeroDifferenceAndMaskedAgentNames() {
+        Long contractId = contractId("FGC-FGL01-202607-0001");
+
+        List<ContractTransactionResponse> result =
+                contractTransactionProjectionService.findTransactionsByContractId(contractId);
+
+        // 시드 데이터: commission_transaction 7건, 각각 attribution 1건씩 100% 귀속
+        // (transaction_attribution.attributed_amount == commission_transaction.amount).
+        assertThat(result).hasSize(7);
+        assertThat(result).allSatisfy(r -> {
+            assertThat(r.getStatus()).isEqualTo("CONFIRMED");
+            assertThat(r.getStatusLabel()).isEqualTo("확정");
+            assertThat(r.getAttributions()).hasSize(1);
+            assertThat(r.getAttributionTotal()).isEqualByComparingTo(r.getAmount());
+            assertThat(r.getDifferenceAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+        });
+
+        // 시드 설계사 이름(김정산·정팀장·한지사·서본부)이 원문 그대로 노출되면 안 된다 —
+        // PersonalInfoMasker.maskName()을 거쳐야 한다("홍길동" 규칙과 같은 첫+*+끝 형태).
+        assertThat(result).flatExtracting(ContractTransactionResponse::getAttributions)
+                .extracting("agentName")
+                .allSatisfy(name -> assertThat((String) name)
+                        .doesNotContain("김정산", "정팀장", "한지사", "서본부"));
+    }
+}

--- a/src/test/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImplIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/service/ContractTransactionProjectionServiceImplIntegrationTest.java
@@ -77,4 +77,31 @@ class ContractTransactionProjectionServiceImplIntegrationTest {
                 .allSatisfy(name -> assertThat((String) name)
                         .doesNotContain("김정산", "정팀장", "한지사", "서본부"));
     }
+
+    @Test
+    void transactionSplitAcrossMultipleContractsIsNotFalselyReportedAsUnderAttributed() {
+        // 코드리뷰 반영 — commission_transaction_id=37(amount=210,000)은 두 계약에
+        // 105,000원씩 정확히 100% 귀속돼 있다(정착지원금·공통비류 분할 귀속 시나리오와
+        // 같은 모양). 이 계약(FGC-FGL01-202607-0005) 하나만 놓고 보면 attributionTotal은
+        // 105,000이라 amount(210,000)와 다르지만, 실제로는 다른 계약 몫까지 합치면
+        // 정확히 귀속된 상태다 — differenceAmount는 "이 계약 몫"이 아니라 "지급 건
+        // 전체 귀속 합계" 기준으로 계산해야 0이 나와야 한다.
+        Long contractId = contractId("FGC-FGL01-202607-0005");
+
+        List<ContractTransactionResponse> result =
+                contractTransactionProjectionService.findTransactionsByContractId(contractId);
+
+        ContractTransactionResponse splitTransaction = result.stream()
+                .filter(r -> r.getCommissionTransactionId() == 37L)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(splitTransaction.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(210_000));
+        // 이 계약 몫만 담은 attributions/attributionTotal은 여전히 105,000이어야 한다
+        assertThat(splitTransaction.getAttributions()).hasSize(1);
+        assertThat(splitTransaction.getAttributionTotal()).isEqualByComparingTo(BigDecimal.valueOf(105_000));
+        // 하지만 차액은 지급 건 전체 기준으로 0이어야 한다 — 고치기 전 코드였다면
+        // 210,000 - 105,000 = 105,000으로 잘못 나왔을 것이다.
+        assertThat(splitTransaction.getDifferenceAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
 }

--- a/src/test/java/com/susukkang/fgc/journal/service/JournalPersistenceServiceImplIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/journal/service/JournalPersistenceServiceImplIntegrationTest.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -25,16 +24,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * #93 "정상 저장, 라인 저장 실패 롤백, 중복 원천, 비활성 계정과목" 테스트(이슈 To-do).
  *
- * 클래스에 @Transactional을 붙여도 journal_header/journal_line/audit_log는 자동
- * 롤백되지 않는다 — JournalPersistenceServiceImpl.saveDraft()의 실제 저장은
- * REQUIRES_NEW로 별도 트랜잭션에서 커밋되므로, 이 테스트 트랜잭션이 롤백돼도 그 커밋은
- * 그대로 남는다(코드리뷰 반영). 그래서 @AfterEach에서 description 마커로 직접
- * DELETE한다 — journal_account.active_yn UPDATE만 REQUIRES_NEW를 타지 않는 일반
- * 쿼리라 @Transactional 롤백으로 정리된다. audit_log는 append-only라 지우지
- * 않는다(다른 통합테스트와 같은 관례 — request_id로 구분되어 해가 없다).
+ * 클래스에 @Transactional을 붙이지 않는다(코드리뷰 반영 — 이전에는 붙어 있었는데,
+ * 그러면 @AfterEach의 정리 DELETE까지 테스트 트랜잭션에 같이 묶여서 테스트 종료 시
+ * 롤백돼 버렸다. saveDraft()의 실제 저장은 REQUIRES_NEW로 커밋되니, 정리 DELETE도
+ * 똑같이 진짜로 커밋돼야 짝이 맞는다 — @Transactional을 빼면 각 jdbcTemplate 호출이
+ * 자동커밋되어 @AfterEach가 실제로 지운다). 이 버그 때문에 매 테스트 실행마다
+ * FGC-FGL01-202607-0001에 분개가 계속 쌓이고 있었다(#108 작업 중 발견, 확인 시점
+ * 기준 30건 누적 — 수동으로 정리함).
  */
 @SpringBootTest
-@Transactional
 class JournalPersistenceServiceImplIntegrationTest {
 
     private static final String TEST_MARKER = "#93 통합테스트";
@@ -56,6 +54,11 @@ class JournalPersistenceServiceImplIntegrationTest {
                 )
                 """, TEST_MARKER);
         jdbcTemplate.update("DELETE FROM fgc.journal_header WHERE description = ?", TEST_MARKER);
+        // inactiveAccountCodeIsRejectedBeforeAnyInsert()가 비활성화시킨 계정과목을
+        // 되돌린다 — @Transactional이 없으니 더는 자동 롤백되지 않는다. 그 테스트가 안
+        // 돌았어도 이미 true인 값을 다시 true로 세팅할 뿐이라 항상 실행해도 안전하다.
+        jdbcTemplate.update("UPDATE fgc.journal_account SET active_yn = true WHERE account_code = ?",
+                JournalAccountCode.EXPECTED_RECEIVABLE.name());
     }
 
     private Long contractId() {
@@ -168,8 +171,8 @@ class JournalPersistenceServiceImplIntegrationTest {
 
     @Test
     void inactiveAccountCodeIsRejectedBeforeAnyInsert() {
-        // @Transactional 테스트라 이 UPDATE도 테스트 종료 시 자동 롤백된다 —
-        // 다른 테스트나 실제 데이터에 영향을 주지 않는다.
+        // @AfterEach의 cleanUp()이 이 UPDATE를 되돌린다(더는 @Transactional 자동
+        // 롤백에 기대지 않는다).
         jdbcTemplate.update("UPDATE fgc.journal_account SET active_yn = false WHERE account_code = ?",
                 JournalAccountCode.EXPECTED_RECEIVABLE.name());
 


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* 계약 상세 화면(CONT-W02)에서 특정 계약과 연결된 검증원장 분개 및 수수료 지급 건을 조회하는 읽기 전용 Projection API 구현

## 🔗 2. 관련 이슈

* Closes #108

## 🛠 3. 구현 내용

* `GET /api/v1/contracts/{id}/journals` : journal_header/journal_line/journal_account를 계약 기준으로 조회해 헤더 단위로 그룹핑, 차변·대변 합계·차액·지급단계를 헤더 응답에 포함
* `GET /api/v1/contracts/{id}/transactions` : commission_transaction/transaction_attribution을 계약 기준으로 조회해 지급 건 단위로 그룹핑, 귀속 합계·지급액 차액 포함
* `JournalHeaderStatus` 신규 enum + `CommissionPaymentStatus`/`InclusionDecisionStatus`에 `label()` 추가
* `PersonalInfoMasker` 유틸 추가
* 계약 없음은 `FGC-COMMON-004`(404)로 처리
* `JournalPersistenceServiceImplIntegrationTest`의 `@AfterEach` 정리가 실제로 커밋되지 않던 버그 수정(REQUIRES_NEW로 커밋되는 데이터를 `@Transactional` 테스트 안에서 지우려 해서 롤백되던 문제)

## 🧪 4. 테스트 방법

1. `./gradlew test --tests "com.susukkang.fgc.contract.service.*" --tests "com.susukkang.fgc.common.util.PersonalInfoMaskerTest"` 실행
2. 계약 없음(404), 데이터 없음(빈 목록), 예상·실제 분개 분리, POSTED 이력 포함, 귀속 합계·차액, 설계사명 마스킹 시나리오 확인
3. POSTED 테스트는 DB 트리거상 POSTED/REVERSED 분개를 영구히 지울 수 없어 `@Transactional` 롤백으로만 정리(별도 격리된 계약 사용)
4. 전체 스위트: `./gradlew test`

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* 이슈 문구상 헤더 응답 필드로 명시된 "지급단계"를 journal_line 값을 헤더로 끌어올려 채운 판단이 적절한지
* 설계사명 마스킹 규칙(목업의 FGC.mask 재사용)이 실제 화면 정책과 맞는지 (화면정의서에는 계약자용으로만 명시돼 있어 설계사명에 그대로 적용한 것)

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음(API만 구현, 화면 연동은 별도)

## 💬 9. 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 계약 상세에서 검증원장, 지급 내역 및 대사 결과를 조회할 수 있습니다.
  - 원장별 합계·차액·상태·지급 단계와 상세 라인을 제공합니다.
  - 지급 건별 귀속 금액, 차액, 상태 및 담당자 정보를 확인할 수 있습니다.
  - 주요 상태와 대사 결과에 한국어 표시명을 제공합니다.
  - 이름 개인정보 마스킹 기능을 추가했습니다.
- **개선**
  - 조회 결과가 없을 때 빈 목록으로 표시됩니다.
  - 존재하지 않는 계약 조회 시 명확한 오류를 제공합니다.
- **테스트**
  - 원장·지급 조회와 이름 마스킹 검증을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->