### PR TITLE
[Style] Figma 기반 잔여 업무 화면 퍼블리싱

### DIFF
--- a/src/main/resources/static/css/common/layout.css
+++ b/src/main/resources/static/css/common/layout.css
@@ -526,6 +526,12 @@
   to { transform: rotate(360deg); }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .month-selector-loading {
+    animation: none;
+  }
+}
+
 .workspace-tab-bar {
   position: fixed;
   inset: var(--layout-header-height) 0 auto var(--layout-sidebar-width);

--- a/src/main/resources/static/css/common/layout.css
+++ b/src/main/resources/static/css/common/layout.css
@@ -262,6 +262,7 @@
   padding: 0 var(--space-6);
   border-bottom: 1px solid var(--color-border-subtle);
   background: var(--color-bg-surface);
+  overflow: visible;
 }
 
 .app-header-title {
@@ -307,6 +308,222 @@
   font-size: 0.75rem;
   line-height: 1.125rem;
   white-space: nowrap;
+}
+
+.month-selector {
+  position: relative;
+}
+
+.month-selector-trigger {
+  display: flex;
+  width: 6.5rem;
+  height: var(--control-height-sm);
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: 0 0.625rem;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-6);
+  color: var(--color-text-primary);
+  background: var(--color-bg-surface);
+  font-size: 0.875rem;
+  line-height: 1.375rem;
+  white-space: nowrap;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.month-selector-trigger:hover {
+  border-color: var(--color-border-strong);
+}
+
+.month-selector-trigger:focus-visible,
+.month-selector.is-open .month-selector-trigger {
+  border-width: 1.5px;
+  border-color: var(--color-border-focus);
+  outline: 0;
+  box-shadow: var(--shadow-focus);
+}
+
+.month-selector-chevron {
+  color: var(--color-text-secondary);
+  font-size: 1.25rem;
+}
+
+.month-selector.is-open .month-selector-chevron {
+  transform: rotate(180deg);
+}
+
+.month-selector-popover {
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  right: 0;
+  z-index: var(--z-overlay);
+  display: flex;
+  width: 22.5rem;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-12);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-md);
+}
+
+.month-selector-popover[hidden] {
+  display: none;
+}
+
+.month-selector-year-navigation {
+  display: flex;
+  height: var(--control-height-sm);
+  align-items: center;
+  justify-content: space-between;
+}
+
+.month-selector-year {
+  color: var(--color-text-primary);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.5rem;
+}
+
+.month-selector-grid {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.month-selector-row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.month-selector-cell {
+  display: flex;
+  min-width: 0;
+  height: 3rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 1.5px solid transparent;
+  border-radius: var(--radius-8);
+  color: var(--color-text-primary);
+  background: var(--color-bg-subtle);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.125rem;
+  transition: color var(--transition-fast), background-color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.month-selector-cell:hover:not(:disabled) {
+  border-color: var(--color-border-strong);
+}
+
+.month-selector-cell.is-selected {
+  border-color: var(--color-action-primary);
+  color: var(--color-text-inverse);
+  background: var(--color-action-primary);
+  font-weight: 700;
+}
+
+.month-selector-cell.is-current {
+  border-color: var(--color-border-focus);
+}
+
+.month-selector-cell.is-selected.is-current {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+}
+
+.month-selector-cell:disabled,
+.month-selector-cell.is-disabled {
+  border-color: transparent;
+  color: var(--color-text-disabled);
+  background: var(--color-bg-subtle);
+  cursor: not-allowed;
+  opacity: 0.72;
+}
+
+.month-selector-cell:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+}
+
+.month-selector-cell-state {
+  font-size: 0.625rem;
+  font-weight: 500;
+  line-height: 0.875rem;
+}
+
+.month-selector-cell.is-current:not(.is-selected) .month-selector-cell-state {
+  color: var(--color-text-secondary);
+}
+
+.month-selector-scope {
+  display: grid;
+  min-height: 4rem;
+  grid-template-columns: 1.25rem minmax(0, 1fr);
+  gap: var(--space-2);
+  align-items: center;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-focus);
+  border-radius: var(--radius-8);
+  color: var(--color-text-link);
+  background: var(--color-action-subtle);
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+}
+
+.month-selector-scope .material-symbols-rounded {
+  font-size: 1.25rem;
+}
+
+.month-selector-scope strong {
+  font-weight: 500;
+}
+
+.month-selector-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.month-selector-selection {
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+  white-space: nowrap;
+}
+
+.month-selector-selection strong {
+  font-weight: 500;
+}
+
+.month-selector-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.month-selector-actions .button {
+  min-width: 6rem;
+}
+
+.month-selector-actions .button-primary[aria-busy="true"] {
+  color: var(--color-text-inverse);
+  background: var(--color-action-primary);
+}
+
+.month-selector-loading {
+  font-size: 0.875rem;
+  animation: month-selector-spin 800ms linear infinite;
+}
+
+@keyframes month-selector-spin {
+  to { transform: rotate(360deg); }
 }
 
 .workspace-tab-bar {
@@ -749,6 +966,23 @@
   .app-header-field-label,
   .app-header-role.status-badge {
     display: none;
+  }
+
+  .month-selector-popover {
+    position: fixed;
+    inset: auto var(--space-4) var(--space-4);
+    width: auto;
+    max-height: calc(100dvh - var(--space-8));
+    overflow-y: auto;
+  }
+
+  .month-selector-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .month-selector-actions .button {
+    flex: 1;
   }
 
   .workspace-tab-bar {

--- a/src/main/resources/static/css/features/publishing.css
+++ b/src/main/resources/static/css/features/publishing.css
@@ -1,0 +1,550 @@
+/*
+ * FGC Production publishing bridge
+ *
+ * The remaining first-phase screens still use the established fgc-* DOM
+ * contract. These scoped rules align that contract with the Production App
+ * Shell without changing Thymeleaf bindings or introducing mock data.
+ */
+
+.app-main > .publishing-page {
+  width: 100%;
+  max-width: var(--layout-content-max);
+  margin: 0 auto;
+  padding: var(--space-4) var(--layout-page-padding) var(--space-8);
+  color: var(--color-text-primary);
+  font-family: var(--font-sans);
+}
+
+.publishing-page,
+.publishing-modal {
+  --fgc-primary: var(--color-action-primary);
+  --fgc-primary-container: var(--color-action-primary-hover);
+  --fgc-secondary: var(--color-steel-500);
+  --fgc-surface-lowest: var(--color-bg-surface);
+  --fgc-surface-low: var(--color-bg-subtle);
+  --fgc-surface-container: var(--color-neutral-100);
+  --fgc-outline: var(--color-border-strong);
+  --fgc-outline-variant: var(--color-border-default);
+  --fgc-on-surface: var(--color-text-primary);
+  --fgc-on-surface-variant: var(--color-text-secondary);
+}
+
+.publishing-page .fgc-page-title {
+  color: var(--color-text-primary);
+  font-size: 1.125rem;
+  font-weight: 700;
+  line-height: 1.625rem;
+  letter-spacing: -0.01em;
+  text-wrap: balance;
+}
+
+.publishing-page .fgc-page-desc {
+  max-width: 65rem;
+  margin-top: var(--space-1);
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+  text-wrap: pretty;
+}
+
+.publishing-page .publishing-page-head > :first-child {
+  flex: 1 1 32rem;
+  min-width: 0;
+}
+
+.publishing-page .publishing-inline-controls {
+  display: flex;
+  flex: 0 1 auto;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
+.publishing-page .publishing-inline-controls .fgc-label,
+.publishing-page .publishing-inline-controls label {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.publishing-page .publishing-inline-controls .fgc-select {
+  width: auto;
+  min-width: 9rem;
+  max-width: 16rem;
+  flex: 1 1 9rem;
+}
+
+.publishing-page .fgc-muted {
+  color: var(--color-text-tertiary);
+}
+
+.publishing-page .fgc-mono,
+.publishing-page .fgc-num,
+.publishing-page .fgc-amount,
+.publishing-modal .fgc-mono,
+.publishing-modal .fgc-num,
+.publishing-modal .fgc-amount {
+  font-family: var(--font-sans);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
+}
+
+.publishing-page .fgc-card,
+.publishing-modal .fgc-card {
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-12);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-xs);
+}
+
+.publishing-page .fgc-card__head,
+.publishing-modal .fgc-card__head {
+  min-height: 2.75rem;
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-surface);
+}
+
+.publishing-page .fgc-card__title,
+.publishing-modal .fgc-card__title {
+  color: var(--color-text-primary);
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 1.375rem;
+}
+
+.publishing-page .fgc-card__body,
+.publishing-modal .fgc-card__body {
+  padding: var(--space-4);
+}
+
+.publishing-page .fgc-banner {
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-8);
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+}
+
+.publishing-page .fgc-banner--info {
+  border-color: var(--color-status-info-border);
+  color: var(--color-status-info-text);
+  background: var(--color-status-info-bg);
+}
+
+.publishing-page .fgc-banner--warn {
+  border-color: var(--color-status-warning-border);
+  color: var(--color-status-warning-text);
+  background: var(--color-status-warning-bg);
+}
+
+.publishing-page .fgc-banner--error {
+  border-color: var(--color-status-error-border);
+  color: var(--color-status-error-text);
+  background: var(--color-status-error-bg);
+}
+
+.publishing-page .fgc-banner--muted {
+  border-color: var(--color-border-default);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-subtle);
+}
+
+.publishing-page .fgc-tabs {
+  gap: 0;
+  border-bottom-color: var(--color-border-default);
+  scrollbar-width: thin;
+}
+
+.publishing-page .fgc-tab {
+  min-height: 2.5rem;
+  padding: 0 var(--space-4);
+  border-bottom-width: 2px;
+  color: var(--color-text-secondary);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  transition: color var(--transition-fast), background-color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.publishing-page .fgc-tab:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-subtle);
+}
+
+.publishing-page .fgc-tab[aria-selected="true"] {
+  border-bottom-color: var(--color-action-primary);
+  color: var(--color-text-link);
+  background: var(--color-bg-surface);
+}
+
+.publishing-page .fgc-tabpanel {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.publishing-page .fgc-toolbar {
+  gap: var(--space-3);
+  align-items: flex-end;
+}
+
+.publishing-page .fgc-field {
+  min-width: 0;
+  gap: var(--space-2);
+}
+
+.publishing-page .fgc-label {
+  color: var(--color-text-primary);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.125rem;
+}
+
+.publishing-page .fgc-input,
+.publishing-page .fgc-select,
+.publishing-page .fgc-textarea {
+  width: 100%;
+  min-height: var(--control-height-sm);
+  padding: 0 var(--space-3);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-8);
+  color: var(--color-text-primary);
+  background: var(--color-bg-surface);
+  font-size: 0.8125rem;
+  line-height: 1.125rem;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.publishing-page .fgc-textarea {
+  min-height: 6rem;
+  padding-block: var(--space-3);
+}
+
+.publishing-page .fgc-input:hover,
+.publishing-page .fgc-select:hover,
+.publishing-page .fgc-textarea:hover {
+  border-color: var(--color-border-strong);
+}
+
+.publishing-page .fgc-input:focus,
+.publishing-page .fgc-select:focus,
+.publishing-page .fgc-textarea:focus {
+  border-color: var(--color-border-focus);
+  outline: 0;
+  box-shadow: var(--shadow-focus);
+}
+
+.publishing-page .fgc-help,
+.publishing-page .fgc-error {
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+}
+
+.publishing-page .fgc-help {
+  color: var(--color-text-tertiary);
+}
+
+.publishing-page .fgc-error {
+  color: var(--color-status-error-text);
+}
+
+.publishing-page .fgc-btn,
+.publishing-modal .fgc-btn {
+  min-width: 6rem;
+  min-height: var(--control-height-sm);
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-8);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.125rem;
+  transition: color var(--transition-fast), background-color var(--transition-fast), border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.publishing-page .fgc-btn:active:not(:disabled),
+.publishing-modal .fgc-btn:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.publishing-page .fgc-btn--primary,
+.publishing-modal .fgc-btn--primary {
+  color: var(--color-text-inverse);
+  background: var(--color-action-primary);
+}
+
+.publishing-page .fgc-btn--primary:hover:not(:disabled),
+.publishing-modal .fgc-btn--primary:hover:not(:disabled) {
+  background: var(--color-action-primary-hover);
+}
+
+.publishing-page .fgc-btn--ghost,
+.publishing-modal .fgc-btn--ghost {
+  border-color: var(--color-border-default);
+  color: var(--color-text-primary);
+  background: var(--color-bg-surface);
+}
+
+.publishing-page .fgc-btn--ghost:hover:not(:disabled),
+.publishing-modal .fgc-btn--ghost:hover:not(:disabled) {
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-subtle);
+}
+
+.publishing-page .fgc-btn:disabled,
+.publishing-modal .fgc-btn:disabled {
+  border-color: var(--color-border-default);
+  color: var(--color-text-disabled);
+  background: var(--color-bg-subtle);
+  opacity: 1;
+  transform: none;
+}
+
+.publishing-page [style*="overflow-x:auto"],
+.publishing-modal [style*="overflow-x:auto"] {
+  max-width: 100%;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: thin;
+}
+
+.publishing-page .fgc-table,
+.publishing-modal .fgc-table {
+  width: 100%;
+  min-width: 48rem;
+  color: var(--color-text-primary);
+  background: var(--color-bg-surface);
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+}
+
+.publishing-page .fgc-table thead th,
+.publishing-modal .fgc-table thead th {
+  height: 2.5rem;
+  padding: 0 var(--data-table-cell-padding-x);
+  border-bottom: 1px solid var(--color-border-default);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-subtle);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.publishing-page .fgc-table tbody td,
+.publishing-modal .fgc-table tbody td {
+  height: 2.625rem;
+  padding: 0 var(--data-table-cell-padding-x);
+  border-bottom: 1px solid var(--color-border-default);
+  color: var(--color-text-primary);
+}
+
+.publishing-page .fgc-table tbody tr,
+.publishing-modal .fgc-table tbody tr {
+  transition: background-color var(--transition-fast);
+}
+
+.publishing-page .fgc-table tbody tr:hover,
+.publishing-modal .fgc-table tbody tr:hover {
+  background: var(--color-neutral-50);
+}
+
+.publishing-page .fgc-table tfoot td,
+.publishing-modal .fgc-table tfoot td {
+  padding: var(--space-2) var(--data-table-cell-padding-x);
+  border-top: 1px solid var(--color-border-strong);
+  background: var(--color-bg-subtle);
+}
+
+.publishing-page .fgc-empty {
+  display: grid;
+  min-height: 10rem;
+  place-items: center;
+  padding: var(--space-8);
+  color: var(--color-text-secondary);
+  font-size: 0.8125rem;
+  text-align: center;
+}
+
+.publishing-page .publishing-empty-state {
+  grid-column: 1 / -1;
+  min-height: 5rem;
+  border: 1px dashed var(--color-border-default);
+  border-radius: var(--radius-12);
+  background: var(--color-bg-subtle);
+}
+
+.publishing-page .fgc-stepper > .publishing-empty-state {
+  flex: 1 1 100%;
+}
+
+.publishing-page .publishing-result-placeholder {
+  display: flex;
+  min-width: 0;
+  min-height: 4.5rem;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-8);
+  color: var(--color-text-primary);
+  background: var(--color-bg-subtle);
+  font-size: 0.8125rem;
+}
+
+.publishing-page .publishing-result-placeholder span {
+  color: var(--color-text-tertiary);
+  font-size: 0.75rem;
+}
+
+.publishing-page .fgc-badge,
+.publishing-modal .fgc-badge {
+  min-height: 1.5rem;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-6);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1.375rem;
+}
+
+.publishing-page .fgc-kpi {
+  min-width: 0;
+  padding: var(--space-4);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-12);
+  background: var(--color-bg-surface);
+  box-shadow: none;
+}
+
+.publishing-page .fgc-kpi:hover {
+  box-shadow: var(--shadow-xs);
+}
+
+.publishing-page .fgc-kpi__value {
+  font-size: 1.75rem;
+  line-height: 2.125rem;
+}
+
+.publishing-page .fgc-responsive-split,
+.publishing-page .fgc-compare {
+  gap: var(--space-4);
+}
+
+.publishing-page .fgc-stage-card,
+.publishing-page .fgc-compare__side {
+  border-color: var(--color-border-default);
+  border-radius: var(--radius-12);
+  background: var(--color-bg-surface);
+}
+
+.publishing-page .fgc-compare__head {
+  padding: var(--space-2) var(--space-4);
+  border-bottom-color: var(--color-border-default);
+  background: var(--color-bg-subtle);
+}
+
+.publishing-page .fgc-stepper__dot,
+.publishing-page .fgc-check__icon {
+  width: 1.375rem;
+  height: 1.375rem;
+}
+
+.publishing-page .fgc-check {
+  gap: var(--space-3);
+  padding: var(--space-3) 0;
+  border-bottom-color: var(--color-border-subtle);
+}
+
+.publishing-page .fgc-evidence__tip {
+  border-radius: var(--radius-8);
+  background: var(--color-neutral-800);
+  box-shadow: var(--shadow-md);
+}
+
+.publishing-modal {
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-12);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-md);
+}
+
+.publishing-modal .fgc-modal__head,
+.publishing-modal .fgc-modal__foot {
+  padding: var(--space-3) var(--space-5);
+  border-color: var(--color-border-default);
+}
+
+.publishing-modal .fgc-modal__body {
+  padding: var(--space-5);
+}
+
+@media (max-width: 63.9375rem) {
+  .publishing-page [style*="grid-template-columns:repeat(4"],
+  .publishing-page [style*="grid-template-columns: repeat(4"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+
+  .publishing-page [style*="grid-template-columns:repeat(3"],
+  .publishing-page [style*="grid-template-columns: repeat(3"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+  }
+}
+
+@media (max-width: 47.9375rem) {
+  .app-main > .publishing-page {
+    padding: var(--space-4) var(--space-3) var(--space-8);
+  }
+
+  .publishing-page [style*="grid-template-columns"] {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+
+  .publishing-page .fgc-toolbar,
+  .publishing-page .fgc-card__head {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .publishing-page .fgc-toolbar .fgc-field,
+  .publishing-page .fgc-toolbar .fgc-input,
+  .publishing-page .fgc-toolbar .fgc-select,
+  .publishing-page .fgc-toolbar .fgc-btn {
+    width: 100% !important;
+  }
+
+  .publishing-page .publishing-page-head {
+    align-items: stretch !important;
+  }
+
+  .publishing-page .publishing-page-head > .fgc-btn,
+  .publishing-page .publishing-page-head > .publishing-inline-controls {
+    width: 100%;
+  }
+
+  .publishing-page .publishing-inline-controls {
+    justify-content: flex-start;
+  }
+
+  .publishing-page .publishing-inline-controls .fgc-select {
+    max-width: none;
+  }
+
+  .publishing-page .fgc-btn {
+    min-height: var(--control-height-md);
+  }
+
+  .publishing-page .fgc-compare {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .publishing-modal .fgc-modal__head,
+  .publishing-modal .fgc-modal__body,
+  .publishing-modal .fgc-modal__foot {
+    padding-inline: var(--space-4);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .publishing-page *,
+  .publishing-modal * {
+    animation: none !important;
+  }
+}

--- a/src/main/resources/static/css/features/publishing.css
+++ b/src/main/resources/static/css/features/publishing.css
@@ -546,5 +546,6 @@
   .publishing-page *,
   .publishing-modal * {
     animation: none !important;
+    transition: none !important;
   }
 }

--- a/src/main/resources/static/js/common/app-shell.js
+++ b/src/main/resources/static/js/common/app-shell.js
@@ -2,10 +2,50 @@
   "use strict";
 
   var MOBILE_SIDEBAR_QUERY = "(max-width: 47.9375rem)";
+  var SIDEBAR_OPEN_SECTIONS_KEY = "fgc.sidebar.open-sections.v1";
   var mobileSidebarMedia = window.matchMedia(MOBILE_SIDEBAR_QUERY);
   var sidebar = document.querySelector("[data-app-sidebar]");
   var sidebarToggle = document.querySelector("[data-action='open-app-sidebar']");
   var sidebarBackdrop = document.querySelector(".app-sidebar-backdrop");
+
+  function getSidebarSections() {
+    if (!sidebar) return [];
+    return Array.prototype.slice.call(sidebar.querySelectorAll("details[data-sidebar-section]"));
+  }
+
+  function readOpenSidebarSections() {
+    try {
+      var stored = JSON.parse(window.sessionStorage.getItem(SIDEBAR_OPEN_SECTIONS_KEY) || "[]");
+      return Array.isArray(stored) ? stored : [];
+    } catch (error) {
+      return [];
+    }
+  }
+
+  function persistOpenSidebarSections() {
+    try {
+      var openSections = getSidebarSections()
+        .filter(function (section) { return section.open; })
+        .map(function (section) { return section.getAttribute("data-sidebar-section"); });
+      window.sessionStorage.setItem(SIDEBAR_OPEN_SECTIONS_KEY, JSON.stringify(openSections));
+    } catch (error) {
+      // Storage may be unavailable in privacy-restricted browsing contexts.
+    }
+  }
+
+  function initializeSidebarSectionState() {
+    var sections = getSidebarSections();
+    var savedOpenSections = readOpenSidebarSections();
+
+    sections.forEach(function (section) {
+      var sectionId = section.getAttribute("data-sidebar-section");
+      if (savedOpenSections.indexOf(sectionId) !== -1) section.open = true;
+      section.addEventListener("toggle", persistOpenSidebarSections);
+    });
+
+    // Preserve both the server-opened active section and previously opened sections.
+    persistOpenSidebarSections();
+  }
 
   function getSidebarFocusableElements() {
     if (!sidebar) return [];
@@ -51,17 +91,37 @@
     document.body.classList.remove("is-app-sidebar-open");
   }
 
-  function changeGlobalMonth(select) {
+  function navigateToGlobalMonth(month) {
     var url = new URL(window.location.href);
-    url.searchParams.set("month", select.value);
+    url.searchParams.set("month", month);
     url.searchParams.delete("page");
     window.location.assign(url.pathname + url.search);
   }
 
-  document.addEventListener("change", function (event) {
-    var select = event.target.closest("[data-action='change-global-month']");
-    if (select) changeGlobalMonth(select);
-  });
+  function initializeGlobalMonthSelector() {
+    var root = document.querySelector("[data-month-selector]");
+    if (!root || !window.FgcUi || !window.FgcUi.createMonthSelector) return;
+
+    window.FgcUi.createMonthSelector(root, {
+      getOpenTabCount: function () {
+        return window.FgcUi.workspaceTabs ? window.FgcUi.workspaceTabs.getOpenTabCount() : 1;
+      },
+      onApply: function (month) {
+        return new Promise(function (resolve, reject) {
+          var previousTabs = null;
+          window.requestAnimationFrame(function () {
+            try {
+              if (window.FgcUi.workspaceTabs) previousTabs = window.FgcUi.workspaceTabs.applyGlobalMonth(month);
+              navigateToGlobalMonth(month);
+            } catch (error) {
+              if (window.FgcUi.workspaceTabs && previousTabs) window.FgcUi.workspaceTabs.restoreTabs(previousTabs);
+              reject(error);
+            }
+          });
+        });
+      }
+    });
+  }
 
   document.addEventListener("click", function (event) {
     if (event.target.closest("[data-action='open-app-sidebar']")) {
@@ -97,5 +157,7 @@
   });
 
   mobileSidebarMedia.addEventListener("change", syncSidebarMode);
+  initializeGlobalMonthSelector();
+  initializeSidebarSectionState();
   syncSidebarMode();
 })();

--- a/src/main/resources/static/js/common/app-shell.js
+++ b/src/main/resources/static/js/common/app-shell.js
@@ -113,6 +113,7 @@
             try {
               if (window.FgcUi.workspaceTabs) previousTabs = window.FgcUi.workspaceTabs.applyGlobalMonth(month);
               navigateToGlobalMonth(month);
+              resolve();
             } catch (error) {
               if (window.FgcUi.workspaceTabs && previousTabs) window.FgcUi.workspaceTabs.restoreTabs(previousTabs);
               reject(error);

--- a/src/main/resources/static/js/common/month-selector.js
+++ b/src/main/resources/static/js/common/month-selector.js
@@ -149,7 +149,7 @@
     function changeYear(offset) {
       if (state.applying) return;
       var nextYear = state.displayYear + offset;
-      if (nextYear < 0 || nextYear > 9999) return;
+      if (nextYear < 1 || nextYear > 9999) return;
       state.displayYear = nextYear;
       render();
       var focusTarget = cells.find(function (cell) {

--- a/src/main/resources/static/js/common/month-selector.js
+++ b/src/main/resources/static/js/common/month-selector.js
@@ -1,0 +1,246 @@
+(function () {
+  "use strict";
+
+  var MONTH_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
+  var KEYBOARD_OFFSETS = {
+    ArrowLeft: -1,
+    ArrowRight: 1,
+    ArrowUp: -4,
+    ArrowDown: 4
+  };
+
+  function actualCurrentMonth() {
+    var now = new Date();
+    return String(now.getFullYear()).padStart(4, "0") + "-" + String(now.getMonth() + 1).padStart(2, "0");
+  }
+
+  function parseDisabledMonths(root) {
+    try {
+      var parsed = JSON.parse(root.dataset.disabledMonths || "[]");
+      return Array.isArray(parsed) ? parsed.filter(function (month) { return MONTH_PATTERN.test(month); }) : [];
+    } catch (error) {
+      return [];
+    }
+  }
+
+  function toMonthValue(year, monthIndex) {
+    return String(year).padStart(4, "0") + "-" + String(monthIndex).padStart(2, "0");
+  }
+
+  function formatMonth(month) {
+    var parts = month.split("-");
+    return Number(parts[0]) + "년 " + Number(parts[1]) + "월";
+  }
+
+  function createMonthSelector(root, options) {
+    var settings = options || {};
+    var trigger = root.querySelector("[data-action='toggle-month-selector']");
+    var popover = root.querySelector(".month-selector-popover");
+    var grid = root.querySelector("[data-month-selector-grid]");
+    var cells = Array.prototype.slice.call(root.querySelectorAll("[data-month-index]"));
+    var yearLabel = root.querySelector("[data-month-selector-year]");
+    var triggerValue = root.querySelector("[data-month-selector-value]");
+    var draftValue = root.querySelector("[data-month-selector-draft-value]");
+    var scopeValue = root.querySelector("[data-month-selector-scope-value]");
+    var tabCount = root.querySelector("[data-month-selector-tab-count]");
+    var applyButton = root.querySelector("[data-action='apply-month-selector']");
+    var applyLabel = root.querySelector("[data-month-selector-apply-label]");
+    var loadingIcon = root.querySelector(".month-selector-loading");
+    var errorRegion = root.querySelector("[data-month-selector-error]");
+    var disabledMonths = parseDisabledMonths(root);
+    var state = {
+      value: MONTH_PATTERN.test(root.dataset.value || "") ? root.dataset.value : actualCurrentMonth(),
+      draftValue: null,
+      currentMonth: actualCurrentMonth(),
+      displayYear: 0,
+      open: false,
+      applying: false
+    };
+
+    if (!trigger || !popover || !grid || !cells.length || !applyButton) return null;
+
+    function isDisabled(month) {
+      return disabledMonths.indexOf(month) !== -1;
+    }
+
+    function updateCell(cell) {
+      var month = toMonthValue(state.displayYear, Number(cell.dataset.monthIndex));
+      var selected = month === state.draftValue;
+      var current = month === state.currentMonth;
+      var disabled = isDisabled(month);
+      var stateText = cell.querySelector(".month-selector-cell-state");
+
+      cell.dataset.month = month;
+      cell.disabled = disabled || state.applying;
+      cell.classList.toggle("is-selected", selected);
+      cell.classList.toggle("is-current", current);
+      cell.classList.toggle("is-disabled", disabled);
+      cell.setAttribute("aria-selected", String(selected));
+      cell.setAttribute("aria-current", current ? "date" : "false");
+      cell.setAttribute("aria-label", Number(cell.dataset.monthIndex) + "월" +
+        (selected ? ", 선택됨" : "") + (current ? ", 현재" : "") + (disabled ? ", 선택 불가" : ""));
+
+      if (stateText) {
+        stateText.textContent = selected && current ? "선택됨 · 현재" : selected ? "선택됨" : current ? "현재" : "";
+        stateText.hidden = !selected && !current;
+      }
+    }
+
+    function render() {
+      yearLabel.textContent = state.displayYear + "년";
+      grid.setAttribute("aria-label", state.displayYear + "년 정산월 선택");
+      cells.forEach(updateCell);
+      triggerValue.textContent = state.value;
+      if (state.draftValue) {
+        draftValue.textContent = formatMonth(state.draftValue);
+        scopeValue.textContent = formatMonth(state.draftValue);
+      }
+      tabCount.textContent = String(typeof settings.getOpenTabCount === "function" ? settings.getOpenTabCount() : 1);
+      applyButton.disabled = state.applying || !state.draftValue || state.draftValue === state.value || isDisabled(state.draftValue);
+      applyButton.classList.toggle("is-loading", state.applying);
+      applyButton.setAttribute("aria-busy", String(state.applying));
+      applyLabel.textContent = state.applying ? "적용 중" : "적용";
+      loadingIcon.hidden = !state.applying;
+    }
+
+    function focusInitialCell() {
+      var selected = cells.find(function (cell) { return cell.dataset.month === state.draftValue && !cell.disabled; });
+      var current = cells.find(function (cell) { return cell.dataset.month === state.currentMonth && !cell.disabled; });
+      var firstEnabled = cells.find(function (cell) { return !cell.disabled; });
+      (selected || current || firstEnabled || trigger).focus();
+    }
+
+    function open() {
+      if (state.applying) return;
+      state.draftValue = state.value;
+      state.displayYear = Number(state.value.slice(0, 4));
+      state.open = true;
+      errorRegion.textContent = "";
+      popover.hidden = false;
+      root.classList.add("is-open");
+      trigger.setAttribute("aria-expanded", "true");
+      render();
+      window.requestAnimationFrame(focusInitialCell);
+    }
+
+    function close(restoreFocus) {
+      if (!state.open || state.applying) return;
+      state.draftValue = null;
+      state.open = false;
+      popover.hidden = true;
+      root.classList.remove("is-open");
+      trigger.setAttribute("aria-expanded", "false");
+      if (restoreFocus !== false) trigger.focus();
+    }
+
+    function changeYear(offset) {
+      if (state.applying) return;
+      state.displayYear += offset;
+      render();
+      var focusTarget = cells.find(function (cell) {
+        return Number(cell.dataset.monthIndex) === Number((state.draftValue || state.currentMonth).slice(5, 7)) && !cell.disabled;
+      });
+      if (focusTarget) focusTarget.focus();
+      if (typeof settings.onYearChange === "function") settings.onYearChange(state.displayYear);
+    }
+
+    function selectCell(cell) {
+      if (!cell || cell.disabled || state.applying) return;
+      state.draftValue = cell.dataset.month;
+      render();
+    }
+
+    function setApplying(applying) {
+      state.applying = applying;
+      trigger.disabled = applying;
+      root.querySelector("[data-action='previous-month-selector-year']").disabled = applying;
+      root.querySelector("[data-action='next-month-selector-year']").disabled = applying;
+      root.querySelector("[data-action='cancel-month-selector']").disabled = applying;
+      render();
+    }
+
+    function showApplyError(error) {
+      setApplying(false);
+      var message = error && error.message ? error.message : "기준 정산월을 적용하지 못했습니다.";
+      errorRegion.textContent = message;
+      if (window.FgcUi && typeof window.FgcUi.toast === "function") window.FgcUi.toast(message, "error");
+    }
+
+    function commitApply(nextValue) {
+      state.value = nextValue;
+      root.dataset.value = nextValue;
+      setApplying(false);
+      close(true);
+    }
+
+    function apply() {
+      if (applyButton.disabled || !state.draftValue) return;
+      var nextValue = state.draftValue;
+      setApplying(true);
+      try {
+        var result = typeof settings.onApply === "function" ? settings.onApply(nextValue, state.value) : null;
+        if (result && typeof result.then === "function") {
+          result.then(function () { commitApply(nextValue); }).catch(showApplyError);
+        } else {
+          commitApply(nextValue);
+        }
+      } catch (error) {
+        showApplyError(error);
+      }
+    }
+
+    function moveCellFocus(currentCell, offset) {
+      var start = cells.indexOf(currentCell);
+      if (start < 0) return;
+      var target = start + offset;
+      while (target >= 0 && target < cells.length && cells[target].disabled) target += offset < 0 ? -1 : 1;
+      if (target >= 0 && target < cells.length) cells[target].focus();
+    }
+
+    trigger.addEventListener("click", function () {
+      if (state.open) close(true);
+      else open();
+    });
+
+    root.querySelector("[data-action='previous-month-selector-year']").addEventListener("click", function () { changeYear(-1); });
+    root.querySelector("[data-action='next-month-selector-year']").addEventListener("click", function () { changeYear(1); });
+    root.querySelector("[data-action='cancel-month-selector']").addEventListener("click", function () { close(true); });
+    applyButton.addEventListener("click", apply);
+
+    grid.addEventListener("click", function (event) {
+      selectCell(event.target.closest("[data-month-index]"));
+    });
+
+    grid.addEventListener("keydown", function (event) {
+      if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+        event.preventDefault();
+        selectCell(event.target.closest("[data-month-index]"));
+        return;
+      }
+      if (!Object.prototype.hasOwnProperty.call(KEYBOARD_OFFSETS, event.key)) return;
+      event.preventDefault();
+      moveCellFocus(event.target.closest("[data-month-index]"), KEYBOARD_OFFSETS[event.key]);
+    });
+
+    document.addEventListener("pointerdown", function (event) {
+      if (state.open && !root.contains(event.target)) close(true);
+    });
+
+    document.addEventListener("keydown", function (event) {
+      if (event.key === "Escape" && state.open) {
+        event.preventDefault();
+        close(true);
+      }
+    });
+
+    render();
+    return {
+      close: close,
+      open: open,
+      getState: function () { return Object.assign({}, state); }
+    };
+  }
+
+  window.FgcUi = window.FgcUi || {};
+  window.FgcUi.createMonthSelector = createMonthSelector;
+})();

--- a/src/main/resources/static/js/common/month-selector.js
+++ b/src/main/resources/static/js/common/month-selector.js
@@ -47,17 +47,23 @@
     var applyLabel = root.querySelector("[data-month-selector-apply-label]");
     var loadingIcon = root.querySelector(".month-selector-loading");
     var errorRegion = root.querySelector("[data-month-selector-error]");
+    var previousYearButton = root.querySelector("[data-action='previous-month-selector-year']");
+    var nextYearButton = root.querySelector("[data-action='next-month-selector-year']");
+    var cancelButton = root.querySelector("[data-action='cancel-month-selector']");
     var disabledMonths = parseDisabledMonths(root);
+    var currentMonth = actualCurrentMonth();
+    var value = MONTH_PATTERN.test(root.dataset.value || "") ? root.dataset.value : currentMonth;
     var state = {
-      value: MONTH_PATTERN.test(root.dataset.value || "") ? root.dataset.value : actualCurrentMonth(),
+      value: value,
       draftValue: null,
-      currentMonth: actualCurrentMonth(),
-      displayYear: 0,
+      currentMonth: currentMonth,
+      displayYear: Number(value.slice(0, 4)),
       open: false,
       applying: false
     };
 
-    if (!trigger || !popover || !grid || !cells.length || !applyButton) return null;
+    if (!trigger || !popover || !grid || !cells.length || !applyButton ||
+        !previousYearButton || !nextYearButton || !cancelButton) return null;
 
     function isDisabled(month) {
       return disabledMonths.indexOf(month) !== -1;
@@ -77,6 +83,7 @@
       cell.classList.toggle("is-disabled", disabled);
       cell.setAttribute("aria-selected", String(selected));
       cell.setAttribute("aria-current", current ? "date" : "false");
+      cell.tabIndex = selected && !disabled ? 0 : -1;
       cell.setAttribute("aria-label", Number(cell.dataset.monthIndex) + "월" +
         (selected ? ", 선택됨" : "") + (current ? ", 현재" : "") + (disabled ? ", 선택 불가" : ""));
 
@@ -107,7 +114,13 @@
       var selected = cells.find(function (cell) { return cell.dataset.month === state.draftValue && !cell.disabled; });
       var current = cells.find(function (cell) { return cell.dataset.month === state.currentMonth && !cell.disabled; });
       var firstEnabled = cells.find(function (cell) { return !cell.disabled; });
-      (selected || current || firstEnabled || trigger).focus();
+      var focusTarget = selected || current || firstEnabled;
+      if (!focusTarget) {
+        trigger.focus();
+        return;
+      }
+      cells.forEach(function (cell) { cell.tabIndex = cell === focusTarget ? 0 : -1; });
+      focusTarget.focus();
     }
 
     function open() {
@@ -135,12 +148,17 @@
 
     function changeYear(offset) {
       if (state.applying) return;
-      state.displayYear += offset;
+      var nextYear = state.displayYear + offset;
+      if (nextYear < 0 || nextYear > 9999) return;
+      state.displayYear = nextYear;
       render();
       var focusTarget = cells.find(function (cell) {
         return Number(cell.dataset.monthIndex) === Number((state.draftValue || state.currentMonth).slice(5, 7)) && !cell.disabled;
       });
-      if (focusTarget) focusTarget.focus();
+      if (focusTarget) {
+        cells.forEach(function (cell) { cell.tabIndex = cell === focusTarget ? 0 : -1; });
+        focusTarget.focus();
+      }
       if (typeof settings.onYearChange === "function") settings.onYearChange(state.displayYear);
     }
 
@@ -153,9 +171,9 @@
     function setApplying(applying) {
       state.applying = applying;
       trigger.disabled = applying;
-      root.querySelector("[data-action='previous-month-selector-year']").disabled = applying;
-      root.querySelector("[data-action='next-month-selector-year']").disabled = applying;
-      root.querySelector("[data-action='cancel-month-selector']").disabled = applying;
+      previousYearButton.disabled = applying;
+      nextYearButton.disabled = applying;
+      cancelButton.disabled = applying;
       render();
     }
 
@@ -194,7 +212,10 @@
       if (start < 0) return;
       var target = start + offset;
       while (target >= 0 && target < cells.length && cells[target].disabled) target += offset < 0 ? -1 : 1;
-      if (target >= 0 && target < cells.length) cells[target].focus();
+      if (target >= 0 && target < cells.length) {
+        cells.forEach(function (cell, index) { cell.tabIndex = index === target ? 0 : -1; });
+        cells[target].focus();
+      }
     }
 
     trigger.addEventListener("click", function () {
@@ -202,9 +223,9 @@
       else open();
     });
 
-    root.querySelector("[data-action='previous-month-selector-year']").addEventListener("click", function () { changeYear(-1); });
-    root.querySelector("[data-action='next-month-selector-year']").addEventListener("click", function () { changeYear(1); });
-    root.querySelector("[data-action='cancel-month-selector']").addEventListener("click", function () { close(true); });
+    previousYearButton.addEventListener("click", function () { changeYear(-1); });
+    nextYearButton.addEventListener("click", function () { changeYear(1); });
+    cancelButton.addEventListener("click", function () { close(true); });
     applyButton.addEventListener("click", apply);
 
     grid.addEventListener("click", function (event) {

--- a/src/main/resources/static/js/common/workspace-tabs.js
+++ b/src/main/resources/static/js/common/workspace-tabs.js
@@ -53,7 +53,15 @@
   }
 
   function restoreTabs(tabs) {
-    writeTabs(Array.isArray(tabs) ? tabs : []);
+    var safeTabs = Array.isArray(tabs) ? tabs : [];
+    writeTabs(safeTabs);
+
+    document.querySelectorAll("[data-workspace-tabs] .workspace-tab-link").forEach(function (link) {
+      var tabElement = link.closest("[data-tab-id]");
+      var tabId = tabElement ? tabElement.dataset.tabId : null;
+      var restoredTab = safeTabs.find(function (tab) { return tab.id === tabId; });
+      if (restoredTab) link.href = restoredTab.href;
+    });
   }
 
   function getOpenTabCount() {

--- a/src/main/resources/static/js/common/workspace-tabs.js
+++ b/src/main/resources/static/js/common/workspace-tabs.js
@@ -32,6 +32,35 @@
     }
   }
 
+  function hrefWithGlobalMonth(href, month) {
+    var url = new URL(href, window.location.origin);
+    url.searchParams.set("month", month);
+    url.searchParams.delete("page");
+    return url.pathname + url.search + url.hash;
+  }
+
+  function applyGlobalMonth(month) {
+    var previousTabs = readTabs();
+    var updatedTabs = previousTabs.map(function (tab) {
+      return Object.assign({}, tab, { href: hrefWithGlobalMonth(tab.href, month) });
+    });
+    writeTabs(updatedTabs);
+
+    document.querySelectorAll("[data-workspace-tabs] .workspace-tab-link").forEach(function (link) {
+      link.href = hrefWithGlobalMonth(link.getAttribute("href"), month);
+    });
+    return previousTabs;
+  }
+
+  function restoreTabs(tabs) {
+    writeTabs(Array.isArray(tabs) ? tabs : []);
+  }
+
+  function getOpenTabCount() {
+    var renderedTabs = document.querySelectorAll("[data-workspace-tabs] .workspace-tab");
+    return renderedTabs.length || readTabs().length || 1;
+  }
+
   function currentTab() {
     var body = document.body;
     var id = body.dataset.workspaceTabId;
@@ -175,4 +204,11 @@
   } else {
     initWorkspaceTabs();
   }
+
+  window.FgcUi = window.FgcUi || {};
+  window.FgcUi.workspaceTabs = {
+    applyGlobalMonth: applyGlobalMonth,
+    getOpenTabCount: getOpenTabCount,
+    restoreTabs: restoreTabs
+  };
 })();

--- a/src/main/resources/templates/arbitrage/list.html
+++ b/src/main/resources/templates/arbitrage/list.html
@@ -24,7 +24,7 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-ARB-W01', '차익거래 검증', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main class="fgc-main">
+<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-arbitrage">
 
   <h1 class="fgc-page-title">차익거래 검증</h1>
   <p class="fgc-page-desc">
@@ -88,7 +88,23 @@
 
   <!-- ② 요약 카드 3장 — 차익거래 조회 API 연동 시 서버 렌더링으로 채운다 -->
   <section style="margin-top:16px;display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:10px"
-           id="summary-cards"></section>
+           id="summary-cards">
+    <div class="fgc-kpi fgc-kpi--success">
+      <div class="fgc-kpi__label">이상없음</div>
+      <div class="fgc-kpi__value">—</div>
+      <div class="fgc-kpi__sub">조회 API 연동 대기</div>
+    </div>
+    <div class="fgc-kpi fgc-kpi--warning">
+      <div class="fgc-kpi__label">검토대상</div>
+      <div class="fgc-kpi__value">—</div>
+      <div class="fgc-kpi__sub">조회 API 연동 대기</div>
+    </div>
+    <div class="fgc-kpi fgc-kpi--closed">
+      <div class="fgc-kpi__label">자료부족</div>
+      <div class="fgc-kpi__value">—</div>
+      <div class="fgc-kpi__sub">조회 API 연동 대기</div>
+    </div>
+  </section>
 
   <div class="fgc-responsive-split" style="margin-top:16px;display:grid;grid-template-columns:1.25fr 1fr;gap:16px" id="arb-grid">
 

--- a/src/main/resources/templates/audit/list.html
+++ b/src/main/resources/templates/audit/list.html
@@ -19,7 +19,7 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-AUDT-W01', '감사로그 조회', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main class="fgc-main">
+<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-audit">
 
   <h1 class="fgc-page-title">감사로그 조회</h1>
   <p class="fgc-page-desc">

--- a/src/main/resources/templates/base/index.html
+++ b/src/main/resources/templates/base/index.html
@@ -20,7 +20,7 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-BASE-W01', '기준정보 조회', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main class="fgc-main">
+<main id="main-content" class="fgc-main publishing-page publishing-page-base">
 
   <h1 class="fgc-page-title">기준정보 조회</h1>
   <p class="fgc-page-desc">

--- a/src/main/resources/templates/contract/form.html
+++ b/src/main/resources/templates/contract/form.html
@@ -25,7 +25,7 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-CONT-W03', '보험계약 등록·수정', '보험계약', '/contracts')}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main class="fgc-main">
+<main id="main-content" class="fgc-main publishing-page publishing-page-form publishing-page-contract-form">
 
   <!-- 목업 head 의 .form-grid 스타일 — ~{::main} 으로 main 만 옮겨지므로 여기 둔다 -->
   <style>
@@ -33,7 +33,7 @@
     @media (max-width: 820px) { .form-grid { grid-template-columns: 1fr; } }
   </style>
 
-  <div style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
+  <div class="publishing-page-head" style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
     <div>
       <h1 class="fgc-page-title">보험계약 등록</h1>
       <p class="fgc-page-desc">

--- a/src/main/resources/templates/exception/list.html
+++ b/src/main/resources/templates/exception/list.html
@@ -28,7 +28,10 @@
   <div class="fgc-banner fgc-banner--warn" style="margin-top:12px">
     <span class="material-symbols-outlined" style="font-size:18px">inbox</span>
     <!-- 미처리 건수 안내 문구 — 예외 조회 API 연동 시 서버 렌더링으로 채운다 -->
-    <span id="notice-exception"><strong>정상 건은 여기 오지 않습니다.</strong> 현재 예외 현황은 조회 API 연동 대기 중입니다.</span>
+    <span>
+      <strong>정상 건은 여기 오지 않습니다. 여기 있는 건 전부 사람이 봐야 합니다.</strong>
+      <span id="notice-exception">현재 예외 현황은 조회 API 연동 대기 중입니다.</span>
+    </span>
   </div>
 
   <!-- ① 유형별 미처리 요약 — 예외 조회 API 연동 시 서버 렌더링으로 채운다 -->

--- a/src/main/resources/templates/exception/list.html
+++ b/src/main/resources/templates/exception/list.html
@@ -20,7 +20,7 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-EXCP-W01', '예외함', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main class="fgc-main">
+<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-exception">
 
   <h1 class="fgc-page-title">예외함</h1>
   <p class="fgc-page-desc">규제·대사·데이터 문제로 <strong>사람이 봐야 하는 건</strong>만 모입니다.</p>
@@ -28,12 +28,14 @@
   <div class="fgc-banner fgc-banner--warn" style="margin-top:12px">
     <span class="material-symbols-outlined" style="font-size:18px">inbox</span>
     <!-- 미처리 건수 안내 문구 — 예외 조회 API 연동 시 서버 렌더링으로 채운다 -->
-    <span id="notice-exception"></span>
+    <span id="notice-exception"><strong>정상 건은 여기 오지 않습니다.</strong> 현재 예외 현황은 조회 API 연동 대기 중입니다.</span>
   </div>
 
   <!-- ① 유형별 미처리 요약 — 예외 조회 API 연동 시 서버 렌더링으로 채운다 -->
   <section style="margin-top:16px;display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px"
-           id="summary-cards" aria-label="유형별 미처리 요약"></section>
+           id="summary-cards" aria-label="유형별 미처리 요약">
+    <div class="fgc-empty publishing-empty-state">유형별 미처리 집계 API 연동 대기</div>
+  </section>
 
   <!-- ② 검색 -->
   <section class="fgc-card" style="margin-top:16px">

--- a/src/main/resources/templates/layout/default.html
+++ b/src/main/resources/templates/layout/default.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" th:href="@{/css/common/layout.css}">
   <link rel="stylesheet" th:href="@{/css/common/components.css}">
   <link rel="stylesheet" th:href="@{/css/common/utilities.css}">
+  <link rel="stylesheet" th:href="@{/css/features/publishing.css}">
   <link rel="stylesheet" th:if="${screenId == 'FGC-UI-DASH-W01'}" th:href="@{/css/features/dashboard.css}">
   <link rel="stylesheet" th:if="${#strings.startsWith(screenId, 'FGC-UI-CONT-')}" th:href="@{/css/features/contract.css}">
   <link rel="stylesheet" th:if="${#strings.startsWith(screenId, 'FGC-UI-CAP-')}" th:href="@{/css/features/cap.css}">
@@ -32,6 +33,7 @@
   <div id="toast-region" class="toast-region" role="region" aria-label="알림" aria-live="polite"></div>
   <div id="modal-root"></div>
   <script th:src="@{/js/common/workspace-tabs.js}" defer></script>
+  <script th:src="@{/js/common/month-selector.js}" defer></script>
   <script th:src="@{/js/common/app-shell.js}" defer></script>
   <script th:src="@{/js/common/modal.js}" defer></script>
   <script th:src="@{/js/common/toast.js}" defer></script>

--- a/src/main/resources/templates/layout/fragments/header.html
+++ b/src/main/resources/templates/layout/fragments/header.html
@@ -44,6 +44,7 @@
               <button class="month-selector-cell" type="button" role="gridcell"
                       th:each="column : ${#numbers.sequence(1, 4)}"
                       th:with="monthIndex=${row * 4 + column}"
+                      tabindex="-1"
                       th:attr="data-month-index=${monthIndex},aria-label=${monthIndex + '월'},aria-selected='false'">
                 <span class="month-selector-cell-label" th:text="${monthIndex + '월'}">1월</span>
                 <span class="month-selector-cell-state" aria-hidden="true" hidden></span>

--- a/src/main/resources/templates/layout/fragments/header.html
+++ b/src/main/resources/templates/layout/fragments/header.html
@@ -12,12 +12,65 @@
     </div>
   </div>
   <div class="app-header-actions">
-    <label class="app-header-field" for="global-settlement-month">
-      <span class="app-header-field-label">기준 정산월</span>
-      <select id="global-settlement-month" class="select-control tabular-nums" name="month" data-action="change-global-month" aria-label="기준 정산월">
-        <option th:each="m : ${monthOptions}" th:value="${m}" th:text="${m}" th:selected="${m == month}">2026-07</option>
-      </select>
-    </label>
+    <div class="app-header-field">
+      <span class="app-header-field-label" id="global-month-label">기준 정산월</span>
+      <div class="month-selector"
+           data-month-selector
+           data-disabled-months="[]"
+           th:attr="data-value=${month}">
+        <button class="month-selector-trigger tabular-nums" id="global-settlement-month" type="button"
+                data-action="toggle-month-selector" aria-haspopup="dialog" aria-expanded="false"
+                aria-controls="global-month-popover" aria-labelledby="global-month-label global-month-value">
+          <span id="global-month-value" data-month-selector-value th:text="${month}">2026-07</span>
+          <span class="material-symbols-rounded month-selector-chevron" aria-hidden="true">expand_more</span>
+        </button>
+
+        <div class="month-selector-popover" id="global-month-popover" role="dialog" aria-modal="false"
+             aria-labelledby="global-month-dialog-title" aria-describedby="global-month-scope-notice" hidden>
+          <div class="month-selector-year-navigation">
+            <button class="icon-button" type="button" data-action="previous-month-selector-year"
+                    aria-label="이전 연도" title="이전 연도">
+              <span class="material-symbols-rounded" aria-hidden="true">chevron_left</span>
+            </button>
+            <strong class="month-selector-year tabular-nums" id="global-month-dialog-title" data-month-selector-year>2026년</strong>
+            <button class="icon-button" type="button" data-action="next-month-selector-year"
+                    aria-label="다음 연도" title="다음 연도">
+              <span class="material-symbols-rounded" aria-hidden="true">chevron_right</span>
+            </button>
+          </div>
+
+          <div class="month-selector-grid" role="grid" aria-label="정산월 선택" data-month-selector-grid>
+            <div class="month-selector-row" role="row" th:each="row : ${#numbers.sequence(0, 2)}">
+              <button class="month-selector-cell" type="button" role="gridcell"
+                      th:each="column : ${#numbers.sequence(1, 4)}"
+                      th:with="monthIndex=${row * 4 + column}"
+                      th:attr="data-month-index=${monthIndex},aria-label=${monthIndex + '월'},aria-selected='false'">
+                <span class="month-selector-cell-label" th:text="${monthIndex + '월'}">1월</span>
+                <span class="month-selector-cell-state" aria-hidden="true" hidden></span>
+              </button>
+            </div>
+          </div>
+
+          <div class="month-selector-scope" id="global-month-scope-notice">
+            <span class="material-symbols-rounded" aria-hidden="true">info</span>
+            <p>적용하면 열린 업무 탭 <strong data-month-selector-tab-count>1</strong>개의 조회 기준이<br>
+              <strong data-month-selector-scope-value>2026년 7월</strong>로 변경됩니다.</p>
+          </div>
+
+          <div class="month-selector-footer">
+            <p class="month-selector-selection">선택&nbsp; · &nbsp;<strong data-month-selector-draft-value>2026년 7월</strong></p>
+            <div class="month-selector-actions">
+              <button class="button button-secondary" type="button" data-action="cancel-month-selector">취소</button>
+              <button class="button button-primary" type="button" data-action="apply-month-selector">
+                <span class="material-symbols-rounded month-selector-loading" aria-hidden="true" hidden>progress_activity</span>
+                <span data-month-selector-apply-label>적용</span>
+              </button>
+            </div>
+          </div>
+          <p class="visually-hidden" role="alert" data-month-selector-error></p>
+        </div>
+      </div>
+    </div>
     <span class="status-badge status-badge-neutral app-header-role" th:title="#{'role.' + ${roleCode} + '.desc'}" th:text="#{'role.' + ${roleCode}}">역할</span>
   </div>
 </header>

--- a/src/main/resources/templates/layout/fragments/sidebar.html
+++ b/src/main/resources/templates/layout/fragments/sidebar.html
@@ -14,7 +14,7 @@
     <ul class="sidebar-nav-list">
       <li><a class="sidebar-nav-link" th:classappend="${screenId == 'FGC-UI-DASH-W01'} ? ' is-active'" th:href="@{/}" th:attr="aria-current=${screenId == 'FGC-UI-DASH-W01'} ? 'page' : null"><span class="material-symbols-rounded" aria-hidden="true">dashboard</span><span class="sidebar-nav-label">업무 대시보드</span></a></li>
       <li>
-        <details class="sidebar-nav-details" th:attr="open=${#strings.startsWith(screenId, 'FGC-UI-CONT-') or #strings.startsWith(screenId, 'FGC-UI-TRAN-') or #strings.startsWith(screenId, 'FGC-UI-SCHE-')} ? 'open' : null">
+        <details class="sidebar-nav-details" data-sidebar-section="contracts" th:attr="open=${#strings.startsWith(screenId, 'FGC-UI-CONT-') or #strings.startsWith(screenId, 'FGC-UI-TRAN-') or #strings.startsWith(screenId, 'FGC-UI-SCHE-')} ? 'open' : null">
           <summary class="sidebar-nav-summary"><span class="material-symbols-rounded" aria-hidden="true">payments</span><span class="sidebar-nav-label">계약·지급</span><span></span><span class="material-symbols-rounded sidebar-nav-chevron" aria-hidden="true">chevron_right</span></summary>
           <ul class="sidebar-subnav">
             <li><a class="sidebar-subnav-link" th:classappend="${#strings.startsWith(screenId, 'FGC-UI-CONT-')} ? ' is-active'" th:href="@{/contracts}" th:attr="aria-current=${#strings.startsWith(screenId, 'FGC-UI-CONT-')} ? 'page' : null">보험계약</a></li>
@@ -24,7 +24,7 @@
         </details>
       </li>
       <li>
-        <details class="sidebar-nav-details" th:attr="open=${#strings.startsWith(screenId, 'FGC-UI-CAP-') or #strings.startsWith(screenId, 'FGC-UI-ARB-') or #strings.startsWith(screenId, 'FGC-UI-VRUN-')} ? 'open' : null">
+        <details class="sidebar-nav-details" data-sidebar-section="compliance" th:attr="open=${#strings.startsWith(screenId, 'FGC-UI-CAP-') or #strings.startsWith(screenId, 'FGC-UI-ARB-') or #strings.startsWith(screenId, 'FGC-UI-VRUN-')} ? 'open' : null">
           <summary class="sidebar-nav-summary"><span class="material-symbols-rounded" aria-hidden="true">fact_check</span><span class="sidebar-nav-label">규제 검증</span><span></span><span class="material-symbols-rounded sidebar-nav-chevron" aria-hidden="true">chevron_right</span></summary>
           <ul class="sidebar-subnav">
             <li><a class="sidebar-subnav-link" th:classappend="${#strings.startsWith(screenId, 'FGC-UI-CAP-')} ? ' is-active'" th:href="@{/cap-checks}" th:attr="aria-current=${#strings.startsWith(screenId, 'FGC-UI-CAP-')} ? 'page' : null">1,200% 한도 검증</a></li>
@@ -34,7 +34,7 @@
         </details>
       </li>
       <li>
-        <details class="sidebar-nav-details" th:attr="open=${#strings.startsWith(screenId, 'FGC-UI-LEDG-') or #strings.startsWith(screenId, 'FGC-UI-RECO-')} ? 'open' : null">
+        <details class="sidebar-nav-details" data-sidebar-section="ledger" th:attr="open=${#strings.startsWith(screenId, 'FGC-UI-LEDG-') or #strings.startsWith(screenId, 'FGC-UI-RECO-')} ? 'open' : null">
           <summary class="sidebar-nav-summary"><span class="material-symbols-rounded" aria-hidden="true">menu_book</span><span class="sidebar-nav-label">원장·대사</span><span></span><span class="material-symbols-rounded sidebar-nav-chevron" aria-hidden="true">chevron_right</span></summary>
           <ul class="sidebar-subnav">
             <li><a class="sidebar-subnav-link" th:classappend="${#strings.startsWith(screenId, 'FGC-UI-LEDG-')} ? ' is-active'" th:href="@{/journals}" th:attr="aria-current=${#strings.startsWith(screenId, 'FGC-UI-LEDG-')} ? 'page' : null">검증원장</a></li>
@@ -44,7 +44,7 @@
       </li>
       <li><a class="sidebar-nav-link" th:classappend="${#strings.startsWith(screenId, 'FGC-UI-EXCP-')} ? ' is-active'" th:href="@{/exceptions}" th:attr="aria-current=${#strings.startsWith(screenId, 'FGC-UI-EXCP-')} ? 'page' : null"><span class="material-symbols-rounded" aria-hidden="true">inbox</span><span class="sidebar-nav-label">예외</span></a></li>
       <li class="sidebar-nav-section">
-        <details class="sidebar-nav-details" th:attr="open=${#strings.startsWith(screenId, 'FGC-UI-BASE-') or #strings.startsWith(screenId, 'FGC-UI-POL-') or #strings.startsWith(screenId, 'FGC-UI-AUDT-')} ? 'open' : null">
+        <details class="sidebar-nav-details" data-sidebar-section="admin" th:attr="open=${#strings.startsWith(screenId, 'FGC-UI-BASE-') or #strings.startsWith(screenId, 'FGC-UI-POL-') or #strings.startsWith(screenId, 'FGC-UI-AUDT-')} ? 'open' : null">
           <summary class="sidebar-nav-summary"><span class="material-symbols-rounded" aria-hidden="true">settings</span><span class="sidebar-nav-label">관리</span><span></span><span class="material-symbols-rounded sidebar-nav-chevron" aria-hidden="true">chevron_right</span></summary>
           <ul class="sidebar-subnav">
             <li><a class="sidebar-subnav-link" th:classappend="${#strings.startsWith(screenId, 'FGC-UI-BASE-')} ? ' is-active'" th:href="@{/base}" th:attr="aria-current=${#strings.startsWith(screenId, 'FGC-UI-BASE-')} ? 'page' : null">기준정보</a></li>

--- a/src/main/resources/templates/ledger/list.html
+++ b/src/main/resources/templates/ledger/list.html
@@ -20,7 +20,7 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-LEDG-W01', '검증원장 조회', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main class="fgc-main">
+<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-ledger">
 
   <h1 class="fgc-page-title">검증원장 조회</h1>
   <p class="fgc-page-desc">
@@ -32,7 +32,7 @@
   <div class="fgc-banner fgc-banner--muted" style="margin-top:12px">
     <span class="material-symbols-outlined" style="font-size:18px">menu_book</span>
     <!-- 원장 안내 문구(FGC.NOTICE.LEDGER)는 메시지 프로퍼티로 채운다 -->
-    <span><strong id="notice-ledger"></strong></span>
+    <span><strong id="notice-ledger">이 원장은 회사의 정식 회계장부가 아닙니다. 정산 검증용 보조 장부입니다.</strong></span>
   </div>
 
   <!-- ② 불균형 경고 배너 — vw_journal_imbalance 조회 결과로 서버 렌더링 시 전환한다 -->

--- a/src/main/resources/templates/ledger/list.html
+++ b/src/main/resources/templates/ledger/list.html
@@ -32,7 +32,7 @@
   <div class="fgc-banner fgc-banner--muted" style="margin-top:12px">
     <span class="material-symbols-outlined" style="font-size:18px">menu_book</span>
     <!-- 원장 안내 문구(FGC.NOTICE.LEDGER)는 메시지 프로퍼티로 채운다 -->
-    <span><strong id="notice-ledger">이 원장은 회사의 정식 회계장부가 아닙니다. 정산 검증용 보조 장부입니다.</strong></span>
+    <span><strong id="notice-ledger">이 원장은 회사의 정식 회계장부가 아닙니다. 정산이 맞는지 확인하려고 FGC가 따로 만드는 보조 장부입니다.</strong></span>
   </div>
 
   <!-- ② 불균형 경고 배너 — vw_journal_imbalance 조회 결과로 서버 렌더링 시 전환한다 -->

--- a/src/main/resources/templates/reco/compare-modal.html
+++ b/src/main/resources/templates/reco/compare-modal.html
@@ -18,7 +18,7 @@
 -->
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
-<div th:fragment="modal" class="fgc-modal" style="max-width:860px">
+<div th:fragment="modal" class="fgc-modal publishing-modal publishing-modal-reconciliation" style="max-width:860px">
 
   <div class="fgc-modal__head">
     <span class="fgc-card__title">

--- a/src/main/resources/templates/reco/list.html
+++ b/src/main/resources/templates/reco/list.html
@@ -22,7 +22,7 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-RECO-W01', '대사 실행·결과', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main class="fgc-main">
+<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-reconciliation">
 
   <h1 class="fgc-page-title">대사 실행 · 결과</h1>
   <p class="fgc-page-desc">
@@ -77,7 +77,13 @@
 
   <!-- ② 실행 요약 — 대상·일치·불일치·일치율·차액 카드는 IF-API 연동 시 채운다 -->
   <section style="margin-top:16px;display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:10px"
-           id="summary-cards"></section>
+           id="summary-cards">
+    <div class="fgc-kpi"><div class="fgc-kpi__label">대상</div><div class="fgc-kpi__value">—</div></div>
+    <div class="fgc-kpi fgc-kpi--success"><div class="fgc-kpi__label">일치</div><div class="fgc-kpi__value">—</div></div>
+    <div class="fgc-kpi fgc-kpi--danger"><div class="fgc-kpi__label">불일치</div><div class="fgc-kpi__value">—</div></div>
+    <div class="fgc-kpi fgc-kpi--warning"><div class="fgc-kpi__label">일치율</div><div class="fgc-kpi__value">—</div></div>
+    <div class="fgc-kpi"><div class="fgc-kpi__label">차액 합계</div><div class="fgc-kpi__value">—</div></div>
+  </section>
 
   <div class="fgc-responsive-split" style="margin-top:16px;display:grid;grid-template-columns:1fr;gap:16px">
 
@@ -85,7 +91,7 @@
     <section class="fgc-card">
       <div class="fgc-card__head">
         <span class="fgc-card__title">③ 대사 결과</span>
-        <div style="display:flex;gap:8px;align-items:center">
+        <div class="publishing-inline-controls" style="display:flex;gap:8px;align-items:center">
           <label class="fgc-label" for="f-type" style="margin:0">결과 유형</label>
           <select class="fgc-select" id="f-type" style="padding:4px 8px"><option value="">전체 (11종)</option></select>
           <label style="display:flex;gap:4px;align-items:center;font-size:12px">

--- a/src/main/resources/templates/schedule/detail.html
+++ b/src/main/resources/templates/schedule/detail.html
@@ -23,7 +23,7 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-SCHE-W02', '예상 스케줄 상세', '현행 예상 스케줄', '/schedules')}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main class="fgc-main">
+<main id="main-content" class="fgc-main publishing-page publishing-page-detail publishing-page-schedule-detail">
 
   <!-- 목업 head 의 화면 전용 스타일 — 셸 조각은 main 만 가져가므로 여기로 옮겼다 -->
   <style>
@@ -32,7 +32,7 @@
     .kv dd { margin: 2px 0 0; font-size: 13px; }
   </style>
 
-  <div style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
+  <div class="publishing-page-head" style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
     <div>
       <h1 class="fgc-page-title">예상 스케줄 상세</h1>
       <p class="fgc-page-desc">
@@ -41,7 +41,7 @@
       </p>
     </div>
     <!-- 버튼 동작은 IF-API-28(엑셀)·IF-API-29(새 버전)·확정 API 연동 시 붙인다 -->
-    <div style="display:flex;gap:8px">
+    <div class="publishing-inline-controls" style="display:flex;gap:8px">
       <button class="fgc-btn fgc-btn--ghost" data-fgc-na="목업에서는 파일을 내려받지 않습니다. 실제 개발에서는 GET /api/v1/schedules/{id}/export 로 만듭니다.">
         <span class="material-symbols-outlined" style="font-size:18px">download</span> 엑셀 다운로드
       </button>
@@ -59,7 +59,7 @@
   <section class="fgc-card" style="margin-top:16px">
     <div class="fgc-card__head">
       <span class="fgc-card__title">스케줄 헤더 · <span class="fgc-mono" id="hdr-id">schedule_header #—</span></span>
-      <div style="display:flex;gap:6px;align-items:center">
+      <div class="publishing-inline-controls" style="display:flex;gap:6px;align-items:center">
         <label class="fgc-label" for="stage" style="margin:0">지급단계</label>
         <select class="fgc-select" id="stage" style="padding:4px 8px">
           <option value="GA_TO_FC">GA→설계사</option>

--- a/src/main/resources/templates/transaction/form.html
+++ b/src/main/resources/templates/transaction/form.html
@@ -26,7 +26,7 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-TRAN-W02', '지급 건 등록·귀속·확정', '수수료 지급 건', '/transactions')}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main class="fgc-main">
+<main id="main-content" class="fgc-main publishing-page publishing-page-form publishing-page-transaction-form">
 
   <!-- 목업 head 의 화면 전용 스타일 — 셸 조각은 main 만 가져가므로 여기로 옮겼다 -->
   <style>
@@ -43,7 +43,7 @@
     .attr-table input, .attr-table select { width: 100%; font-size: 12px; padding: 4px 6px; }
   </style>
 
-  <div style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
+  <div class="publishing-page-head" style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
     <div>
       <h1 class="fgc-page-title">지급 건 등록 · 귀속 · 확정</h1>
       <p class="fgc-page-desc">

--- a/src/main/resources/templates/transaction/list.html
+++ b/src/main/resources/templates/transaction/list.html
@@ -18,9 +18,9 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-TRAN-W01', '수수료 지급 건 목록', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main class="fgc-main">
+<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-transaction-list">
 
-  <div style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
+  <div class="publishing-page-head" style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
     <div>
       <h1 class="fgc-page-title">수수료 지급 건 목록</h1>
       <p class="fgc-page-desc">

--- a/src/main/resources/templates/vrun/detail.html
+++ b/src/main/resources/templates/vrun/detail.html
@@ -27,7 +27,7 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-VRUN-W02', '월 통합검증 상세·확정', '월 통합검증 실행 목록', '/validation-runs')}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main class="fgc-main">
+<main id="main-content" class="fgc-main publishing-page publishing-page-detail publishing-page-validation-detail">
 
   <style>
     .kv { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px 20px; }
@@ -35,7 +35,7 @@
     .kv dd { margin: 2px 0 0; font-size: 13px; }
   </style>
 
-  <div style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
+  <div class="publishing-page-head" style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
     <div>
       <h1 class="fgc-page-title">월 통합검증 상세 · 확정</h1>
       <p class="fgc-page-desc">
@@ -43,10 +43,12 @@
         문제가 있는 건만 예외함으로 보냅니다.
       </p>
     </div>
-    <div style="display:flex;gap:8px;align-items:center">
+    <div class="publishing-inline-controls" style="display:flex;gap:8px;align-items:center">
       <label class="fgc-label" for="pick-run" style="margin:0">실행</label>
       <!-- 실행 선택지는 validation_run 목록으로 서버 렌더링해 채운다 -->
-      <select class="fgc-select" id="pick-run"></select>
+      <select class="fgc-select" id="pick-run">
+        <option value="">실행 목록 연동 대기</option>
+      </select>
     </div>
   </div>
 
@@ -63,7 +65,7 @@
   <section class="fgc-card" style="margin-top:16px">
     <div class="fgc-card__head">
       <span class="fgc-card__title">실행 <span class="fgc-mono" id="hdr-id">—</span></span>
-      <span id="hdr-status"></span>
+      <span id="hdr-status" class="fgc-badge fgc-badge--neutral">연동 대기</span>
     </div>
     <div class="fgc-card__body">
       <dl class="kv">
@@ -96,7 +98,9 @@
     <div class="fgc-card__body">
       <!-- 진행률은 운영정책서 제43조 모델(current_step, 9단계는 저장하지 않음)을 따른다. batch_step_execution 에서 역산하지 않는다. -->
       <!-- 스텝 칸은 IF-API(진행률 폴링) 연동 시 서버 렌더링으로 채운다 -->
-      <div class="fgc-stepper" id="stepper"></div>
+      <div class="fgc-stepper" id="stepper">
+        <div class="fgc-empty publishing-empty-state">진행률 API 연동 대기</div>
+      </div>
       <div class="fgc-banner fgc-banner--muted" style="margin-top:16px">
         <span class="material-symbols-outlined" style="font-size:18px">engineering</span>
         <span>
@@ -132,7 +136,12 @@
     <!-- ④ 결과 요약 4블록 — 1,200%·차익거래·원장·대사 집계는 IF-API 연동 시 채운다 -->
     <section class="fgc-card">
       <div class="fgc-card__head"><span class="fgc-card__title">④ 결과 요약</span></div>
-      <div class="fgc-card__body" style="display:grid;grid-template-columns:1fr 1fr;gap:10px" id="result-blocks"></div>
+      <div class="fgc-card__body" style="display:grid;grid-template-columns:1fr 1fr;gap:10px" id="result-blocks">
+        <div class="publishing-result-placeholder"><strong>1,200%</strong><span>집계 연동 대기</span></div>
+        <div class="publishing-result-placeholder"><strong>차익거래</strong><span>집계 연동 대기</span></div>
+        <div class="publishing-result-placeholder"><strong>원장</strong><span>집계 연동 대기</span></div>
+        <div class="publishing-result-placeholder"><strong>대사</strong><span>집계 연동 대기</span></div>
+      </div>
     </section>
   </div>
 
@@ -140,9 +149,11 @@
   <section class="fgc-card" style="margin-top:16px">
     <div class="fgc-card__head">
       <span class="fgc-card__title">⑤ 확정 조건 (운영정책서 제44조 · 6개 전부 통과해야 함)</span>
-      <span id="cond-summary" class="fgc-muted" style="font-size:12px"></span>
+      <span id="cond-summary" class="fgc-muted" style="font-size:12px">연동 대기</span>
     </div>
-    <div class="fgc-card__body" id="cond-body"></div>
+    <div class="fgc-card__body" id="cond-body">
+      <div class="fgc-empty publishing-empty-state">확정 조건 API 연동 대기</div>
+    </div>
   </section>
 
   <!-- ⑥ 확정 -->

--- a/src/main/resources/templates/vrun/detail.html
+++ b/src/main/resources/templates/vrun/detail.html
@@ -90,7 +90,7 @@
           <span class="material-symbols-outlined" style="font-size:16px">refresh</span> 새로고침
         </button>
         <!-- 실행은 SETTLEMENT (화면정의서 :1485, IF-API-48) -->
-        <button class="fgc-btn fgc-btn--primary" id="btn-execute" data-fgc-action="execute" th:disabled="${!canProcess}" style="padding:4px 12px;font-size:12px">
+        <button class="fgc-btn fgc-btn--primary" id="btn-execute" data-fgc-action="execute" style="padding:4px 12px;font-size:12px" disabled>
           <span class="material-symbols-outlined" style="font-size:16px">play_arrow</span> 실행
         </button>
       </div>

--- a/src/main/resources/templates/vrun/list.html
+++ b/src/main/resources/templates/vrun/list.html
@@ -17,7 +17,7 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-VRUN-W01', '월 통합검증 실행 목록', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main class="fgc-main">
+<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-validation-list">
 
   <h1 class="fgc-page-title">월 통합검증 실행 목록</h1>
   <p class="fgc-page-desc">
@@ -62,7 +62,7 @@
   <section class="fgc-card" style="margin-top:16px">
     <div class="fgc-card__head">
       <span class="fgc-card__title">② 실행 목록</span>
-      <div style="display:flex;gap:8px;align-items:center">
+      <div class="publishing-inline-controls" style="display:flex;gap:8px;align-items:center">
         <label class="fgc-label" for="f-status" style="margin:0">상태</label>
         <select class="fgc-select" id="f-status" style="padding:4px 8px"><option value="">전체</option></select>
       </div>

--- a/src/test/java/com/susukkang/fgc/common/web/ShellMonthSessionWebTest.java
+++ b/src/test/java/com/susukkang/fgc/common/web/ShellMonthSessionWebTest.java
@@ -75,15 +75,15 @@ class ShellMonthSessionWebTest {
                 .andExpect(model().attribute("month", "2026-05"))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString(
                         "data-value=\"2026-05\"")))
-                .andExpect(content().string(org.hamcrest.Matchers.containsString(
-                        "<span id=\"global-month-value\" data-month-selector-value>2026-05</span>")));
+                .andExpect(content().string(org.hamcrest.Matchers.matchesPattern(
+                        "(?s).*<span\\b(?=[^>]*\\bid=\"global-month-value\")(?=[^>]*\\bdata-month-selector-value\\b)[^>]*>2026-05</span>.*")));
 
         mvc.perform(get("/").session(session).with(user(settleUser())))
                 .andExpect(model().attribute("month", "2026-05"))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString(
                         "data-value=\"2026-05\"")))
-                .andExpect(content().string(org.hamcrest.Matchers.containsString(
-                        "<span id=\"global-month-value\" data-month-selector-value>2026-05</span>")));
+                .andExpect(content().string(org.hamcrest.Matchers.matchesPattern(
+                        "(?s).*<span\\b(?=[^>]*\\bid=\"global-month-value\")(?=[^>]*\\bdata-month-selector-value\\b)[^>]*>2026-05</span>.*")));
     }
 
     /** 기준월의 임시 선택과 확정은 공통 Month Selector와 App Shell adapter가 처리한다. */

--- a/src/test/java/com/susukkang/fgc/common/web/ShellMonthSessionWebTest.java
+++ b/src/test/java/com/susukkang/fgc/common/web/ShellMonthSessionWebTest.java
@@ -74,22 +74,32 @@ class ShellMonthSessionWebTest {
         mvc.perform(get("/").param("month", "2026-05").session(session).with(user(settleUser())))
                 .andExpect(model().attribute("month", "2026-05"))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString(
-                        "<option value=\"2026-05\" selected=\"selected\"")));
+                        "data-value=\"2026-05\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "<span id=\"global-month-value\" data-month-selector-value>2026-05</span>")));
 
         mvc.perform(get("/").session(session).with(user(settleUser())))
                 .andExpect(model().attribute("month", "2026-05"))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString(
-                        "<option value=\"2026-05\" selected=\"selected\"")));
+                        "data-value=\"2026-05\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "<span id=\"global-month-value\" data-month-selector-value>2026-05</span>")));
     }
 
-    /** 기준월 변경은 인라인 스크립트 대신 공통 app-shell.js의 위임 이벤트로 처리한다. */
+    /** 기준월의 임시 선택과 확정은 공통 Month Selector와 App Shell adapter가 처리한다. */
     @Test
-    void month_select_is_connected_to_common_shell_script() throws Exception {
+    void month_selector_is_connected_to_common_shell_scripts() throws Exception {
         stubEmptySummary();
 
         mvc.perform(get("/").with(user(settleUser())))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString(
-                        "data-action=\"change-global-month\"")))
+                        "data-month-selector")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "aria-haspopup=\"dialog\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "aria-expanded=\"false\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "src=\"/js/common/month-selector.js\"")))
                 .andExpect(content().string(org.hamcrest.Matchers.containsString(
                         "src=\"/js/common/app-shell.js\"")));
     }

--- a/src/test/java/com/susukkang/fgc/ui/GlobalMonthSelectorStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/GlobalMonthSelectorStructureTest.java
@@ -31,7 +31,7 @@ class GlobalMonthSelectorStructureTest {
     void componentKeepsDraftSeparateUntilApplyAndSupportsDismissal() throws IOException {
         assertThat(resource("static/js/common/month-selector.js"))
                 .contains("displayYear: Number(value.slice(0, 4))")
-                .contains("nextYear < 0 || nextYear > 9999")
+                .contains("nextYear < 1 || nextYear > 9999")
                 .contains("previousYearButton")
                 .contains("nextYearButton")
                 .contains("cancelButton")

--- a/src/test/java/com/susukkang/fgc/ui/GlobalMonthSelectorStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/GlobalMonthSelectorStructureTest.java
@@ -19,6 +19,7 @@ class GlobalMonthSelectorStructureTest {
                 .contains("aria-expanded=\"false\"")
                 .contains("role=\"dialog\"")
                 .contains("role=\"grid\"")
+                .contains("tabindex=\"-1\"")
                 .contains("data-month-index=${monthIndex}")
                 .contains("${#numbers.sequence(0, 2)}")
                 .contains("${#numbers.sequence(1, 4)}")
@@ -29,6 +30,11 @@ class GlobalMonthSelectorStructureTest {
     @Test
     void componentKeepsDraftSeparateUntilApplyAndSupportsDismissal() throws IOException {
         assertThat(resource("static/js/common/month-selector.js"))
+                .contains("displayYear: Number(value.slice(0, 4))")
+                .contains("nextYear < 0 || nextYear > 9999")
+                .contains("previousYearButton")
+                .contains("nextYearButton")
+                .contains("cancelButton")
                 .contains("state.draftValue = state.value")
                 .contains("state.draftValue = cell.dataset.month")
                 .contains("state.draftValue = null")
@@ -40,6 +46,7 @@ class GlobalMonthSelectorStructureTest {
                 .contains("trigger.focus()")
                 .contains("ArrowLeft: -1")
                 .contains("ArrowUp: -4")
+                .contains("cell.tabIndex = selected && !disabled ? 0 : -1")
                 .contains("cell.disabled = disabled");
     }
 
@@ -51,11 +58,13 @@ class GlobalMonthSelectorStructureTest {
                 .contains("url.searchParams.set(\"month\", month)")
                 .contains("url.searchParams.delete(\"page\")")
                 .contains("getOpenTabCount")
-                .contains("restoreTabs");
+                .contains("restoreTabs")
+                .contains("tab.id === tabId");
 
         assertThat(resource("static/js/common/app-shell.js"))
                 .contains("workspaceTabs.applyGlobalMonth(month)")
                 .contains("navigateToGlobalMonth(month)")
+                .contains("resolve();")
                 .contains("workspaceTabs.restoreTabs(previousTabs)");
     }
 
@@ -68,6 +77,7 @@ class GlobalMonthSelectorStructureTest {
                 .contains("grid-template-columns: repeat(4, minmax(0, 1fr))")
                 .contains(".month-selector-cell.is-selected")
                 .contains(".month-selector-cell.is-current")
+                .contains("prefers-reduced-motion: reduce")
                 .contains("position: fixed");
     }
 

--- a/src/test/java/com/susukkang/fgc/ui/GlobalMonthSelectorStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/GlobalMonthSelectorStructureTest.java
@@ -1,0 +1,80 @@
+package com.susukkang.fgc.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalMonthSelectorStructureTest {
+
+    @Test
+    void headerProvidesAccessiblePopoverAndTwelveMonthCells() throws IOException {
+        String header = resource("templates/layout/fragments/header.html");
+
+        assertThat(header)
+                .contains("data-month-selector")
+                .contains("aria-haspopup=\"dialog\"")
+                .contains("aria-expanded=\"false\"")
+                .contains("role=\"dialog\"")
+                .contains("role=\"grid\"")
+                .contains("data-month-index=${monthIndex}")
+                .contains("${#numbers.sequence(0, 2)}")
+                .contains("${#numbers.sequence(1, 4)}")
+                .contains("data-action=\"cancel-month-selector\"")
+                .contains("data-action=\"apply-month-selector\"");
+    }
+
+    @Test
+    void componentKeepsDraftSeparateUntilApplyAndSupportsDismissal() throws IOException {
+        assertThat(resource("static/js/common/month-selector.js"))
+                .contains("state.draftValue = state.value")
+                .contains("state.draftValue = cell.dataset.month")
+                .contains("state.draftValue = null")
+                .contains("settings.onApply(nextValue, state.value)")
+                .contains("event.key === \"Escape\"")
+                .contains("event.key === \"Enter\"")
+                .contains("event.key === \" \"")
+                .contains("!root.contains(event.target)")
+                .contains("trigger.focus()")
+                .contains("ArrowLeft: -1")
+                .contains("ArrowUp: -4")
+                .contains("cell.disabled = disabled");
+    }
+
+    @Test
+    void applySynchronizesEveryWorkspaceTabAndOnlyResetsPagination() throws IOException {
+        assertThat(resource("static/js/common/workspace-tabs.js"))
+                .contains("function applyGlobalMonth(month)")
+                .contains("previousTabs.map")
+                .contains("url.searchParams.set(\"month\", month)")
+                .contains("url.searchParams.delete(\"page\")")
+                .contains("getOpenTabCount")
+                .contains("restoreTabs");
+
+        assertThat(resource("static/js/common/app-shell.js"))
+                .contains("workspaceTabs.applyGlobalMonth(month)")
+                .contains("navigateToGlobalMonth(month)")
+                .contains("workspaceTabs.restoreTabs(previousTabs)");
+    }
+
+    @Test
+    void stylesMatchFigmaDimensionsAndProvideNarrowScreenFallback() throws IOException {
+        assertThat(resource("static/css/common/layout.css"))
+                .contains(".month-selector-popover")
+                .contains("width: 22.5rem")
+                .contains("top: calc(100% + var(--space-2))")
+                .contains("grid-template-columns: repeat(4, minmax(0, 1fr))")
+                .contains(".month-selector-cell.is-selected")
+                .contains(".month-selector-cell.is-current")
+                .contains("position: fixed");
+    }
+
+    private static String resource(String path) throws IOException {
+        try (var input = GlobalMonthSelectorStructureTest.class.getClassLoader().getResourceAsStream(path)) {
+            assertThat(input).as(path).isNotNull();
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -55,7 +55,8 @@ class PublishingTemplateStructureTest {
                 .contains("예외 현황은 조회 API 연동 대기 중입니다.");
         assertThat(resource("templates/vrun/detail.html"))
                 .contains("진행률 API 연동 대기")
-                .contains("확정 조건 API 연동 대기");
+                .contains("확정 조건 API 연동 대기")
+                .containsPattern("(?s)<button[^>]*id=\"btn-execute\"[^>]*\\bdisabled\\b[^>]*>");
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -1,0 +1,79 @@
+package com.susukkang.fgc.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PublishingTemplateStructureTest {
+
+    private static final List<String> PUBLISHED_TEMPLATES = List.of(
+            "templates/base/index.html",
+            "templates/contract/form.html",
+            "templates/transaction/list.html",
+            "templates/transaction/form.html",
+            "templates/schedule/detail.html",
+            "templates/arbitrage/list.html",
+            "templates/ledger/list.html",
+            "templates/reco/list.html",
+            "templates/exception/list.html",
+            "templates/vrun/list.html",
+            "templates/vrun/detail.html",
+            "templates/audit/list.html"
+    );
+
+    @Test
+    void publishedScreensUseProductionShellScopeWithoutPrototypeDependencies() throws IOException {
+        for (String resource : PUBLISHED_TEMPLATES) {
+            String template = resource(resource);
+
+            assertThat(template)
+                    .as(resource)
+                    .contains("id=\"main-content\"")
+                    .contains("publishing-page")
+                    .doesNotContain("cdn.tailwindcss.com")
+                    .doesNotContain("FGC.SEED");
+        }
+    }
+
+    @Test
+    void reconciliationComparisonKeepsPopupPublishingScope() throws IOException {
+        assertThat(resource("templates/reco/compare-modal.html"))
+                .contains("th:fragment=\"modal\"")
+                .contains("publishing-modal")
+                .doesNotContain("<main");
+    }
+
+    @Test
+    void apiDeferredScreensExposeExplicitPendingStatesWithoutSeedData() throws IOException {
+        assertThat(resource("templates/arbitrage/list.html"))
+                .contains("조회 API 연동 대기");
+        assertThat(resource("templates/exception/list.html"))
+                .contains("예외 현황은 조회 API 연동 대기 중입니다.");
+        assertThat(resource("templates/vrun/detail.html"))
+                .contains("진행률 API 연동 대기")
+                .contains("확정 조건 API 연동 대기");
+    }
+
+    @Test
+    void productionLayoutLoadsScopedResponsivePublishingStyles() throws IOException {
+        assertThat(resource("templates/layout/default.html"))
+                .contains("/css/features/publishing.css");
+
+        assertThat(resource("static/css/features/publishing.css"))
+                .contains(".app-main > .publishing-page")
+                .contains("@media (max-width: 63.9375rem)")
+                .contains("@media (max-width: 47.9375rem)")
+                .contains("@media (prefers-reduced-motion: reduce)");
+    }
+
+    private static String resource(String path) throws IOException {
+        try (var input = PublishingTemplateStructureTest.class.getClassLoader().getResourceAsStream(path)) {
+            assertThat(input).as(path).isNotNull();
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -59,6 +59,14 @@ class PublishingTemplateStructureTest {
     }
 
     @Test
+    void fixedBusinessNoticesStayAlignedWithScreenSpecification() throws IOException {
+        assertThat(resource("templates/exception/list.html"))
+                .contains("정상 건은 여기 오지 않습니다. 여기 있는 건 전부 사람이 봐야 합니다.");
+        assertThat(resource("templates/ledger/list.html"))
+                .contains("이 원장은 회사의 정식 회계장부가 아닙니다. 정산이 맞는지 확인하려고 FGC가 따로 만드는 보조 장부입니다.");
+    }
+
+    @Test
     void productionLayoutLoadsScopedResponsivePublishingStyles() throws IOException {
         assertThat(resource("templates/layout/default.html"))
                 .contains("/css/features/publishing.css");

--- a/src/test/java/com/susukkang/fgc/ui/SidebarSectionStateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/SidebarSectionStateStructureTest.java
@@ -21,7 +21,7 @@ class SidebarSectionStateStructureTest {
     }
 
     @Test
-    void appShellPersistsMultipleOpenSectionsForTheCurrentSession() throws IOException {
+    void appShellContainsSidebarPersistenceHooks() throws IOException {
         String appShell = resource("static/js/common/app-shell.js");
 
         assertThat(appShell)

--- a/src/test/java/com/susukkang/fgc/ui/SidebarSectionStateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/SidebarSectionStateStructureTest.java
@@ -1,0 +1,41 @@
+package com.susukkang.fgc.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SidebarSectionStateStructureTest {
+
+    @Test
+    void sidebarSectionsExposeStablePersistenceKeys() throws IOException {
+        String sidebar = resource("templates/layout/fragments/sidebar.html");
+
+        assertThat(sidebar)
+                .contains("data-sidebar-section=\"contracts\"")
+                .contains("data-sidebar-section=\"compliance\"")
+                .contains("data-sidebar-section=\"ledger\"")
+                .contains("data-sidebar-section=\"admin\"");
+    }
+
+    @Test
+    void appShellPersistsMultipleOpenSectionsForTheCurrentSession() throws IOException {
+        String appShell = resource("static/js/common/app-shell.js");
+
+        assertThat(appShell)
+                .contains("fgc.sidebar.open-sections.v1")
+                .contains("window.sessionStorage.getItem")
+                .contains("window.sessionStorage.setItem")
+                .contains("section.addEventListener(\"toggle\"")
+                .contains("if (savedOpenSections.indexOf(sectionId) !== -1) section.open = true");
+    }
+
+    private static String resource(String path) throws IOException {
+        try (var input = SidebarSectionStateStructureTest.class.getClassLoader().getResourceAsStream(path)) {
+            assertThat(input).as(path).isNotNull();
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## 1. 변경 사항 요약
- Figma Production 및 최신 HTML 목업을 기준으로 Foundation/Pilot 이후 잔여 업무 화면의 퍼블리싱을 적용했습니다.
- Steel Blue App Shell의 사이드바 상태 유지, Workspace Tabs, 전역 Month Selector UX를 보완했습니다.
- 기존 Thymeleaf·Spring Security·서버 모델 바인딩과 백엔드 API 계약은 변경하지 않았습니다.

## 2. 관련 이슈
- Closes #125
- 후속 QA: #135, #136, #137, #138

## 3. 구현 내용
- BASE-W01, CONT-W03, TRAN-W01/W02, SCHE-W02, ARB-W01, LEDG-W01, RECO-W01/W02, EXCP-W01, VRUN-W01/W02, AUDT-W01에 Production 퍼블리싱 범위를 적용했습니다.
- 공통 `publishing.css` 브리지를 추가해 기존 `fgc-*` DOM 계약을 보존하면서 최신 토큰·반응형 레이아웃을 적용했습니다.
- Month Selector에 연도 이동, 12개월 그리드, 임시 선택·취소·적용, 키보드 이동, 열린 Workspace Tab 정산월 동기화를 구현했습니다.
- 사이드바의 여러 업무 그룹을 동시에 열어 두고 상태를 유지하도록 개선했습니다.
- 미구현 API에는 더미 데이터나 가짜 성공 응답을 추가하지 않았습니다.

## 4. 테스트 방법
1. UI·View 관련 테스트 75개 통과
2. 1440px, 900px, 720px에서 대상 화면 렌더링 및 본문 가로 넘침 확인
3. Sidebar 그룹 상태, Workspace Tabs, Month Selector의 적용·취소·키보드 조작 확인
4. `./gradlew test` 실행 — 591개 중 기존 CAP/Dashboard 집계 통합 테스트 3개 실패

실패한 기존 테스트:
- `CapCalculatorIntegrationTest.searchReturnsPersistedCapCheckFilteredByContractNoWithSummaryCounts`
- `DashboardServiceIntegrationTest.summarizeCountsOnlyLatestCapCheckPerContract`
- `DashboardServiceIntegrationTest.summarizeStillCountsJulyViolationEvenWhenContractWasRecheckedNormalInAugust`

## 5. DB / Flyway 변경
- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일
- 없음

## 6. 리뷰 요구사항
- POL-W01 PR #117의 최신 화면과 조건부 리소스가 유지되는지 확인 부탁드립니다.
- 기존 Thymeleaf 바인딩, Security 권한 조건, 화면 GET 라우트가 보존되는지 확인 부탁드립니다.
- 레거시 `fgc-*` 공통 컴포넌트의 점진 통합은 후속 #138로 분리했습니다.

## 7. 체크리스트
- [x] `develop` 최신 내용을 반영했습니다.
- [ ] 전체 로컬 테스트에 성공했습니다. (기존 백엔드 통합 테스트 3건 실패)
- [x] 애플리케이션 실행을 확인했습니다.
- [x] 관련 기능을 직접 테스트했습니다.
- [x] UI 구조 테스트를 추가했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 디버깅 코드를 포함하지 않았습니다.

## 8. 화면 변경
- 대상 업무 화면의 타이포그래피, 간격, 카드, 필드, 테이블, 반응형 구조를 Production App Shell 기준으로 조정했습니다.
- App Header 기준 정산월을 12개월 Month Selector 팝오버로 변경했습니다.
- 사이드바 업무 그룹의 다중 펼침 상태를 유지하도록 변경했습니다.

## 9. 참고 사항
- API 미연동 작업 버튼의 안전 상태는 #135에서 후속 정리합니다.
- SCHE-W01 Production Scope 보완은 #136에서 진행합니다.
- RECO-W02 실제 진입 및 API 연결은 #137에서 진행합니다.
- 공통 UI 컴포넌트 점진 통합은 #138에서 진행합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 연도 탐색과 월 그리드를 지원하는 월 선택기를 추가했습니다.
  * 월 적용 시 관련 탭과 페이지 상태가 자동으로 동기화됩니다.
  * 사이드바의 열린 메뉴 상태를 세션 동안 유지합니다.
  * 주요 화면에 데이터 연동 대기 상태와 요약 정보를 표시합니다.

* **개선 사항**
  * 일관된 게시 스타일과 반응형 레이아웃을 적용했습니다.
  * 모바일 환경에서 팝오버, 버튼, 모달 사용성을 개선했습니다.
  * 키보드 탐색, 포커스, 오류 및 로딩 상태를 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->