### PR TITLE
[FEAT] FUN-048-03 GA→FC 스케줄·확정 지급 건 매칭

### DIFF
--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/GaFcActualSourceRow.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/GaFcActualSourceRow.java
@@ -1,0 +1,31 @@
+package com.susukkang.fgc.reconciliation.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 설명 : GA→FC 대사의 확정 지급 건 계약귀속 원자행
+ *
+ * @author yslee
+ * @since 2026-08-13
+ * @version 1.2
+ */
+@Getter
+@Setter
+public class GaFcActualSourceRow {
+
+    private Long transactionAttributionId;
+    private Long commissionTransactionId;
+    private Long journalHeaderId;
+    private Long contractId;
+    private Long actualAgentId;
+    private Long commissionItemId;
+    private Integer actualInstallmentNo;
+    private LocalDate settlementMonth;
+    private LocalDate dueDate;
+    private BigDecimal actualAmount;
+    private String sourceBusinessKey;
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/GaFcExpectedSourceRow.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/GaFcExpectedSourceRow.java
@@ -1,0 +1,29 @@
+package com.susukkang.fgc.reconciliation.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 설명 : GA→FC 대사의 예상 지급 스케줄 원자행
+ *
+ * @author yslee
+ * @since 2026-08-13
+ * @version 1.2
+ */
+@Getter
+@Setter
+public class GaFcExpectedSourceRow {
+
+    private Long scheduleLineId;
+    private Long journalHeaderId;
+    private Long contractId;
+    private Long expectedAgentId;
+    private Long commissionItemId;
+    private Integer installmentNo;
+    private LocalDate dueDate;
+    private LocalDate dueMonth;
+    private BigDecimal expectedAmount;
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/GaFcMatchCandidate.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/GaFcMatchCandidate.java
@@ -1,0 +1,44 @@
+package com.susukkang.fgc.reconciliation.dto;
+
+import com.susukkang.fgc.reconciliation.domain.ReconciliationResultType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 설명 : FUN-048-04 저장 단계에 전달할 GA→FC 대사 후보
+ *
+ * @author yslee
+ * @since 2026-08-13
+ * @version 1.2
+ */
+public record GaFcMatchCandidate(
+        String matchGroupKey,
+        Long contractId,
+        Long expectedAgentId,
+        Long actualAgentId,
+        Long commissionItemId,
+        Integer installmentNo,
+        Integer actualInstallmentNo,
+        LocalDate dueDate,
+        LocalDate dueMonth,
+        ReconciliationResultType resultType,
+        BigDecimal expectedTotalAmount,
+        BigDecimal actualTotalAmount,
+        BigDecimal differenceAmount,
+        String primaryReasonCode,
+        List<String> secondaryReasonCodes,
+        List<Long> scheduleLineIds,
+        List<Long> transactionAttributionIds,
+        List<Long> expectedJournalHeaderIds,
+        List<Long> actualJournalHeaderIds
+) {
+    public GaFcMatchCandidate {
+        secondaryReasonCodes = List.copyOf(secondaryReasonCodes);
+        scheduleLineIds = List.copyOf(scheduleLineIds);
+        transactionAttributionIds = List.copyOf(transactionAttributionIds);
+        expectedJournalHeaderIds = List.copyOf(expectedJournalHeaderIds);
+        actualJournalHeaderIds = List.copyOf(actualJournalHeaderIds);
+    }
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/mapper/GaFcReconciliationMapper.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/mapper/GaFcReconciliationMapper.java
@@ -1,0 +1,30 @@
+package com.susukkang.fgc.reconciliation.mapper;
+
+import com.susukkang.fgc.reconciliation.dto.GaFcActualSourceRow;
+import com.susukkang.fgc.reconciliation.dto.GaFcExpectedSourceRow;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 설명 : 기존 정규화 DB에서 GA→FC 대사 원자행을 조회하는 Mapper
+ *
+ * @author yslee
+ * @since 2026-08-13
+ * @version 1.2
+ */
+@Mapper
+public interface GaFcReconciliationMapper {
+
+    List<GaFcExpectedSourceRow> findExpectedSources(
+            @Param("settlementMonth") LocalDate settlementMonth,
+            @Param("insurerId") Long insurerId
+    );
+
+    List<GaFcActualSourceRow> findActualSources(
+            @Param("settlementMonth") LocalDate settlementMonth,
+            @Param("insurerId") Long insurerId
+    );
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/GaFcReconciliationMatcher.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/GaFcReconciliationMatcher.java
@@ -1,0 +1,18 @@
+package com.susukkang.fgc.reconciliation.service;
+
+import com.susukkang.fgc.reconciliation.dto.GaFcMatchCandidate;
+import com.susukkang.fgc.reconciliation.port.ReconciliationExecutionRequest;
+
+import java.util.List;
+
+/**
+ * 설명 : GA→FC 예상 스케줄과 확정 지급 건의 정규화 매칭 계약
+ *
+ * @author yslee
+ * @since 2026-08-13
+ * @version 1.2
+ */
+public interface GaFcReconciliationMatcher {
+
+    List<GaFcMatchCandidate> match(ReconciliationExecutionRequest request);
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/GaFcReconciliationMatcherImpl.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/GaFcReconciliationMatcherImpl.java
@@ -225,9 +225,11 @@ public class GaFcReconciliationMatcherImpl implements GaFcReconciliationMatcher 
         } else if (expectedSources.size() > 1 || actualSources.size() > 1) {
             reasons.add(ReconciliationResultType.DUPLICATE.name());
         }
-        if (agentResolutionIssue) {
-            reasons.add(ReconciliationResultType.REVIEW_REQUIRED.name());
-        } else if (agentMismatch) {
+        // 2026-08-13 yslee - FGC-FUN-048-03 설계사 식별 불가 보조 사유 보존
+        // 기존 코드: 식별 불가 시 주 결과와 같은 REVIEW_REQUIRED를 보조 사유로 추가
+        // 문제: 주 결과와 같은 사유를 제거하는 후처리로 설계사 검토 사유가 사라짐
+        // 개선: 식별 불가와 명시적 불일치 모두 AGENT_MISMATCH를 보조 사유로 보존
+        if (agentResolutionIssue || agentMismatch) {
             reasons.add(ReconciliationResultType.AGENT_MISMATCH.name());
         }
         if (expectedSources.isEmpty()) {

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/GaFcReconciliationMatcherImpl.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/GaFcReconciliationMatcherImpl.java
@@ -1,0 +1,332 @@
+package com.susukkang.fgc.reconciliation.service;
+
+import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.common.util.MoneyUtil;
+import com.susukkang.fgc.reconciliation.domain.ReconciliationResultType;
+import com.susukkang.fgc.reconciliation.dto.GaFcActualSourceRow;
+import com.susukkang.fgc.reconciliation.dto.GaFcExpectedSourceRow;
+import com.susukkang.fgc.reconciliation.dto.GaFcMatchCandidate;
+import com.susukkang.fgc.reconciliation.mapper.GaFcReconciliationMapper;
+import com.susukkang.fgc.reconciliation.port.ReconciliationExecutionRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * 설명 : FUN-048-03 GA→FC 예상 스케줄·확정 지급 건 정규화 매칭
+ *
+ * @author yslee
+ * @since 2026-08-13
+ * @version 1.2
+ */
+@Service
+@RequiredArgsConstructor
+public class GaFcReconciliationMatcherImpl implements GaFcReconciliationMatcher {
+
+    private static final BigDecimal ZERO = BigDecimal.ZERO;
+    private static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
+
+    private final GaFcReconciliationMapper reconciliationMapper;
+    private final ReconciliationAmountTolerancePolicy tolerancePolicy;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<GaFcMatchCandidate> match(ReconciliationExecutionRequest request) {
+        validateRequest(request);
+
+        List<GaFcExpectedSourceRow> expectedSources = reconciliationMapper.findExpectedSources(
+                request.settlementMonth(), request.insurerId());
+        List<GaFcActualSourceRow> actualSources = reconciliationMapper.findActualSources(
+                request.settlementMonth(), request.insurerId());
+
+        Map<BaseMatchKey, List<GaFcExpectedSourceRow>> expectedByKey = groupExpected(expectedSources);
+        Map<BaseMatchKey, List<GaFcActualSourceRow>> actualByKey = groupActual(actualSources);
+        Set<BaseMatchKey> keys = new LinkedHashSet<>();
+        keys.addAll(expectedByKey.keySet());
+        keys.addAll(actualByKey.keySet());
+
+        return keys.stream()
+                .sorted(BaseMatchKey.ORDER)
+                .map(key -> createCandidate(
+                        request,
+                        key,
+                        expectedByKey.getOrDefault(key, List.of()),
+                        actualByKey.getOrDefault(key, List.of())
+                ))
+                .toList();
+    }
+
+    private GaFcMatchCandidate createCandidate(
+            ReconciliationExecutionRequest request,
+            BaseMatchKey key,
+            List<GaFcExpectedSourceRow> expectedSources,
+            List<GaFcActualSourceRow> actualSources
+    ) {
+        // 2026-08-13 yslee - 지급 스케줄·귀속행별 원 단위 반올림 후 합산
+        // 기존 코드: GA→FC 예상·실제 지급을 비교하는 계산 경로가 없음
+        // 문제: 합계 후 반올림하면 상세행별 HALF_UP을 요구하는 운영정책과 금액 결과가 달라질 수 있음
+        // 개선: 예상 스케줄행과 실제 귀속행을 각각 roundWon 처리한 뒤 합산하여 0원 허용오차로 판정
+        BigDecimal expectedTotal = expectedSources.stream()
+                .map(GaFcExpectedSourceRow::getExpectedAmount)
+                .map(MoneyUtil::roundWon)
+                .reduce(ZERO, BigDecimal::add);
+        BigDecimal actualTotal = actualSources.stream()
+                .map(GaFcActualSourceRow::getActualAmount)
+                .map(MoneyUtil::roundWon)
+                .reduce(ZERO, BigDecimal::add);
+
+        List<Integer> expectedInstallments = distinctIntegers(expectedSources.stream()
+                .map(GaFcExpectedSourceRow::getInstallmentNo)
+                .toList());
+        List<Integer> actualInstallments = distinctIntegers(actualSources.stream()
+                .map(GaFcActualSourceRow::getActualInstallmentNo)
+                .toList());
+        Integer installmentNo = singleValue(expectedInstallments);
+        Integer actualInstallmentNo = singleValue(actualInstallments);
+        boolean hasBothSources = !expectedSources.isEmpty() && !actualSources.isEmpty();
+
+        // 2026-08-13 yslee - 회차·수취 설계사 비교 불가능 상태와 실제 불일치 상태 분리
+        // 기존 코드: 지급 건의 회차·수취인 값이 없을 때 임의 추정하거나 불일치로 단정할 수 있음
+        // 문제: 비교 기준이 없는 데이터가 확정 불일치 건수에 포함되면 FUN-048 대사 집계가 왜곡됨
+        // 개선: 누락·복수 식별값은 REVIEW_REQUIRED, 양쪽 단일 식별값이 다른 경우에만 명시적 불일치로 판정
+        boolean installmentResolutionIssue = hasBothSources
+                && (expectedSources.stream().anyMatch(source -> source.getInstallmentNo() == null)
+                || actualSources.stream().anyMatch(source -> source.getActualInstallmentNo() == null)
+                || expectedInstallments.size() != 1
+                || actualInstallments.size() != 1);
+        boolean installmentMismatch = hasBothSources
+                && !installmentResolutionIssue
+                && !Objects.equals(installmentNo, actualInstallmentNo);
+
+        List<Long> expectedAgentIds = distinctLongs(expectedSources.stream()
+                .map(GaFcExpectedSourceRow::getExpectedAgentId)
+                .toList());
+        List<Long> actualAgentIds = distinctLongs(actualSources.stream()
+                .map(GaFcActualSourceRow::getActualAgentId)
+                .toList());
+        Long expectedAgentId = singleValue(expectedAgentIds);
+        Long actualAgentId = singleValue(actualAgentIds);
+        boolean agentResolutionIssue = hasBothSources
+                && (expectedSources.stream().anyMatch(source -> source.getExpectedAgentId() == null)
+                || actualSources.stream().anyMatch(source -> source.getActualAgentId() == null)
+                || expectedAgentIds.size() != 1
+                || actualAgentIds.size() != 1);
+        boolean agentMismatch = hasBothSources
+                && !agentResolutionIssue
+                && !Objects.equals(expectedAgentId, actualAgentId);
+
+        ReconciliationResultType resultType = classify(
+                expectedSources,
+                actualSources,
+                installmentResolutionIssue,
+                installmentMismatch,
+                agentResolutionIssue,
+                agentMismatch,
+                expectedTotal,
+                actualTotal
+        );
+        List<String> secondaryReasons = secondaryReasons(
+                resultType,
+                expectedSources,
+                actualSources,
+                installmentResolutionIssue,
+                installmentMismatch,
+                agentResolutionIssue,
+                agentMismatch,
+                expectedTotal,
+                actualTotal
+        );
+
+        return new GaFcMatchCandidate(
+                matchGroupKey(request, key, installmentNo, actualInstallmentNo, expectedAgentId, actualAgentId),
+                key.contractId(),
+                expectedAgentId,
+                actualAgentId,
+                key.commissionItemId(),
+                installmentNo,
+                actualInstallmentNo,
+                key.dueDate(),
+                key.dueMonth(),
+                resultType,
+                expectedTotal,
+                actualTotal,
+                actualTotal.subtract(expectedTotal),
+                resultType.name(),
+                secondaryReasons,
+                distinctLongs(expectedSources.stream().map(GaFcExpectedSourceRow::getScheduleLineId).toList()),
+                distinctLongs(actualSources.stream().map(GaFcActualSourceRow::getTransactionAttributionId).toList()),
+                distinctLongs(expectedSources.stream().map(GaFcExpectedSourceRow::getJournalHeaderId).toList()),
+                distinctLongs(actualSources.stream().map(GaFcActualSourceRow::getJournalHeaderId).toList())
+        );
+    }
+
+    private ReconciliationResultType classify(
+            List<GaFcExpectedSourceRow> expectedSources,
+            List<GaFcActualSourceRow> actualSources,
+            boolean installmentResolutionIssue,
+            boolean installmentMismatch,
+            boolean agentResolutionIssue,
+            boolean agentMismatch,
+            BigDecimal expectedTotal,
+            BigDecimal actualTotal
+    ) {
+        if (actualSources.stream().anyMatch(source -> source.getDueDate() == null)) {
+            return ReconciliationResultType.REVIEW_REQUIRED;
+        }
+        if (installmentResolutionIssue || agentResolutionIssue) {
+            return ReconciliationResultType.REVIEW_REQUIRED;
+        }
+        if (expectedSources.size() > 1 || actualSources.size() > 1) {
+            return ReconciliationResultType.DUPLICATE;
+        }
+        if (expectedSources.isEmpty()) {
+            return ReconciliationResultType.EXPECTED_MISSING;
+        }
+        if (actualSources.isEmpty()) {
+            return ReconciliationResultType.ACTUAL_MISSING;
+        }
+        if (installmentMismatch) {
+            return ReconciliationResultType.INSTALLMENT_MISMATCH;
+        }
+        if (agentMismatch) {
+            return ReconciliationResultType.AGENT_MISMATCH;
+        }
+        return tolerancePolicy.matches(expectedTotal, actualTotal)
+                ? ReconciliationResultType.MATCHED
+                : ReconciliationResultType.AMOUNT_DIFFERENCE;
+    }
+
+    private List<String> secondaryReasons(
+            ReconciliationResultType primary,
+            List<GaFcExpectedSourceRow> expectedSources,
+            List<GaFcActualSourceRow> actualSources,
+            boolean installmentResolutionIssue,
+            boolean installmentMismatch,
+            boolean agentResolutionIssue,
+            boolean agentMismatch,
+            BigDecimal expectedTotal,
+            BigDecimal actualTotal
+    ) {
+        List<String> reasons = new ArrayList<>();
+        if (installmentResolutionIssue || installmentMismatch) {
+            reasons.add(ReconciliationResultType.INSTALLMENT_MISMATCH.name());
+        } else if (expectedSources.size() > 1 || actualSources.size() > 1) {
+            reasons.add(ReconciliationResultType.DUPLICATE.name());
+        }
+        if (agentResolutionIssue) {
+            reasons.add(ReconciliationResultType.REVIEW_REQUIRED.name());
+        } else if (agentMismatch) {
+            reasons.add(ReconciliationResultType.AGENT_MISMATCH.name());
+        }
+        if (expectedSources.isEmpty()) {
+            reasons.add(ReconciliationResultType.EXPECTED_MISSING.name());
+        } else if (actualSources.isEmpty()) {
+            reasons.add(ReconciliationResultType.ACTUAL_MISSING.name());
+        } else if (!tolerancePolicy.matches(expectedTotal, actualTotal)) {
+            reasons.add(ReconciliationResultType.AMOUNT_DIFFERENCE.name());
+        }
+        return reasons.stream().filter(reason -> !reason.equals(primary.name())).distinct().toList();
+    }
+
+    private static Map<BaseMatchKey, List<GaFcExpectedSourceRow>> groupExpected(
+            List<GaFcExpectedSourceRow> rows
+    ) {
+        Map<BaseMatchKey, List<GaFcExpectedSourceRow>> grouped = new LinkedHashMap<>();
+        for (GaFcExpectedSourceRow row : rows) {
+            requireSource(row.getContractId(), row.getCommissionItemId(), row.getDueMonth(), row.getExpectedAmount());
+            grouped.computeIfAbsent(new BaseMatchKey(
+                            row.getContractId(), row.getCommissionItemId(), row.getDueMonth(), row.getDueDate()),
+                    ignored -> new ArrayList<>()).add(row);
+        }
+        return grouped;
+    }
+
+    private static Map<BaseMatchKey, List<GaFcActualSourceRow>> groupActual(
+            List<GaFcActualSourceRow> rows
+    ) {
+        Map<BaseMatchKey, List<GaFcActualSourceRow>> grouped = new LinkedHashMap<>();
+        for (GaFcActualSourceRow row : rows) {
+            requireSource(row.getContractId(), row.getCommissionItemId(), row.getSettlementMonth(), row.getActualAmount());
+            grouped.computeIfAbsent(new BaseMatchKey(
+                            row.getContractId(), row.getCommissionItemId(), row.getSettlementMonth(), row.getDueDate()),
+                    ignored -> new ArrayList<>()).add(row);
+        }
+        return grouped;
+    }
+
+    private static void requireSource(Long contractId, Long commissionItemId, LocalDate month, BigDecimal amount) {
+        if (contractId == null || commissionItemId == null || month == null || amount == null) {
+            throw new IllegalStateException("대사 원자행의 계약·항목·기준월·금액은 필수입니다.");
+        }
+    }
+
+    private static void validateRequest(ReconciliationExecutionRequest request) {
+        Objects.requireNonNull(request, "대사 실행 요청은 필수입니다.");
+        if (request.reconciliationRunId() == null || request.reconciliationRunId() <= 0) {
+            throw new IllegalArgumentException("reconciliationRunId는 1 이상이어야 합니다.");
+        }
+        if (request.paymentStage() != PaymentStage.GA_TO_FC) {
+            throw new IllegalArgumentException("FUN-048-03은 GA_TO_FC 실행만 처리합니다.");
+        }
+        if (request.settlementMonth() == null || request.settlementMonth().getDayOfMonth() != 1) {
+            throw new IllegalArgumentException("settlementMonth는 월의 1일이어야 합니다.");
+        }
+        if (request.insurerId() == null || request.insurerId() <= 0) {
+            throw new IllegalArgumentException("insurerId는 1 이상이어야 합니다.");
+        }
+    }
+
+    private static String matchGroupKey(
+            ReconciliationExecutionRequest request,
+            BaseMatchKey key,
+            Integer installmentNo,
+            Integer actualInstallmentNo,
+            Long expectedAgentId,
+            Long actualAgentId
+    ) {
+        return String.join(":",
+                PaymentStage.GA_TO_FC.name(),
+                String.valueOf(request.insurerId()),
+                MONTH_FORMATTER.format(key.dueMonth()),
+                String.valueOf(key.contractId()),
+                String.valueOf(key.commissionItemId()),
+                "E" + Objects.toString(expectedAgentId, "NA")
+                        + "-A" + Objects.toString(actualAgentId, "NA"),
+                "E" + Objects.toString(installmentNo, "NA")
+                        + "-A" + Objects.toString(actualInstallmentNo, "NA"),
+                key.dueDate() == null ? "NA" : DateTimeFormatter.BASIC_ISO_DATE.format(key.dueDate())
+        );
+    }
+
+    private static List<Long> distinctLongs(List<Long> values) {
+        return values.stream().filter(Objects::nonNull).distinct().sorted().toList();
+    }
+
+    private static List<Integer> distinctIntegers(List<Integer> values) {
+        return values.stream().filter(Objects::nonNull).distinct().sorted().toList();
+    }
+
+    private static <T> T singleValue(List<T> values) {
+        return values.size() == 1 ? values.getFirst() : null;
+    }
+
+    private record BaseMatchKey(Long contractId, Long commissionItemId, LocalDate dueMonth, LocalDate dueDate) {
+        private static final Comparator<BaseMatchKey> ORDER = Comparator
+                .comparing(BaseMatchKey::contractId)
+                .thenComparing(BaseMatchKey::commissionItemId)
+                .thenComparing(BaseMatchKey::dueMonth)
+                .thenComparing(BaseMatchKey::dueDate, Comparator.nullsLast(Comparator.naturalOrder()));
+    }
+}

--- a/src/main/resources/mapper/reconciliation/GaFcReconciliationMapper.xml
+++ b/src/main/resources/mapper/reconciliation/GaFcReconciliationMapper.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.susukkang.fgc.reconciliation.mapper.GaFcReconciliationMapper">
+
+    <!-- 2026-08-13 yslee - GA→FC 운영 스케줄의 예상 지급 원자행 조회 -->
+    <!-- 기존 코드: 보험사→GA 예상 수입 스케줄만 대사 원천으로 조회 -->
+    <!-- 문제: GA→FC 예상 지급과 확정 지급 건을 비교할 원천이 없어 FUN-048의 두 번째 방향을 실행할 수 없음 -->
+    <!-- 개선: 활성 OPERATIONAL GA→FC 스케줄을 조회하고 POSTED 예상지급 분개는 존재할 때 추적 ID로 연결 -->
+    <select id="findExpectedSources"
+            resultType="com.susukkang.fgc.reconciliation.dto.GaFcExpectedSourceRow">
+        SELECT sl.schedule_line_id AS scheduleLineId,
+               jh.journal_header_id AS journalHeaderId,
+               sh.contract_id AS contractId,
+               sl.beneficiary_agent_id AS expectedAgentId,
+               sl.commission_item_id AS commissionItemId,
+               sl.installment_no AS installmentNo,
+               sl.due_date AS dueDate,
+               sl.due_month AS dueMonth,
+               sl.expected_amount AS expectedAmount
+          FROM fgc.schedule_header sh
+          JOIN fgc.schedule_line sl
+            ON sl.schedule_header_id = sh.schedule_header_id
+          JOIN fgc.insurance_contract c
+            ON c.contract_id = sh.contract_id
+          LEFT JOIN fgc.journal_header jh
+            ON jh.journal_type = 'EXPECTED_FC_PAYOUT'
+           AND jh.source_entity_type = 'SCHEDULE_LINE'
+           AND jh.source_entity_id = CAST(sl.schedule_line_id AS varchar)
+           AND jh.status = 'POSTED'
+         WHERE sh.payment_stage = 'GA_TO_FC'
+           AND sh.schedule_purpose = 'OPERATIONAL'
+           AND sh.active_yn = TRUE
+           AND sh.status NOT IN ('HOLD', 'CANCELLED')
+           AND sl.line_status NOT IN ('HOLD', 'CANCELLED')
+           AND sl.due_month = #{settlementMonth}
+           AND c.insurer_id = #{insurerId}
+         ORDER BY sh.contract_id, sl.commission_item_id, sl.due_month,
+                  sl.installment_no, sl.schedule_line_id
+    </select>
+
+    <!-- 2026-08-13 yslee - FUN-065 확정 지급 건의 계약귀속 원자행 조회 -->
+    <!-- 기존 코드: 원수사 명세 거래만 실제 대사 원천으로 조회 -->
+    <!-- 문제: GA→FC 지급 건의 수취 설계사·회차·귀속금액을 예상 스케줄과 비교할 수 없음 -->
+    <!-- 개선: 특정 원천유형을 하드코딩하지 않고 GA→FC CONFIRMED PAYMENT를 조회하며 POSTED 확정지급 분개는 선택 연결 -->
+    <select id="findActualSources"
+            resultType="com.susukkang.fgc.reconciliation.dto.GaFcActualSourceRow">
+        SELECT ta.transaction_attribution_id AS transactionAttributionId,
+               ct.commission_transaction_id AS commissionTransactionId,
+               jh.journal_header_id AS journalHeaderId,
+               ta.contract_id AS contractId,
+               ct.recipient_agent_id AS actualAgentId,
+               ct.commission_item_id AS commissionItemId,
+               ct.installment_no AS actualInstallmentNo,
+               ct.settlement_month AS settlementMonth,
+               ct.due_date AS dueDate,
+               ta.attributed_amount AS actualAmount,
+               ct.source_business_key AS sourceBusinessKey
+          FROM fgc.commission_transaction ct
+          JOIN fgc.transaction_attribution ta
+            ON ta.commission_transaction_id = ct.commission_transaction_id
+          JOIN fgc.insurance_contract c
+            ON c.contract_id = ta.contract_id
+          LEFT JOIN fgc.journal_header jh
+            ON jh.journal_type = 'CONFIRMED_FC_PAYOUT'
+           AND jh.source_entity_type = 'COMMISSION_TRANSACTION'
+           AND jh.source_entity_id = CAST(ct.commission_transaction_id AS varchar)
+           AND jh.status = 'POSTED'
+         WHERE ct.payment_stage = 'GA_TO_FC'
+           AND ct.settlement_month = #{settlementMonth}
+           AND ct.cashflow_type = 'PAYMENT'
+           AND ct.status = 'CONFIRMED'
+           AND ta.attribution_scope = 'CONTRACT'
+           AND ta.attribution_month = #{settlementMonth}
+           AND c.insurer_id = #{insurerId}
+         ORDER BY ta.contract_id, ct.commission_item_id,
+                  COALESCE(ct.due_date, ct.settlement_month),
+                  ct.commission_transaction_id, ta.attribution_seq
+    </select>
+
+</mapper>

--- a/src/test/java/com/susukkang/fgc/reconciliation/GaFcReconciliationIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/GaFcReconciliationIntegrationTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * 설명 : 실제 PostgreSQL에서 GA→FC 대사 원천 필터와 매칭 결과를 검증
+ * 설명 : FGC-FUN-048-03 실제 PostgreSQL에서 GA→FC 대사 원천 필터와 매칭 결과를 검증
  *
  * @author yslee
  * @since 2026-08-13
@@ -74,6 +74,21 @@ class GaFcReconciliationIntegrationTest {
                 contractId, agentId, commissionItemId, "777000",
                 "CONFIRMED_PAYOUT_EXPENSE", "CONFIRMED_PAYOUT_PAYABLE");
 
+        // 2026-08-13 yslee - FGC-FUN-048-03 원천 조회 제외 조건 회귀 검증
+        // 기존 코드: DRAFT 지급 제외만 검증해 스케줄 활성·목적·지급단계 필터 회귀를 발견하지 못함
+        // 문제: 비활성·비운영 스케줄이나 다른 지급단계의 확정 건이 같은 매칭 그룹에 섞일 수 있음
+        // 개선: 각 제외 원천을 같은 키로 적재하고 결과 식별자에 포함되지 않는지 검증
+        Long inactiveScheduleLineId = insertSchedule(
+                contractId, policyVersionId, commissionItemId, agentId,
+                1, "888000", "OPERATIONAL", null, false, 901);
+        Long comparisonScheduleLineId = insertSchedule(
+                contractId, policyVersionId, commissionItemId, agentId,
+                1, "999000", "COMPARISON", "IT-048-03-COMPARISON", true, 902);
+        PaymentInsert insurerToGaConfirmed = insertPayment(
+                contractId, policyVersionId, commissionItemId, agentId,
+                1, "111000", "CONFIRMED", "INSURER-TO-GA-EXCLUDED",
+                "INSURER_TO_GA", "INSURER_STATEMENT");
+
         List<GaFcMatchCandidate> results = matcher.match(new ReconciliationExecutionRequest(
                 99L, 88L, TEST_MONTH, PaymentStage.GA_TO_FC, insurerId, null));
 
@@ -83,8 +98,11 @@ class GaFcReconciliationIntegrationTest {
         assertThat(result.expectedAgentId()).isEqualTo(agentId);
         assertThat(result.actualAgentId()).isEqualTo(agentId);
         assertThat(result.scheduleLineIds()).containsExactly(scheduleLineId);
+        assertThat(result.scheduleLineIds())
+                .doesNotContain(inactiveScheduleLineId, comparisonScheduleLineId);
         assertThat(result.transactionAttributionIds()).containsExactly(confirmed.attributionId());
-        assertThat(result.transactionAttributionIds()).doesNotContain(draft.attributionId());
+        assertThat(result.transactionAttributionIds())
+                .doesNotContain(draft.attributionId(), insurerToGaConfirmed.attributionId());
         assertThat(result.expectedJournalHeaderIds()).containsExactly(expectedJournalId);
         assertThat(result.actualJournalHeaderIds()).containsExactly(actualJournalId);
     }
@@ -173,13 +191,32 @@ class GaFcReconciliationIntegrationTest {
             int installmentNo,
             String amount
     ) {
+        return insertSchedule(
+                contractId, policyVersionId, commissionItemId, agentId,
+                installmentNo, amount, "OPERATIONAL", null, true, 300 + installmentNo);
+    }
+
+    private Long insertSchedule(
+            Long contractId,
+            Long policyVersionId,
+            Long commissionItemId,
+            Long agentId,
+            int installmentNo,
+            String amount,
+            String schedulePurpose,
+            String scenarioCode,
+            boolean active,
+            int scheduleVersionNo
+    ) {
         Long headerId = jdbcTemplate.queryForObject("""
                 INSERT INTO fgc.schedule_header (
                     contract_id, payment_stage, policy_version_id, schedule_version_no,
-                    schedule_purpose, schedule_regime, active_yn
-                ) VALUES (?, 'GA_TO_FC', ?, ?, 'OPERATIONAL', 'CURRENT', TRUE)
+                    schedule_purpose, scenario_code, schedule_regime, active_yn
+                ) VALUES (?, 'GA_TO_FC', ?, ?, ?, ?, 'CURRENT', ?)
                 RETURNING schedule_header_id
-                """, Long.class, contractId, policyVersionId, 300 + installmentNo);
+                """, Long.class,
+                contractId, policyVersionId, scheduleVersionNo,
+                schedulePurpose, scenarioCode, active);
         return jdbcTemplate.queryForObject("""
                 INSERT INTO fgc.schedule_line (
                     schedule_header_id, line_no, installment_no, contract_month_no, due_date,
@@ -203,14 +240,33 @@ class GaFcReconciliationIntegrationTest {
             String status,
             String suffix
     ) {
+        return insertPayment(
+                contractId, policyVersionId, commissionItemId, agentId,
+                installmentNo, amount, status, suffix,
+                "GA_TO_FC", "GA_MANUAL_PAYMENT");
+    }
+
+    private PaymentInsert insertPayment(
+            Long contractId,
+            Long policyVersionId,
+            Long commissionItemId,
+            Long agentId,
+            Integer installmentNo,
+            String amount,
+            String status,
+            String suffix,
+            String paymentStage,
+            String sourceType
+    ) {
         Long transactionId = jdbcTemplate.queryForObject("""
                 INSERT INTO fgc.commission_transaction (
                     payment_stage, source_type, source_business_key, source_contract_id,
                     recipient_agent_id, commission_item_id, policy_version_id, installment_no,
                     settlement_month, due_date, amount, cashflow_type, status
-                ) VALUES ('GA_TO_FC', 'GA_MANUAL_PAYMENT', ?, ?, ?, ?, ?, ?, ?, ?, ?, 'PAYMENT', 'DRAFT')
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'PAYMENT', 'DRAFT')
                 RETURNING commission_transaction_id
                 """, Long.class,
+                paymentStage, sourceType,
                 "IT-048-03:" + suffix, contractId, agentId, commissionItemId, policyVersionId,
                 installmentNo, TEST_MONTH, TEST_MONTH.plusDays(14), new BigDecimal(amount));
         Long attributionId = jdbcTemplate.queryForObject("""

--- a/src/test/java/com/susukkang/fgc/reconciliation/GaFcReconciliationIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/GaFcReconciliationIntegrationTest.java
@@ -1,0 +1,282 @@
+package com.susukkang.fgc.reconciliation;
+
+import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.reconciliation.domain.ReconciliationResultType;
+import com.susukkang.fgc.reconciliation.dto.GaFcMatchCandidate;
+import com.susukkang.fgc.reconciliation.port.ReconciliationExecutionRequest;
+import com.susukkang.fgc.reconciliation.service.GaFcReconciliationMatcher;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 설명 : 실제 PostgreSQL에서 GA→FC 대사 원천 필터와 매칭 결과를 검증
+ *
+ * @author yslee
+ * @since 2026-08-13
+ * @version 1.2
+ */
+@SpringBootTest
+@Transactional
+class GaFcReconciliationIntegrationTest {
+
+    private static final LocalDate TEST_MONTH = LocalDate.of(2098, 9, 1);
+
+    @Autowired
+    private GaFcReconciliationMatcher matcher;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void 기존_DB에서_GA_TO_FC_운영_스케줄과_FUN_065_확정_지급만_매칭한다() {
+        Long insurerId = id("SELECT insurer_id FROM fgc.insurer WHERE active_yn = true ORDER BY insurer_id LIMIT 1");
+        Long contractId = id(
+                "SELECT contract_id FROM fgc.insurance_contract WHERE insurer_id = ? ORDER BY contract_id LIMIT 1",
+                insurerId);
+        Long policyVersionId = id("SELECT policy_version_id FROM fgc.policy_version ORDER BY policy_version_id LIMIT 1");
+        Long commissionItemId = id("""
+                SELECT commission_item_id
+                  FROM fgc.commission_item
+                 WHERE cashflow_type = 'PAYMENT'
+                 ORDER BY commission_item_id
+                 LIMIT 1
+                """);
+        Long agentId = id("SELECT agent_id FROM fgc.insurance_contract WHERE contract_id = ?", contractId);
+
+        Long scheduleLineId = insertSchedule(contractId, policyVersionId, commissionItemId, agentId, 1, "650000");
+        Long expectedJournalId = insertPostedJournal(
+                "EXPECTED_FC_PAYOUT", "SCHEDULE_LINE", scheduleLineId,
+                contractId, agentId, commissionItemId, "650000",
+                "EXPECTED_PAYOUT_EXPENSE", "EXPECTED_PAYOUT_PAYABLE");
+
+        PaymentInsert confirmed = insertPayment(
+                contractId, policyVersionId, commissionItemId, agentId,
+                1, "650000", "CONFIRMED", "MATCHED");
+        Long actualJournalId = insertPostedJournal(
+                "CONFIRMED_FC_PAYOUT", "COMMISSION_TRANSACTION", confirmed.transactionId(),
+                contractId, agentId, commissionItemId, "650000",
+                "CONFIRMED_PAYOUT_EXPENSE", "CONFIRMED_PAYOUT_PAYABLE");
+
+        PaymentInsert draft = insertPayment(
+                contractId, policyVersionId, commissionItemId, agentId,
+                1, "777000", "DRAFT", "DRAFT-EXCLUDED");
+        insertPostedJournal(
+                "CONFIRMED_FC_PAYOUT", "COMMISSION_TRANSACTION", draft.transactionId(),
+                contractId, agentId, commissionItemId, "777000",
+                "CONFIRMED_PAYOUT_EXPENSE", "CONFIRMED_PAYOUT_PAYABLE");
+
+        List<GaFcMatchCandidate> results = matcher.match(new ReconciliationExecutionRequest(
+                99L, 88L, TEST_MONTH, PaymentStage.GA_TO_FC, insurerId, null));
+
+        assertThat(results).hasSize(1);
+        GaFcMatchCandidate result = results.getFirst();
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.MATCHED);
+        assertThat(result.expectedAgentId()).isEqualTo(agentId);
+        assertThat(result.actualAgentId()).isEqualTo(agentId);
+        assertThat(result.scheduleLineIds()).containsExactly(scheduleLineId);
+        assertThat(result.transactionAttributionIds()).containsExactly(confirmed.attributionId());
+        assertThat(result.transactionAttributionIds()).doesNotContain(draft.attributionId());
+        assertThat(result.expectedJournalHeaderIds()).containsExactly(expectedJournalId);
+        assertThat(result.actualJournalHeaderIds()).containsExactly(actualJournalId);
+    }
+
+    // 2026-08-13 yslee - DB 원천의 수취 설계사·회차 비교 불가 상태 검증
+    // 기존 코드: FUN-065 지급 건과 GA→FC 스케줄의 정규화 매칭 통합 시나리오가 없음
+    // 문제: 실제 회차가 NULL인 기존 확정 지급 건을 예정일만으로 정상일치 처리할 위험이 있음
+    // 개선: 실제 PostgreSQL 조회에서도 회차 누락을 유지하고 REVIEW_REQUIRED로 판정되는지 확인
+    @Test
+    void 확정_지급_건의_회차가_없으면_REVIEW_REQUIRED다() {
+        Long insurerId = id("SELECT insurer_id FROM fgc.insurer WHERE active_yn = true ORDER BY insurer_id LIMIT 1");
+        Long contractId = id(
+                "SELECT contract_id FROM fgc.insurance_contract WHERE insurer_id = ? ORDER BY contract_id LIMIT 1",
+                insurerId);
+        Long policyVersionId = id("SELECT policy_version_id FROM fgc.policy_version ORDER BY policy_version_id LIMIT 1");
+        Long commissionItemId = id("""
+                SELECT commission_item_id
+                  FROM fgc.commission_item
+                 WHERE cashflow_type = 'PAYMENT'
+                 ORDER BY commission_item_id
+                 LIMIT 1
+                """);
+        Long agentId = id("SELECT agent_id FROM fgc.insurance_contract WHERE contract_id = ?", contractId);
+
+        Long scheduleLineId = insertSchedule(contractId, policyVersionId, commissionItemId, agentId, 13, "650000");
+        insertPostedJournal(
+                "EXPECTED_FC_PAYOUT", "SCHEDULE_LINE", scheduleLineId,
+                contractId, agentId, commissionItemId, "650000",
+                "EXPECTED_PAYOUT_EXPENSE", "EXPECTED_PAYOUT_PAYABLE");
+        PaymentInsert confirmed = insertPayment(
+                contractId, policyVersionId, commissionItemId, agentId,
+                null, "650000", "CONFIRMED", "NULL-INSTALLMENT");
+        insertPostedJournal(
+                "CONFIRMED_FC_PAYOUT", "COMMISSION_TRANSACTION", confirmed.transactionId(),
+                contractId, agentId, commissionItemId, "650000",
+                "CONFIRMED_PAYOUT_EXPENSE", "CONFIRMED_PAYOUT_PAYABLE");
+
+        GaFcMatchCandidate result = matcher.match(new ReconciliationExecutionRequest(
+                99L, 88L, TEST_MONTH, PaymentStage.GA_TO_FC, insurerId, null)).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.REVIEW_REQUIRED);
+        assertThat(result.installmentNo()).isEqualTo(13);
+        assertThat(result.actualInstallmentNo()).isNull();
+    }
+
+    // 2026-08-13 yslee - FUN-046 원장 연동 전 확정 지급 건 대사 회귀 검증
+    // 기존 코드: journal_header를 필수 JOIN하여 POSTED 분개가 없는 스케줄·확정 지급 건을 조회에서 제거
+    // 문제: FUN-065 확정은 완료됐지만 FUN-046 분개가 아직 생성되지 않은 실제 지급 건이 대사 대상에서 사라짐
+    // 개선: 원천 매칭은 계속 수행하고 원장 ID는 존재하는 경우에만 후속 저장 후보에 보존
+    @Test
+    void POSTED_원장_연동_전에도_스케줄과_확정_지급_건을_매칭한다() {
+        Long insurerId = id("SELECT insurer_id FROM fgc.insurer WHERE active_yn = true ORDER BY insurer_id LIMIT 1");
+        Long contractId = id(
+                "SELECT contract_id FROM fgc.insurance_contract WHERE insurer_id = ? ORDER BY contract_id LIMIT 1",
+                insurerId);
+        Long policyVersionId = id("SELECT policy_version_id FROM fgc.policy_version ORDER BY policy_version_id LIMIT 1");
+        Long commissionItemId = id("""
+                SELECT commission_item_id
+                  FROM fgc.commission_item
+                 WHERE cashflow_type = 'PAYMENT'
+                 ORDER BY commission_item_id
+                 LIMIT 1
+                """);
+        Long agentId = id("SELECT agent_id FROM fgc.insurance_contract WHERE contract_id = ?", contractId);
+
+        Long scheduleLineId = insertSchedule(contractId, policyVersionId, commissionItemId, agentId, 1, "650000");
+        PaymentInsert confirmed = insertPayment(
+                contractId, policyVersionId, commissionItemId, agentId,
+                1, "650000", "CONFIRMED", "NO-JOURNAL");
+
+        GaFcMatchCandidate result = matcher.match(new ReconciliationExecutionRequest(
+                99L, 88L, TEST_MONTH, PaymentStage.GA_TO_FC, insurerId, null)).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.MATCHED);
+        assertThat(result.scheduleLineIds()).containsExactly(scheduleLineId);
+        assertThat(result.transactionAttributionIds()).containsExactly(confirmed.attributionId());
+        assertThat(result.expectedJournalHeaderIds()).isEmpty();
+        assertThat(result.actualJournalHeaderIds()).isEmpty();
+    }
+
+    private Long insertSchedule(
+            Long contractId,
+            Long policyVersionId,
+            Long commissionItemId,
+            Long agentId,
+            int installmentNo,
+            String amount
+    ) {
+        Long headerId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.schedule_header (
+                    contract_id, payment_stage, policy_version_id, schedule_version_no,
+                    schedule_purpose, schedule_regime, active_yn
+                ) VALUES (?, 'GA_TO_FC', ?, ?, 'OPERATIONAL', 'CURRENT', TRUE)
+                RETURNING schedule_header_id
+                """, Long.class, contractId, policyVersionId, 300 + installmentNo);
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.schedule_line (
+                    schedule_header_id, line_no, installment_no, contract_month_no, due_date,
+                    commission_item_id, beneficiary_agent_id, basis_code, basis_amount,
+                    calculation_type, fixed_amount, expected_amount
+                ) VALUES (?, 1, ?, ?, ?, ?, ?, 'IT_RECONCILIATION', ?, 'FIXED', ?, ?)
+                RETURNING schedule_line_id
+                """, Long.class,
+                headerId, installmentNo, installmentNo, TEST_MONTH.plusDays(14),
+                commissionItemId, agentId,
+                new BigDecimal(amount), new BigDecimal(amount), new BigDecimal(amount));
+    }
+
+    private PaymentInsert insertPayment(
+            Long contractId,
+            Long policyVersionId,
+            Long commissionItemId,
+            Long agentId,
+            Integer installmentNo,
+            String amount,
+            String status,
+            String suffix
+    ) {
+        Long transactionId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.commission_transaction (
+                    payment_stage, source_type, source_business_key, source_contract_id,
+                    recipient_agent_id, commission_item_id, policy_version_id, installment_no,
+                    settlement_month, due_date, amount, cashflow_type, status
+                ) VALUES ('GA_TO_FC', 'GA_MANUAL_PAYMENT', ?, ?, ?, ?, ?, ?, ?, ?, ?, 'PAYMENT', 'DRAFT')
+                RETURNING commission_transaction_id
+                """, Long.class,
+                "IT-048-03:" + suffix, contractId, agentId, commissionItemId, policyVersionId,
+                installmentNo, TEST_MONTH, TEST_MONTH.plusDays(14), new BigDecimal(amount));
+        Long attributionId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.transaction_attribution (
+                    commission_transaction_id, attribution_seq, attribution_scope, contract_id,
+                    attribution_date, attribution_month, attributed_amount,
+                    inclusion_status_snapshot, attribution_method
+                ) VALUES (?, 1, 'CONTRACT', ?, ?, ?, ?, 'INCLUDED', 'DIRECT')
+                RETURNING transaction_attribution_id
+                """, Long.class,
+                transactionId, contractId, TEST_MONTH.plusDays(14), TEST_MONTH, new BigDecimal(amount));
+        if ("CONFIRMED".equals(status)) {
+            jdbcTemplate.update("""
+                    UPDATE fgc.commission_transaction
+                       SET status = 'CONFIRMED'
+                     WHERE commission_transaction_id = ?
+                    """, transactionId);
+        }
+        return new PaymentInsert(transactionId, attributionId);
+    }
+
+    private Long insertPostedJournal(
+            String journalType,
+            String sourceEntityType,
+            Long sourceEntityId,
+            Long contractId,
+            Long agentId,
+            Long commissionItemId,
+            String amount,
+            String debitAccountCode,
+            String creditAccountCode
+    ) {
+        Long journalHeaderId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.journal_header (
+                    journal_no, journal_date, journal_type, source_entity_type,
+                    source_entity_id, contract_id, policy_version_id, status
+                ) VALUES (?, ?, ?, ?, ?, ?, NULL, 'DRAFT')
+                RETURNING journal_header_id
+                """, Long.class,
+                "IT-048-03-" + journalType + "-" + sourceEntityId,
+                TEST_MONTH.plusDays(14), journalType, sourceEntityType,
+                String.valueOf(sourceEntityId), contractId);
+        Long debitAccountId = id(
+                "SELECT journal_account_id FROM fgc.journal_account WHERE account_code = ?", debitAccountCode);
+        Long creditAccountId = id(
+                "SELECT journal_account_id FROM fgc.journal_account WHERE account_code = ?", creditAccountCode);
+        BigDecimal journalAmount = new BigDecimal(amount);
+        jdbcTemplate.update("""
+                INSERT INTO fgc.journal_line (
+                    journal_header_id, line_no, journal_account_id, debit_amount, credit_amount,
+                    contract_id, agent_id, payment_stage, commission_item_id
+                ) VALUES (?, 1, ?, ?, 0, ?, ?, 'GA_TO_FC', ?),
+                         (?, 2, ?, 0, ?, ?, ?, 'GA_TO_FC', ?)
+                """,
+                journalHeaderId, debitAccountId, journalAmount, contractId, agentId, commissionItemId,
+                journalHeaderId, creditAccountId, journalAmount, contractId, agentId, commissionItemId);
+        jdbcTemplate.update(
+                "UPDATE fgc.journal_header SET status = 'POSTED' WHERE journal_header_id = ?",
+                journalHeaderId);
+        return journalHeaderId;
+    }
+
+    private Long id(String sql, Object... args) {
+        return jdbcTemplate.queryForObject(sql, Long.class, args);
+    }
+
+    private record PaymentInsert(Long transactionId, Long attributionId) {
+    }
+}

--- a/src/test/java/com/susukkang/fgc/reconciliation/service/GaFcReconciliationMatcherImplTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/service/GaFcReconciliationMatcherImplTest.java
@@ -1,0 +1,251 @@
+package com.susukkang.fgc.reconciliation.service;
+
+import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.reconciliation.domain.ReconciliationResultType;
+import com.susukkang.fgc.reconciliation.dto.GaFcActualSourceRow;
+import com.susukkang.fgc.reconciliation.dto.GaFcExpectedSourceRow;
+import com.susukkang.fgc.reconciliation.dto.GaFcMatchCandidate;
+import com.susukkang.fgc.reconciliation.mapper.GaFcReconciliationMapper;
+import com.susukkang.fgc.reconciliation.port.ReconciliationExecutionRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * 설명 : GA→FC 예상 스케줄·확정 지급 건 매칭 단위 테스트
+ *
+ * @author yslee
+ * @since 2026-08-13
+ * @version 1.2
+ */
+@ExtendWith(MockitoExtension.class)
+class GaFcReconciliationMatcherImplTest {
+
+    private static final LocalDate MONTH = LocalDate.of(2026, 8, 1);
+
+    @Mock
+    private GaFcReconciliationMapper reconciliationMapper;
+
+    private GaFcReconciliationMatcherImpl matcher;
+
+    @BeforeEach
+    void setUp() {
+        matcher = new GaFcReconciliationMatcherImpl(
+                reconciliationMapper,
+                new ZeroAmountTolerancePolicy()
+        );
+    }
+
+    @Test
+    void 계약_설계사_항목_회차_날짜와_금액이_같으면_MATCHED다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 501L, 1, "650000", 101L)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, 501L, 1, "650000", 201L)));
+
+        GaFcMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.MATCHED);
+        assertThat(result.differenceAmount()).isEqualByComparingTo("0");
+        assertThat(result.scheduleLineIds()).containsExactly(11L);
+        assertThat(result.transactionAttributionIds()).containsExactly(21L);
+        assertThat(result.expectedJournalHeaderIds()).containsExactly(101L);
+        assertThat(result.actualJournalHeaderIds()).containsExactly(201L);
+    }
+
+    @Test
+    void 실제_지급액이_1원_작으면_AMOUNT_DIFFERENCE다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 501L, 1, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, 501L, 1, "649999", null)));
+
+        GaFcMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.AMOUNT_DIFFERENCE);
+        assertThat(result.differenceAmount()).isEqualByComparingTo("-1");
+    }
+
+    @Test
+    void 실제가_없으면_ACTUAL_MISSING이고_예상이_없으면_EXPECTED_MISSING이다() {
+        GaFcActualSourceRow actual = actual(21L, 501L, 1, "100000", null);
+        actual.setContractId(999L);
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 501L, 1, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L)).willReturn(List.of(actual));
+
+        List<GaFcMatchCandidate> results = matcher.match(request());
+
+        assertThat(results).extracting(GaFcMatchCandidate::resultType)
+                .containsExactly(ReconciliationResultType.ACTUAL_MISSING, ReconciliationResultType.EXPECTED_MISSING);
+    }
+
+    @Test
+    void 같은_키의_확정_지급_귀속행이_둘이면_DUPLICATE다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 501L, 1, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(
+                        actual(21L, 501L, 1, "300000", null),
+                        actual(22L, 501L, 1, "350000", null)
+                ));
+
+        GaFcMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.DUPLICATE);
+        assertThat(result.actualTotalAmount()).isEqualByComparingTo("650000");
+        assertThat(result.transactionAttributionIds()).containsExactly(21L, 22L);
+    }
+
+    @Test
+    void 수취_설계사가_다르면_AGENT_MISMATCH다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 501L, 1, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, 502L, 1, "650000", null)));
+
+        GaFcMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.AGENT_MISMATCH);
+        assertThat(result.expectedAgentId()).isEqualTo(501L);
+        assertThat(result.actualAgentId()).isEqualTo(502L);
+    }
+
+    @Test
+    void 예상_13회차와_실제_14회차는_INSTALLMENT_MISMATCH다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 501L, 13, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, 501L, 14, "650000", null)));
+
+        GaFcMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.INSTALLMENT_MISMATCH);
+        assertThat(result.installmentNo()).isEqualTo(13);
+        assertThat(result.actualInstallmentNo()).isEqualTo(14);
+    }
+
+    // 2026-08-13 yslee - 기존 지급 건의 실제 회차 누락 회귀 검증
+    // 기존 코드: V18 이전 지급 건이나 회차 입력이 없는 수기 지급 건의 회차를 비교할 수 없음
+    // 문제: 예정일로 회차를 추정하면 정책·스케줄 변경 시 다른 회차를 정상일치로 오판할 수 있음
+    // 개선: 양쪽 원천이 있으나 실제 회차가 없으면 자동 불일치 대신 REVIEW_REQUIRED로 보존
+    @Test
+    void 실제_회차가_없으면_임의_추정하지_않고_REVIEW_REQUIRED다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 501L, 13, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, 501L, null, "650000", null)));
+
+        GaFcMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.REVIEW_REQUIRED);
+        assertThat(result.secondaryReasonCodes())
+                .containsExactly(ReconciliationResultType.INSTALLMENT_MISMATCH.name());
+    }
+
+    @Test
+    void 실제_수취_설계사가_없으면_REVIEW_REQUIRED다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 501L, 1, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, null, 1, "650000", null)));
+
+        GaFcMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.REVIEW_REQUIRED);
+    }
+
+    @Test
+    void 지급예정일이_다르면_서로_다른_누락_후보로_분리한다() {
+        GaFcActualSourceRow actual = actual(21L, 501L, 1, "650000", null);
+        actual.setDueDate(MONTH.plusDays(15));
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 501L, 1, "650000", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L)).willReturn(List.of(actual));
+
+        List<GaFcMatchCandidate> results = matcher.match(request());
+
+        assertThat(results).extracting(GaFcMatchCandidate::resultType)
+                .containsExactly(ReconciliationResultType.ACTUAL_MISSING, ReconciliationResultType.EXPECTED_MISSING);
+    }
+
+    @Test
+    void 상세행은_합산_전에_원단위_HALF_UP으로_반올림한다() {
+        given(reconciliationMapper.findExpectedSources(MONTH, 3L))
+                .willReturn(List.of(expected(11L, 501L, 1, "0.5", null)));
+        given(reconciliationMapper.findActualSources(MONTH, 3L))
+                .willReturn(List.of(actual(21L, 501L, 1, "1", null)));
+
+        GaFcMatchCandidate result = matcher.match(request()).getFirst();
+
+        assertThat(result.resultType()).isEqualTo(ReconciliationResultType.MATCHED);
+        assertThat(result.expectedTotalAmount()).isEqualByComparingTo("1");
+        assertThat(result.actualTotalAmount()).isEqualByComparingTo("1");
+    }
+
+    @Test
+    void INSURER_TO_GA_요청은_FUN_048_03_범위가_아니므로_거절한다() {
+        ReconciliationExecutionRequest wrongStage = new ReconciliationExecutionRequest(
+                7L, 9L, MONTH, PaymentStage.INSURER_TO_GA, 3L, 5L);
+
+        assertThatThrownBy(() -> matcher.match(wrongStage))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("GA_TO_FC");
+    }
+
+    private static ReconciliationExecutionRequest request() {
+        return new ReconciliationExecutionRequest(7L, 9L, MONTH, PaymentStage.GA_TO_FC, 3L, 5L);
+    }
+
+    private static GaFcExpectedSourceRow expected(
+            Long scheduleLineId,
+            Long agentId,
+            Integer installmentNo,
+            String amount,
+            Long journalHeaderId
+    ) {
+        GaFcExpectedSourceRow row = new GaFcExpectedSourceRow();
+        row.setScheduleLineId(scheduleLineId);
+        row.setJournalHeaderId(journalHeaderId);
+        row.setContractId(100L);
+        row.setExpectedAgentId(agentId);
+        row.setCommissionItemId(200L);
+        row.setInstallmentNo(installmentNo);
+        row.setDueDate(MONTH.plusDays(14));
+        row.setDueMonth(MONTH);
+        row.setExpectedAmount(new BigDecimal(amount));
+        return row;
+    }
+
+    private static GaFcActualSourceRow actual(
+            Long attributionId,
+            Long agentId,
+            Integer installmentNo,
+            String amount,
+            Long journalHeaderId
+    ) {
+        GaFcActualSourceRow row = new GaFcActualSourceRow();
+        row.setTransactionAttributionId(attributionId);
+        row.setCommissionTransactionId(attributionId + 1000);
+        row.setJournalHeaderId(journalHeaderId);
+        row.setContractId(100L);
+        row.setActualAgentId(agentId);
+        row.setCommissionItemId(200L);
+        row.setActualInstallmentNo(installmentNo);
+        row.setSettlementMonth(MONTH);
+        row.setDueDate(MONTH.plusDays(14));
+        row.setActualAmount(new BigDecimal(amount));
+        row.setSourceBusinessKey("GA:TEST:" + attributionId);
+        return row;
+    }
+}

--- a/src/test/java/com/susukkang/fgc/reconciliation/service/GaFcReconciliationMatcherImplTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/service/GaFcReconciliationMatcherImplTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 /**
- * 설명 : GA→FC 예상 스케줄·확정 지급 건 매칭 단위 테스트
+ * 설명 : FGC-FUN-048-03 GA→FC 예상 스케줄·확정 지급 건 매칭 단위 테스트
  *
  * @author yslee
  * @since 2026-08-13
@@ -163,6 +163,12 @@ class GaFcReconciliationMatcherImplTest {
         GaFcMatchCandidate result = matcher.match(request()).getFirst();
 
         assertThat(result.resultType()).isEqualTo(ReconciliationResultType.REVIEW_REQUIRED);
+        // 2026-08-13 yslee - 설계사 식별 불가 원인의 보조 사유 회귀 검증
+        // 기존 코드: REVIEW_REQUIRED 주 결과만 확인해 구체적인 검토 원인 소실을 발견하지 못함
+        // 문제: 후속 FUN-048-04 저장 단계에서 설계사 문제를 추적할 수 없음
+        // 개선: 보조 사유에 AGENT_MISMATCH가 남는지 함께 검증
+        assertThat(result.secondaryReasonCodes())
+                .containsExactly(ReconciliationResultType.AGENT_MISMATCH.name());
     }
 
     @Test


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* FUN-048-03 범위로 GA→FC 예상 지급 스케줄과 FUN-065 확정 지급 건을 정규화하여 매칭합니다.
* 신규 API·DB·Flyway·별도 API 명세 문서 변경 없이 기존 스케줄·지급·귀속·원장 테이블을 사용합니다.

## 🔗 2. 관련 이슈

* Closes #141

## 🛠 3. 구현 내용

* 활성 `OPERATIONAL`·`GA_TO_FC` 스케줄과 `CONFIRMED`·`PAYMENT` 지급 건의 계약 귀속행을 조회합니다.
* 계약·설계사·수수료 항목·회차·귀속월·지급예정일·금액을 기준으로 `MATCHED`, 금액 차이, 누락, 중복, 설계사/회차 불일치, `REVIEW_REQUIRED`를 판정합니다.
* 예상액과 실제 귀속액은 상세행별 원 단위 `HALF_UP` 후 0원 허용오차로 비교합니다.
* 회차나 설계사 식별값을 비교할 수 없으면 임의 추정하지 않고 `REVIEW_REQUIRED`로 분류합니다.
* POSTED 원장이 존재하면 식별자를 보존하되, FUN-046 연동 전에도 스케줄·확정 지급 건 자체는 대사 대상에서 누락하지 않습니다.
* FUN-048-04 저장 단계가 사용할 원천 스케줄행·귀속행·원장 식별자를 후보 DTO에 보존합니다.

## 🧪 4. 테스트 방법

1. PostgreSQL을 실행합니다.
2. `.\gradlew.bat test --tests "com.susukkang.fgc.reconciliation.service.GaFcReconciliationMatcherImplTest" --tests "com.susukkang.fgc.reconciliation.GaFcReconciliationIntegrationTest"`를 실행합니다.
3. `.\gradlew.bat clean build`를 실행합니다.

검증 결과:

* GA→FC 매칭 단위 테스트 성공
* 실제 PostgreSQL 원천 필터·원장 미연동·회차 누락 통합 테스트 성공
* 전체 clean build 성공

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* 특정 `source_type` 하드코딩 없이 `GA_TO_FC + CONFIRMED + PAYMENT` 상태로 실제 지급 원천을 선별한 기준을 확인해 주세요.
* 원장은 선택적으로 연결하여 FUN-046 미연동 지급 건도 대사하는 경계를 확인해 주세요.
* 식별값 누락은 `REVIEW_REQUIRED`, 명확한 양쪽 값 불일치는 전용 결과유형으로 분리한 판정 순서를 확인해 주세요.

## ✅ 7. 체크리스트

* [ ] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 컨텍스트와 PostgreSQL 연동 테스트를 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음

## 💬 9. 참고 사항

* 선행 PR #114가 아직 `develop` 대상 OPEN이므로, FUN-048-01·02를 포함한 `feature/100-reconciliation-run-create-api`를 base로 한 순차 PR입니다.
* IF-API-22·23에서 회차가 입력되지 않은 기존 수기 지급 건은 이 PR에서 명세대로 `REVIEW_REQUIRED` 처리합니다.
* 수수료 계산·한도 판정·지급 실행과 대사 결과 DB 저장(FUN-048-04)은 범위에서 제외했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 정산월과 보험사 기준으로 예상 지급 및 확정 지급 내역을 조회하고 자동 대사합니다.
  * 계약, 수수료 항목, 지급일, 회차, 설계사 및 금액을 기준으로 대사 후보를 생성합니다.
  * 일치, 금액 차이, 누락, 중복 및 불일치 결과와 상세 사유를 제공합니다.
  * 필수 정보가 없거나 판단이 어려운 건은 `REVIEW_REQUIRED`로 분류합니다.
* **품질 개선**
  * 금액 반올림, 원장 연계, 지급 상태 및 비활성 스케줄 등 주요 시나리오를 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->