### PR TITLE
[Feat] FUN-002 역할 기반 접근제어

### DIFF
--- a/src/main/java/com/susukkang/fgc/base/controller/OrganizationController.java
+++ b/src/main/java/com/susukkang/fgc/base/controller/OrganizationController.java
@@ -3,6 +3,7 @@ package com.susukkang.fgc.base.controller;
 import com.susukkang.fgc.base.dto.OrganizationResponse;
 import com.susukkang.fgc.base.dto.OrganizationSearchCriteria;
 import com.susukkang.fgc.base.service.OrganizationService;
+import com.susukkang.fgc.common.security.Roles;
 import com.susukkang.fgc.common.web.ApiResponse;
 import com.susukkang.fgc.common.web.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,7 +33,7 @@ public class OrganizationController {
                     + "적용기간 안의 비활성 조직도 반환되며 activeYn=false인 항목은 선택할 수 없습니다."
     )
     @GetMapping
-    @PreAuthorize("hasAnyRole('SYSTEM_ADMIN', 'GA_ADMIN', 'SETTLEMENT', 'COMPLIANCE')")
+    @PreAuthorize(Roles.ANY_ROLE)
     public ApiResponse<PageResponse<OrganizationResponse>> search(
             @Parameter(description = "조직 코드 또는 조직명 검색어")
             @RequestParam(required = false)

--- a/src/main/java/com/susukkang/fgc/common/config/SecurityConfig.java
+++ b/src/main/java/com/susukkang/fgc/common/config/SecurityConfig.java
@@ -1,17 +1,21 @@
 package com.susukkang.fgc.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.susukkang.fgc.common.exception.GlobalExceptionHandler;
 import com.susukkang.fgc.common.security.Roles;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 
 // FUN-001 개발 순서 1
@@ -29,11 +33,31 @@ import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 public class SecurityConfig {
 
     /**
+     * FUN-002(#82) — 필터 단계(아래 URL 굵은 규칙·CSRF)에서 거부된 /api/** 요청도 컨트롤러
+     * @PreAuthorize 거부와 같은 ApiResponse 봉투(FGC-AUTH-003)로 나가게 한다.
+     * 기본 핸들러는 sendError(403) → Boot 기본 오류 JSON이라 인터페이스정의서 3-3의
+     * 봉투 규칙(이슈 #82 인수조건 "403 + ApiResponse 오류 봉투")을 깬다.
+     * 매핑을 복사하지 않고 GlobalExceptionHandler.handleAccessDenied 를 그대로 재사용한다.
+     */
+    @Bean
+    public AccessDeniedHandler apiAccessDeniedHandler(
+            GlobalExceptionHandler globalExceptionHandler, ObjectMapper objectMapper) {
+        return (request, response, exception) -> {
+            var entity = globalExceptionHandler.handleAccessDenied(exception);
+            response.setStatus(entity.getStatusCode().value());
+            response.setCharacterEncoding("UTF-8");
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            objectMapper.writeValue(response.getWriter(), entity.getBody());
+        };
+    }
+
+    /**
      * FUN-065 지급 등록·수정·확정 API는 세션 인증과 CSRF 토큰을 함께 검증한다.
      */
     @Bean
     @Order(1)
-    public SecurityFilterChain commissionPaymentApiSecurityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain commissionPaymentApiSecurityFilterChain(
+            HttpSecurity http, AccessDeniedHandler apiAccessDeniedHandler) throws Exception {
         http
                 .securityMatcher("/api/v1/transactions/**")
                 // 2026-08-11 yslee - 세션 쿠키 기반 지급 API의 CSRF 보호 활성화
@@ -52,8 +76,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
                         .anyRequest().authenticated())
                 .httpBasic(Customizer.withDefaults())
-                .exceptionHandling(ex -> ex.authenticationEntryPoint(
-                        new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)));
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                        .accessDeniedHandler(apiAccessDeniedHandler));
         return http.build();
     }
 
@@ -72,7 +97,8 @@ public class SecurityConfig {
      */
     @Bean
     @Order(2)
-    public SecurityFilterChain apiSecurityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain apiSecurityFilterChain(
+            HttpSecurity http, AccessDeniedHandler apiAccessDeniedHandler) throws Exception {
         http
                 .securityMatcher("/api/**")
                 .csrf(csrf -> csrf.disable())
@@ -88,8 +114,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.PATCH, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
                         .anyRequest().authenticated())
                 .httpBasic(Customizer.withDefaults())
-                .exceptionHandling(ex -> ex.authenticationEntryPoint(
-                        new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)));
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+                        .accessDeniedHandler(apiAccessDeniedHandler));
         return http.build();
     }
 

--- a/src/main/java/com/susukkang/fgc/common/config/SecurityConfig.java
+++ b/src/main/java/com/susukkang/fgc/common/config/SecurityConfig.java
@@ -1,8 +1,10 @@
 package com.susukkang.fgc.common.config;
 
+import com.susukkang.fgc.common.security.Roles;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -39,7 +41,16 @@ public class SecurityConfig {
                 // 문제: 로그인 세션을 악용한 외부 사이트가 지급 등록·수정·확정 요청을 위조할 수 있음
                 // 개선: FUN-065 상태 변경 요청에 Spring Security 기본 CSRF 토큰 검증을 우선 적용
                 .csrf(Customizer.withDefaults())
-                .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                .authorizeHttpRequests(auth -> auth
+                        // FUN-002(#82) — COMPLIANCE는 역할 정의(§4-1)상 "조회만". 컨트롤러
+                        // @PreAuthorize를 빠뜨려도 최소한 이 굵은 규칙이 COMPLIANCE의 상태 변경
+                        // 요청을 막는다. 세분화된 역할 구분(SETTLEMENT vs GA_ADMIN 등)은
+                        // 여전히 컨트롤러 @PreAuthorize가 담당한다.
+                        .requestMatchers(HttpMethod.POST, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
+                        .requestMatchers(HttpMethod.PUT, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
+                        .requestMatchers(HttpMethod.DELETE, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
+                        .requestMatchers(HttpMethod.PATCH, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
+                        .anyRequest().authenticated())
                 .httpBasic(Customizer.withDefaults())
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(
                         new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)));
@@ -65,7 +76,17 @@ public class SecurityConfig {
         http
                 .securityMatcher("/api/**")
                 .csrf(csrf -> csrf.disable())
-                .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                .authorizeHttpRequests(auth -> auth
+                        // 감사로그 API(IF-API-52)는 아직 미구현이지만 구현 시점에 바로
+                        // 적용되도록 선제 등록한다.
+                        .requestMatchers(HttpMethod.GET, "/api/v1/audit-logs/**")
+                        .hasAnyRole(Roles.COMPLIANCE, Roles.SYSTEM_ADMIN)
+                        // FUN-002(#82) 굵은 규칙 — commissionPaymentApiSecurityFilterChain 주석 참고.
+                        .requestMatchers(HttpMethod.POST, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
+                        .requestMatchers(HttpMethod.PUT, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
+                        .requestMatchers(HttpMethod.DELETE, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
+                        .requestMatchers(HttpMethod.PATCH, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
+                        .anyRequest().authenticated())
                 .httpBasic(Customizer.withDefaults())
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(
                         new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)));
@@ -85,6 +106,13 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/login", "/assets/**", "/css/**", "/js/**",
                                 "/images/**", "/fonts/**", "/favicon.ico", "/error").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/audit-logs")
+                        .hasAnyRole(Roles.COMPLIANCE, Roles.SYSTEM_ADMIN)
+                        // FUN-002(#82) 굵은 규칙 — commissionPaymentApiSecurityFilterChain 주석 참고.
+                        .requestMatchers(HttpMethod.POST, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
+                        .requestMatchers(HttpMethod.PUT, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
+                        .requestMatchers(HttpMethod.DELETE, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
+                        .requestMatchers(HttpMethod.PATCH, "/**").hasAnyRole(Roles.NON_COMPLIANCE)
                         .anyRequest().authenticated())
                 .formLogin(form -> form
                         .loginPage("/login")

--- a/src/main/java/com/susukkang/fgc/common/security/Roles.java
+++ b/src/main/java/com/susukkang/fgc/common/security/Roles.java
@@ -1,0 +1,40 @@
+package com.susukkang.fgc.common.security;
+
+/**
+ * FUN-002 역할 코드와 역할 조합을 한 곳에 모은다 (이슈 #82).
+ *
+ * 이전에는 "SETTLEMENT"·"SYSTEM_ADMIN" 같은 리터럴이 컨트롤러 11곳 + ShellAdvice +
+ * sidebar.html 에 흩어져 있었다. 여기 상수를 참조하게 해서 역할 조합을 바꿀 때 한 곳만 고치면
+ * 되게 한다.
+ *
+ * SpEL 상수가 @PreAuthorize 애노테이션에 그대로 쓰이는 이유
+ *  애노테이션 값은 컴파일타임 상수여야 한다. static final String 리터럴끼리의 "+" 결합은
+ *  자바 컴파일러가 컴파일타임에 접어(constant fold) 상수로 취급하므로 애노테이션에 쓸 수 있다.
+ *
+ * 지금 실제로 쓰이는 역할 조합만 정의한다. 새 조합(예: EXCP-W01의 SETTLEMENT·GA_ADMIN, 아직
+ * 미구현인 역분개·검증실행확정)은 그 엔드포인트가 실제로 생길 때 추가한다.
+ */
+public final class Roles {
+
+    public static final String SYSTEM_ADMIN = "SYSTEM_ADMIN";
+    public static final String GA_ADMIN = "GA_ADMIN";
+    public static final String SETTLEMENT = "SETTLEMENT";
+    public static final String COMPLIANCE = "COMPLIANCE";
+
+    /** 계약·지급·스케줄·검증실행 생성 등 "처리" 화면 공통 역할. 화면정의서 v2.0 §4-1/각 화면 권한 줄. */
+    public static final String CAN_PROCESS =
+            "hasAnyRole('" + SETTLEMENT + "','" + SYSTEM_ADMIN + "')";
+
+    /** AUDT-W01 감사로그 조회. 화면정의서 v2.0 :1503,:1530. */
+    public static final String CAN_VIEW_AUDIT_LOG =
+            "hasAnyRole('" + COMPLIANCE + "','" + SYSTEM_ADMIN + "')";
+
+    /**
+     * SecurityConfig 의 URL 단위 굵은 규칙에 쓴다. COMPLIANCE 는 역할 정의(§4-1)상 "조회만"이라
+     * 상태를 바꾸는 요청(POST/PUT/DELETE/PATCH)에서는 화면·API 종류를 가리지 않고 항상 배제된다.
+     */
+    public static final String[] NON_COMPLIANCE = {SYSTEM_ADMIN, GA_ADMIN, SETTLEMENT};
+
+    private Roles() {
+    }
+}

--- a/src/main/java/com/susukkang/fgc/common/security/Roles.java
+++ b/src/main/java/com/susukkang/fgc/common/security/Roles.java
@@ -30,6 +30,13 @@ public final class Roles {
             "hasAnyRole('" + COMPLIANCE + "','" + SYSTEM_ADMIN + "')";
 
     /**
+     * "전체 조회" API용(기준정보 등). 사실상 authenticated()와 같지만, 역할 4종을 명시해
+     * 새 역할이 추가될 때 조회 범위를 다시 판단하도록 강제한다.
+     */
+    public static final String ANY_ROLE = "hasAnyRole('" + SYSTEM_ADMIN + "','" + GA_ADMIN
+            + "','" + SETTLEMENT + "','" + COMPLIANCE + "')";
+
+    /**
      * SecurityConfig 의 URL 단위 굵은 규칙에 쓴다. COMPLIANCE 는 역할 정의(§4-1)상 "조회만"이라
      * 상태를 바꾸는 요청(POST/PUT/DELETE/PATCH)에서는 화면·API 종류를 가리지 않고 항상 배제된다.
      */

--- a/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
+++ b/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
@@ -98,7 +98,7 @@ public class ScreenViewController {
     }
 
     /**
-     * AUDT-W01 은 다른 1차 화면과 달리 "전체 조회"가 아니다 — 화면정의서 :1491 권한
+     * AUDT-W01 은 다른 1차 화면과 달리 "전체 조회"가 아니다 — 화면정의서 :1530 권한
      * COMPLIANCE·SYSTEM_ADMIN. FUN-002 인수조건: 직접 URL 호출도 403 으로 차단된다.
      */
     @PreAuthorize(Roles.CAN_VIEW_AUDIT_LOG)

--- a/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
+++ b/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
@@ -1,5 +1,6 @@
 package com.susukkang.fgc.common.web;
 
+import com.susukkang.fgc.common.security.Roles;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,13 +23,13 @@ public class ScreenViewController {
      * CONT-W03 — 인터페이스정의서 IF-API-18/19 역할 SETTLEMENT (+SYSTEM_ADMIN 은 전부, §4-1).
      * FGC-FUN-002 인수조건: 직접 URL 호출도 403 으로 차단된다.
      */
-    @PreAuthorize("hasAnyRole('SETTLEMENT', 'SYSTEM_ADMIN')")
+    @PreAuthorize(Roles.CAN_PROCESS)
     @GetMapping("/contracts/new")
     public String contractNew() {
         return "contract/form";
     }
 
-    @PreAuthorize("hasAnyRole('SETTLEMENT', 'SYSTEM_ADMIN')")
+    @PreAuthorize(Roles.CAN_PROCESS)
     @GetMapping("/contracts/{id}/edit")
     public String contractEdit() {
         return "contract/form";
@@ -45,7 +46,7 @@ public class ScreenViewController {
     }
 
     /** TRAN-W02 — 화면정의서 :686 역할 SETTLEMENT (+SYSTEM_ADMIN 은 전부, §4-1). */
-    @PreAuthorize("hasAnyRole('SETTLEMENT', 'SYSTEM_ADMIN')")
+    @PreAuthorize(Roles.CAN_PROCESS)
     @GetMapping("/transactions/new")
     public String transactionNew() {
         return "transaction/form";
@@ -100,7 +101,7 @@ public class ScreenViewController {
      * AUDT-W01 은 다른 1차 화면과 달리 "전체 조회"가 아니다 — 화면정의서 :1491 권한
      * COMPLIANCE·SYSTEM_ADMIN. FUN-002 인수조건: 직접 URL 호출도 403 으로 차단된다.
      */
-    @PreAuthorize("hasAnyRole('COMPLIANCE', 'SYSTEM_ADMIN')")
+    @PreAuthorize(Roles.CAN_VIEW_AUDIT_LOG)
     @GetMapping("/audit-logs")
     public String auditLogList() {
         return "audit/list";

--- a/src/main/java/com/susukkang/fgc/common/web/ShellAdvice.java
+++ b/src/main/java/com/susukkang/fgc/common/web/ShellAdvice.java
@@ -1,6 +1,7 @@
 package com.susukkang.fgc.common.web;
 
 import com.susukkang.fgc.auth.dto.FgcUserDetails;
+import com.susukkang.fgc.common.security.Roles;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Value;
@@ -84,7 +85,7 @@ public class ShellAdvice {
      */
     @ModelAttribute("readOnly")
     public boolean readOnly(Authentication authentication) {
-        return "COMPLIANCE".equals(roleCode(authentication));
+        return Roles.COMPLIANCE.equals(roleCode(authentication));
     }
 
     /**
@@ -95,7 +96,14 @@ public class ShellAdvice {
     @ModelAttribute("canProcess")
     public boolean canProcess(Authentication authentication) {
         String role = roleCode(authentication);
-        return "SETTLEMENT".equals(role) || "SYSTEM_ADMIN".equals(role);
+        return Roles.SETTLEMENT.equals(role) || Roles.SYSTEM_ADMIN.equals(role);
+    }
+
+    /** AUDT-W01 감사로그 메뉴 노출 기준. sidebar.html 이 역할 문자열을 직접 비교하지 않도록 한다. */
+    @ModelAttribute("canViewAuditLog")
+    public boolean canViewAuditLog(Authentication authentication) {
+        String role = roleCode(authentication);
+        return Roles.COMPLIANCE.equals(role) || Roles.SYSTEM_ADMIN.equals(role);
     }
 
     /** 셸 헤더·사이드바의 역할 배지. messages.properties 의 role.{code} 키로 라벨을 찾는다. */
@@ -103,7 +111,7 @@ public class ShellAdvice {
     public String roleCode(Authentication authentication) {
         return authentication != null && authentication.getPrincipal() instanceof FgcUserDetails user
                 ? user.getRoleCode()
-                : "COMPLIANCE";
+                : Roles.COMPLIANCE;
     }
 
     /**

--- a/src/main/java/com/susukkang/fgc/contract/controller/ContractController.java
+++ b/src/main/java/com/susukkang/fgc/contract/controller/ContractController.java
@@ -4,6 +4,7 @@ import com.susukkang.fgc.arbitrage.dto.ReArbitrageCheckRequest;
 import com.susukkang.fgc.arbitrage.dto.ReArbitrageCheckResponse;
 import com.susukkang.fgc.arbitrage.service.ArbitrageService;
 import com.susukkang.fgc.auth.dto.FgcUserDetails;
+import com.susukkang.fgc.common.security.Roles;
 import com.susukkang.fgc.common.web.ApiResponse;
 import com.susukkang.fgc.common.web.PageResponse;
 import com.susukkang.fgc.contract.dto.*;
@@ -58,7 +59,7 @@ public class ContractController {
      * @since 2026-08-05
      */
     @PostMapping
-    @PreAuthorize("hasAnyRole('SETTLEMENT', 'SYSTEM_ADMIN')")
+    @PreAuthorize(Roles.CAN_PROCESS)
     public ApiResponse<ContractResponse> createContract(@Valid @RequestBody ContractCreateRequest request ) {
         return ApiResponse.success(contractService.createContract(request));
     }
@@ -71,7 +72,7 @@ public class ContractController {
      * @since 2026-08-05
      */
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyRole('SETTLEMENT', 'SYSTEM_ADMIN')")
+    @PreAuthorize(Roles.CAN_PROCESS)
     public ApiResponse<ContractResponse> updateContract(@PathVariable Long id, @Valid @RequestBody ContractUpdateRequest request) {
         return ApiResponse.success(contractService.updateContract(id, request));
     }
@@ -117,7 +118,7 @@ public class ContractController {
      * @since 2026-08-12
      */
     @PostMapping("/{id}/arbitrage-check")
-    @PreAuthorize("hasAnyRole('SETTLEMENT', 'SYSTEM_ADMIN')")
+    @PreAuthorize(Roles.CAN_PROCESS)
     public ApiResponse<ReArbitrageCheckResponse> reArbitrageCheck(
             @PathVariable Long id,
             @Valid @RequestBody ReArbitrageCheckRequest request,

--- a/src/main/java/com/susukkang/fgc/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/susukkang/fgc/schedule/controller/ScheduleController.java
@@ -1,5 +1,6 @@
 package com.susukkang.fgc.schedule.controller;
 
+import com.susukkang.fgc.common.security.Roles;
 import com.susukkang.fgc.common.web.ApiResponse;
 import com.susukkang.fgc.common.web.PageResponse;
 import com.susukkang.fgc.schedule.dto.*;
@@ -52,7 +53,7 @@ public class ScheduleController {
      * @author hjKang
      * @since 2026-08-11
      */
-    @PreAuthorize("hasAnyRole('SETTLEMENT', 'SYSTEM_ADMIN')")
+    @PreAuthorize(Roles.CAN_PROCESS)
     @PostMapping("/{id}/regenerate")
     public ApiResponse<ScheduleRegenResponse> regenerate(
             @PathVariable Long id,

--- a/src/main/java/com/susukkang/fgc/transaction/controller/CommissionPaymentApiController.java
+++ b/src/main/java/com/susukkang/fgc/transaction/controller/CommissionPaymentApiController.java
@@ -1,5 +1,6 @@
 package com.susukkang.fgc.transaction.controller;
 
+import com.susukkang.fgc.common.security.Roles;
 import com.susukkang.fgc.common.web.ApiResponse;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentCreateRequest;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentResponse;
@@ -41,7 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
 // 기존 코드: SETTLEMENT만 허용하여 모든 기능 권한을 가진 SYSTEM_ADMIN도 접근 차단
 // 문제: 인터페이스 정의서의 SYSTEM_ADMIN 전부 권한과 FUN-065 API 인가가 불일치
 // 개선: SETTLEMENT 업무권한을 유지하면서 SYSTEM_ADMIN의 전체관리 권한도 허용
-@PreAuthorize("hasAnyRole('SETTLEMENT', 'SYSTEM_ADMIN')")
+@PreAuthorize(Roles.CAN_PROCESS)
 public class CommissionPaymentApiController {
 
     private final CommissionPaymentService commissionPaymentService;

--- a/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
@@ -19,6 +19,7 @@ import com.susukkang.fgc.common.code.ExceptionType;
 import com.susukkang.fgc.common.code.InclusionDecisionStatus;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.security.Roles;
 import com.susukkang.fgc.common.util.MoneyUtil;
 import com.susukkang.fgc.transaction.domain.CapCheckCommand;
 import com.susukkang.fgc.transaction.domain.CapRuleSnapshot;
@@ -35,6 +36,7 @@ import com.susukkang.fgc.transaction.dto.CommissionPaymentResponse;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentUpdateRequest;
 import com.susukkang.fgc.transaction.mapper.CommissionPaymentMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -99,6 +101,9 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
     // 문제: 부모 지급 건의 FOR UPDATE 잠금과 FK 검사가 충돌하고 이슈 #14의 동일 트랜잭션 조건을 위반
     // 개선: 같은 계약 행 잠금과 멱등키를 포함해 점검·예외·상태 처리를 한 트랜잭션에서 수행
     @Transactional(noRollbackFor = CommissionPaymentConfirmationRejectedException.class)
+    // FUN-002(#82) — 컨트롤러(@PreAuthorize)를 우회하는 호출 경로가 생겨도 지급 확정만은
+    // 서비스 계층에서 한 번 더 막는다. @EnableMethodSecurity는 SecurityConfig에 이미 켜져 있다.
+    @PreAuthorize(Roles.CAN_PROCESS)
     public CommissionPaymentResponse confirm(Long paymentId, String idempotencyKey) {
         // 2026-08-11 yslee - 운영정책서 제31조의 확정 게이트 6단계 순서를 코드에 명시
         // 기존 코드: 실제 확정 로직은 정책 순서를 따르지만 단계별 주석이 없어 문서와 코드의 대응 확인이 어려움

--- a/src/main/java/com/susukkang/fgc/validation/controller/ValidationRunController.java
+++ b/src/main/java/com/susukkang/fgc/validation/controller/ValidationRunController.java
@@ -5,6 +5,7 @@ import com.susukkang.fgc.common.code.ValidationRunStatus;
 import com.susukkang.fgc.common.code.ValidationRunType;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.security.Roles;
 import com.susukkang.fgc.common.util.DateUtil;
 import com.susukkang.fgc.common.web.ApiResponse;
 import com.susukkang.fgc.common.web.PageResponse;
@@ -71,7 +72,7 @@ public class ValidationRunController {
     })
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    @PreAuthorize("hasAnyRole('SETTLEMENT', 'SYSTEM_ADMIN')")
+    @PreAuthorize(Roles.CAN_PROCESS)
     public ApiResponse<CreateValidationRunResponse> create(
             @RequestBody CreateValidationRunRequest request,
             @AuthenticationPrincipal FgcUserDetails principal

--- a/src/main/resources/static/js/features/auth/login.js
+++ b/src/main/resources/static/js/features/auth/login.js
@@ -1,6 +1,11 @@
 (() => {
   "use strict";
 
+  // 로그아웃 직후든 세션 만료든, 로그인 화면은 미인증 상태에서만 뜬다.
+  // 이전 세션의 워크스페이스 탭이 다음 로그인까지 남아있지 않도록 여기서 지운다.
+  // (fgc.workspace-tabs.v1 은 common/workspace-tabs.js STORAGE_KEY와 같은 값)
+  sessionStorage.removeItem("fgc.workspace-tabs.v1");
+
   const form = document.querySelector("[data-login-form]");
   const passwordInput = document.querySelector("[data-password-input]");
   const passwordToggle = document.querySelector("[data-password-toggle]");

--- a/src/main/resources/templates/layout/fragments/sidebar.html
+++ b/src/main/resources/templates/layout/fragments/sidebar.html
@@ -49,7 +49,7 @@
           <ul class="sidebar-subnav">
             <li><a class="sidebar-subnav-link" th:classappend="${#strings.startsWith(screenId, 'FGC-UI-BASE-')} ? ' is-active'" th:href="@{/base}" th:attr="aria-current=${#strings.startsWith(screenId, 'FGC-UI-BASE-')} ? 'page' : null">기준정보</a></li>
             <li><a class="sidebar-subnav-link" th:classappend="${#strings.startsWith(screenId, 'FGC-UI-POL-')} ? ' is-active'" th:href="@{/policies}" th:attr="aria-current=${#strings.startsWith(screenId, 'FGC-UI-POL-')} ? 'page' : null">정책·룰셋</a></li>
-            <li th:if="${roleCode == 'COMPLIANCE' or roleCode == 'SYSTEM_ADMIN'}"><a class="sidebar-subnav-link" th:classappend="${#strings.startsWith(screenId, 'FGC-UI-AUDT-')} ? ' is-active'" th:href="@{/audit-logs}" th:attr="aria-current=${#strings.startsWith(screenId, 'FGC-UI-AUDT-')} ? 'page' : null">감사로그</a></li>
+            <li th:if="${canViewAuditLog}"><a class="sidebar-subnav-link" th:classappend="${#strings.startsWith(screenId, 'FGC-UI-AUDT-')} ? ' is-active'" th:href="@{/audit-logs}" th:attr="aria-current=${#strings.startsWith(screenId, 'FGC-UI-AUDT-')} ? 'page' : null">감사로그</a></li>
           </ul>
         </details>
       </li>

--- a/src/test/java/com/susukkang/fgc/common/web/MpaErrorPageIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/common/web/MpaErrorPageIntegrationTest.java
@@ -4,11 +4,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
+import java.net.CookieManager;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -64,6 +69,62 @@ class MpaErrorPageIntegrationTest {
                 // 템플릿 주석에도 {requestId} 가 나오므로 문장째로 본다.
                 .doesNotContain("요청번호 {requestId}")
                 .contains("수수료 정산·검증 Workspace");         // 셸까지 끝까지 렌더링됨
+    }
+
+    /**
+     * FUN-002(#82) 인수조건 — 권한 없는 화면 URL 직접 호출은 403 + error/403.html 렌더링.
+     *
+     * SecurityConfig 의 GET /audit-logs 규칙은 필터 단계에서 sendError(403)로 거부하고,
+     * 그 뒤의 ERROR 디스패치(/error → error/403.html)는 MockMvc 가 타지 않아 실제 포트로 본다.
+     * 시드(V3)의 settle01(SETTLEMENT)은 AUDT-W01(COMPLIANCE·SYSTEM_ADMIN 전용)을 못 본다.
+     *
+     * 로그인이 audit_log 에 LOGIN_SUCCESS 한 행을 남긴다 — 실제 로그인과 같은 경로라 무해하고,
+     * RANDOM_PORT 는 서버 스레드가 따로 돌아 @Transactional 롤백으로 지울 수도 없다.
+     */
+    @Test
+    void forbidden_screen_url_renders_403_page_not_menu_hiding() throws Exception {
+        HttpClient client = HttpClient.newBuilder().cookieHandler(new CookieManager()).build();
+        String base = "http://localhost:" + port;
+
+        // 1) 로그인 화면에서 CSRF 토큰을 꺼낸다 (세션 쿠키는 CookieManager 가 들고 간다)
+        HttpResponse<String> loginPage = client.send(
+                HttpRequest.newBuilder().uri(URI.create(base + "/login")).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        Matcher csrf = Pattern.compile("name=\"_csrf\"[^>]*value=\"([^\"]+)\"").matcher(loginPage.body());
+        assertThat(csrf.find()).as("로그인 폼의 _csrf hidden input").isTrue();
+
+        // 2) settle01 로 폼 로그인 — 성공하면 defaultSuccessUrl("/") 로 302
+        HttpResponse<String> login = client.send(
+                HttpRequest.newBuilder().uri(URI.create(base + "/login"))
+                        .header("Content-Type", "application/x-www-form-urlencoded")
+                        .POST(HttpRequest.BodyPublishers.ofString(
+                                "username=settle01&password=" + URLEncoder.encode("fgc1234!", UTF_8)
+                                        + "&_csrf=" + URLEncoder.encode(csrf.group(1), UTF_8)))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(login.statusCode()).isEqualTo(302);
+        assertThat(login.headers().firstValue("Location").orElse(""))
+                .as("로그인 성공 리다이렉트 — /login?error 면 자격증명·CSRF 문제")
+                .endsWith("/");
+
+        // 3) 감사로그 화면 직접 호출 — 메뉴 숨김이 아니라 서버가 403 화면으로 막아야 한다
+        HttpResponse<String> response = getHtmlWith(client, "/audit-logs");
+
+        assertThat(response.statusCode()).isEqualTo(403);
+        assertThat(response.headers().firstValue("Content-Type").orElse("")).startsWith("text/html");
+        assertThat(response.body())
+                .contains("403 · 권한 없음")                       // error/403.html
+                .contains("이 작업을 할 권한이 없습니다.")            // error.auth.forbidden 이 실제로 풀렸다
+                .contains("수수료 정산·검증 Workspace");             // 셸 레이아웃까지 렌더링됨
+    }
+
+    private HttpResponse<String> getHtmlWith(HttpClient client, String path) throws Exception {
+        return client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + port + path))
+                        .header("Accept", "text/html")
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString());
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * 요구사항 추적(FGC-FUN-xxx): CONT 018 ·
  * TRAN 065/031/033/034 · SCHE 036/039 · CAP 030/032/035 · ARB 063 ·
  * LEDG 046/047 · RECO 048~051 · EXCP 052/053 · VRUN 041~044 · AUDT 061.
- * /audit-logs 만 역할 제한(FUN-002·화면정의서 :1491)이라 별도 테스트로 뺐다.
+ * /audit-logs 만 역할 제한(FUN-002·화면정의서 :1530)이라 별도 테스트로 뺐다.
  */
 @WebMvcTest(ScreenViewController.class)
 @Import({ShellAdvice.class, SecurityConfig.class, MessageSourceAutoConfiguration.class,
@@ -82,7 +82,7 @@ class ScreenViewControllerTest {
         return new com.susukkang.fgc.auth.dto.FgcUserDetails(view, true, true);
     }
 
-    /** AUDT-W01(FUN-061)은 COMPLIANCE·SYSTEM_ADMIN 전용 — 화면정의서 :1491. */
+    /** AUDT-W01(FUN-061)은 COMPLIANCE·SYSTEM_ADMIN 전용 — 화면정의서 :1530. */
     @Test
     void audit_log_screen_renders_for_compliance() throws Exception {
         mvc.perform(get("/audit-logs").with(user(complianceUser())))

--- a/src/test/java/com/susukkang/fgc/contract/controller/ContractControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/controller/ContractControllerTest.java
@@ -362,4 +362,40 @@ class ContractControllerTest {
                         )))
                 .andExpect(status().isForbidden());
     }
+
+    /** FUN-002(#82) — COMPLIANCE는 §4-1 "조회만"이라 계약 생성·수정 모두 403이어야 한다. */
+    @Test
+    @DisplayName("준법·감사는 보험계약을 생성할 수 없다")
+    void createContractRejectsComplianceUser() throws Exception {
+        mockMvc.perform(post("/api/v1/contracts")
+                        .with(user("comp01").roles("COMPLIANCE"))
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                createRequest()
+                        )))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("준법·감사는 보험계약을 수정할 수 없다")
+    void updateContractRejectsComplianceUser() throws Exception {
+        mockMvc.perform(put("/api/v1/contracts/{id}", 21L)
+                        .with(user("comp01").roles("COMPLIANCE"))
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                updateRequest()
+                        )))
+                .andExpect(status().isForbidden());
+    }
+
+    /** FUN-002(#82) — 차익거래 수동 검증도 CAN_PROCESS(SETTLEMENT·SYSTEM_ADMIN) 전용이다. */
+    @Test
+    @DisplayName("준법·감사는 차익거래 수동 검증을 실행할 수 없다")
+    void reArbitrageCheckRejectsComplianceUser() throws Exception {
+        mockMvc.perform(post("/api/v1/contracts/{id}/arbitrage-check", 21L)
+                        .with(user("comp01").roles("COMPLIANCE"))
+                        .contentType(APPLICATION_JSON)
+                        .content("{\"asOfDate\":\"2026-08-13\",\"reason\":\"정기 점검\"}"))
+                .andExpect(status().isForbidden());
+    }
 }

--- a/src/test/java/com/susukkang/fgc/contract/controller/ContractControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/controller/ContractControllerTest.java
@@ -363,7 +363,11 @@ class ContractControllerTest {
                 .andExpect(status().isForbidden());
     }
 
-    /** FUN-002(#82) — COMPLIANCE는 §4-1 "조회만"이라 계약 생성·수정 모두 403이어야 한다. */
+    /**
+     * FUN-002(#82) — COMPLIANCE는 §4-1 "조회만"이라 계약 생성·수정 모두 403이어야 한다.
+     * 이 거부는 SecurityConfig 굵은 규칙(필터 단계)에서 나므로, ApiResponse 봉투는
+     * 컨트롤러 advice 가 아니라 apiAccessDeniedHandler 가 써 준다 — 봉투까지 확인한다.
+     */
     @Test
     @DisplayName("준법·감사는 보험계약을 생성할 수 없다")
     void createContractRejectsComplianceUser() throws Exception {
@@ -373,7 +377,9 @@ class ContractControllerTest {
                         .content(objectMapper.writeValueAsString(
                                 createRequest()
                         )))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("FGC-AUTH-003"))
+                .andExpect(jsonPath("$.data").doesNotExist());
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/schedule/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/schedule/controller/ScheduleControllerTest.java
@@ -69,6 +69,13 @@ class ScheduleControllerTest {
                 .andExpect(status().isForbidden());
     }
 
+    /** FUN-002(#82) — COMPLIANCE는 §4-1 "조회만"이라 재생성도 403이어야 한다. */
+    @Test
+    void rejectsRegenerationForComplianceRole() throws Exception {
+        mockMvc.perform(post("/api/v1/schedules/{id}/regenerate", 10L).with(user("comp01").roles("COMPLIANCE")).contentType(APPLICATION_JSON).content("{\"reason\":\"정책 변경 반영\"}"))
+                .andExpect(status().isForbidden());
+    }
+
     /** FGC-FUN-002 — SYSTEM_ADMIN 은 "전부"(화면정의서 §4-1)라 재생성도 허용된다. */
     @Test
     void allowsRegenerationForSystemAdmin() throws Exception {

--- a/src/test/java/com/susukkang/fgc/transaction/CommissionPaymentIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/CommissionPaymentIntegrationTest.java
@@ -22,6 +22,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.concurrent.DelegatingSecurityContextExecutorService;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +51,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 @SpringBootTest
 @Transactional
+// FUN-002(#82) — confirm()에 @PreAuthorize(Roles.CAN_PROCESS)가 붙은 뒤로 서비스를 직접 호출하는
+// 이 통합 테스트에도 SecurityContext가 필요하다. 지급 확정은 SETTLEMENT가 소유하는 동작이다.
+@WithMockUser(roles = "SETTLEMENT")
 class CommissionPaymentIntegrationTest {
 
     @Autowired
@@ -399,7 +404,10 @@ class CommissionPaymentIntegrationTest {
 
         CountDownLatch ready = new CountDownLatch(2);
         CountDownLatch start = new CountDownLatch(1);
-        ExecutorService executor = Executors.newFixedThreadPool(2);
+        // @WithMockUser는 메인 스레드의 SecurityContext(ThreadLocal)만 채운다. 워커 스레드가
+        // confirm()을 직접 호출하므로 제출 시점의 SecurityContext를 감싸 넘겨준다.
+        ExecutorService executor = new DelegatingSecurityContextExecutorService(
+                Executors.newFixedThreadPool(2));
         try {
             Future<String> firstResult = executor.submit(() -> confirmOutcome(
                     first.paymentId(), "IT-LOCK-A-" + runId, ready, start

--- a/src/test/java/com/susukkang/fgc/transaction/controller/CommissionPaymentApiControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/controller/CommissionPaymentApiControllerTest.java
@@ -206,12 +206,15 @@ class CommissionPaymentApiControllerTest {
     // FUN-002(#82) — COMPLIANCE는 §4-1 "조회만"이라 등록·수정·확정 전부 403이어야 한다.
     @Test
     void rejectsCreateUpdateAndConfirmForComplianceRole() throws Exception {
+        // 필터 단계 거부도 ApiResponse 봉투로 나가야 한다(apiAccessDeniedHandler, 이슈 #82 인수조건)
         mockMvc.perform(post("/api/v1/transactions")
                         .with(user("comp01").roles("COMPLIANCE"))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(validCreateJson()))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("FGC-AUTH-003"))
+                .andExpect(jsonPath("$.data").doesNotExist());
 
         mockMvc.perform(put("/api/v1/transactions/101")
                         .with(user("comp01").roles("COMPLIANCE"))

--- a/src/test/java/com/susukkang/fgc/transaction/controller/CommissionPaymentApiControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/controller/CommissionPaymentApiControllerTest.java
@@ -203,6 +203,29 @@ class CommissionPaymentApiControllerTest {
                 .andExpect(status().isForbidden());
     }
 
+    // FUN-002(#82) — COMPLIANCE는 §4-1 "조회만"이라 등록·수정·확정 전부 403이어야 한다.
+    @Test
+    void rejectsCreateUpdateAndConfirmForComplianceRole() throws Exception {
+        mockMvc.perform(post("/api/v1/transactions")
+                        .with(user("comp01").roles("COMPLIANCE"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validCreateJson()))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(put("/api/v1/transactions/101")
+                        .with(user("comp01").roles("COMPLIANCE"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(validUpdateJson()))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/v1/transactions/101/confirm")
+                        .with(user("comp01").roles("COMPLIANCE"))
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
     @Test
     void rejectsMissingRequiredValues() throws Exception {
         mockMvc.perform(post("/api/v1/transactions")

--- a/src/test/java/com/susukkang/fgc/validation/controller/ValidationRunControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/controller/ValidationRunControllerTest.java
@@ -162,6 +162,18 @@ class ValidationRunControllerTest {
                 .andExpect(status().isForbidden());
     }
 
+    /** FUN-002(#82) — COMPLIANCE는 §4-1 "조회만"이라 검증 실행 생성도 403이어야 한다. */
+    @Test
+    void returns403ForComplianceRole() throws Exception {
+        CreateValidationRunRequest request = new CreateValidationRunRequest("2026-08", "MONTHLY");
+
+        mockMvc.perform(post("/api/v1/validation-runs")
+                        .with(user("comp01").roles("COMPLIANCE"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
     @Test
     // Service가 VRUN_001(FgcBusinessException)을 던지면 409로 매핑되는지
     void returns409WhenServiceThrowsAlreadyRunning() throws Exception {


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* FUN-002 역할 정책을 `Roles` 상수 클래스 한 곳으로 모으고, 컨트롤러·`ShellAdvice`·`sidebar.html` 에 흩어져 있던 역할 문자열 리터럴을 전부 이 상수를 참조하도록 바꿨습니다.
* 세 개의 `SecurityFilterChain` 모두 `anyRequest().authenticated()` 하나뿐이던 인가 규칙에 **URL 단위 역할 규칙**을 추가했습니다. 감사로그(AUDT-W01) 조회 제한과, `COMPLIANCE` 의 상태 변경 요청(POST/PUT/DELETE/PATCH) 전면 차단입니다.
* 지급 확정(`CommissionPaymentServiceImpl.confirm`)은 컨트롤러를 우회하는 호출 경로에 대비해 **서비스 계층에도** `@PreAuthorize` 를 걸었습니다.
* `COMPLIANCE` 역할이 주요 처리 엔드포인트에서 403 을 받는지 검증하는 테스트를 4개 테스트 클래스에 추가했습니다.

## 🔗 2. 관련 이슈

* Closes #82

## 🛠 3. 구현 내용

### 1) 역할 정책 단일화 — `common/security/Roles.java` (신규)

* 역할 코드 4종(`SYSTEM_ADMIN`·`GA_ADMIN`·`SETTLEMENT`·`COMPLIANCE`)과, 지금 실제로 쓰이는 역할 **조합** 만 상수로 정의했습니다.
  * `CAN_PROCESS` = `hasAnyRole('SETTLEMENT','SYSTEM_ADMIN')` — 계약·지급·스케줄·검증실행 등 "처리"
  * `CAN_VIEW_AUDIT_LOG` = `hasAnyRole('COMPLIANCE','SYSTEM_ADMIN')` — AUDT-W01
  * `NON_COMPLIANCE` = `{SYSTEM_ADMIN, GA_ADMIN, SETTLEMENT}` — `SecurityConfig` 굵은 규칙용 배열
* `@PreAuthorize` 애노테이션 값은 컴파일타임 상수여야 하므로, `static final String` 리터럴끼리 `+` 로 접합해 컴파일러가 상수 폴딩하도록 만들었습니다(정책 클래스 빈 주입 방식 대신 이 방식을 택한 이유를 클래스 주석에 남겼습니다).
* 아직 엔드포인트가 없는 조합(EXCP-W01 의 `SETTLEMENT`·`GA_ADMIN`, 역분개, 검증 실행 확정)은 **미리 만들지 않았습니다.** 해당 API 가 실제로 생길 때 추가합니다.

치환된 호출부:

| 파일 | 전 | 후 |
|---|---|---|
| `ScreenViewController` (3곳 + 감사로그 1곳) | `@PreAuthorize("hasAnyRole('SETTLEMENT', 'SYSTEM_ADMIN')")` | `@PreAuthorize(Roles.CAN_PROCESS)` / `Roles.CAN_VIEW_AUDIT_LOG` |
| `ContractController` (3곳) | 동일 리터럴 | `Roles.CAN_PROCESS` |
| `ScheduleController`, `ValidationRunController`, `CommissionPaymentApiController` | 동일 리터럴 | `Roles.CAN_PROCESS` |
| `ShellAdvice.readOnly / canProcess / roleCode` | `"COMPLIANCE".equals(..)` 등 문자열 비교 | `Roles.*` 상수 비교 |

### 2) `SecurityConfig` URL 단위 역할 규칙

세 체인(`/api/v1/transactions/**`, `/api/**`, 화면 MPA) 모두에 적용했습니다.

* **감사로그** — `GET /audit-logs`(화면), `GET /api/v1/audit-logs/**`(API) → `COMPLIANCE`·`SYSTEM_ADMIN` 만. 감사로그 API(IF-API-52)는 아직 미구현이지만, 구현되는 순간 인가가 붙어 있도록 규칙을 선제 등록했습니다.
* **상태 변경 굵은 규칙** — POST/PUT/DELETE/PATCH `/**` → `NON_COMPLIANCE`. `COMPLIANCE` 는 화면정의서 §4-1 상 "조회만"이므로 경로 종류를 가리지 않고 배제됩니다. 컨트롤러에 `@PreAuthorize` 를 빠뜨려도 최소한 이 한 겹이 남습니다.
* 세분화된 구분(`SETTLEMENT` vs `GA_ADMIN`)은 이 굵은 규칙이 아니라 **컨트롤러 `@PreAuthorize` 가 계속 담당**합니다. URL 매처에 화면별 역할표를 다 옮기면 경로가 바뀔 때마다 두 곳을 고쳐야 해서, 의도적으로 층을 나눴습니다.

### 3) 서비스 계층 — `CommissionPaymentServiceImpl.confirm`

* 지급 확정에 `@PreAuthorize(Roles.CAN_PROCESS)` 추가. `@EnableMethodSecurity` 는 이미 켜져 있어 설정 변경은 없습니다.
* 역분개는 IF-API-36 자체가 미구현이라 이번 PR 범위에서 제외했습니다(#134·#144 후속 시 함께).

### 4) 화면

* `sidebar.html:52` 의 `th:if="${roleCode == 'COMPLIANCE' or roleCode == 'SYSTEM_ADMIN'}"` 하드코딩을 제거하고, `ShellAdvice` 에 새로 추가한 `canViewAuditLog` 모델 속성을 보게 했습니다. 템플릿이 역할 문자열을 직접 비교하지 않습니다.

### 5) (부수) 로그인 화면 워크스페이스 탭 정리

* `login.js` 에서 `sessionStorage` 의 `fgc.workspace-tabs.v1` 을 제거합니다. 로그인 화면은 미인증 상태에서만 뜨므로(로그아웃 직후·세션 만료 모두), 이전 세션의 탭이 다음 로그인까지 남는 문제를 여기서 끊습니다.

## 🧪 4. 테스트 방법

1. 컴파일 확인
   ```bash
   ./gradlew compileJava compileTestJava
   ```
2. 이번 PR 에서 추가·수정한 인가 테스트 실행 (전부 통과 확인함)
   ```bash
   ./gradlew test --tests '*ContractControllerTest' \
                  --tests '*ScheduleControllerTest' \
                  --tests '*CommissionPaymentApiControllerTest' \
                  --tests '*ValidationRunControllerTest'
   ```
   * `COMPLIANCE` 로 `POST /api/v1/contracts`, `PUT /api/v1/contracts/{id}`, `POST /api/v1/contracts/{id}/arbitrage-check`, `POST /api/v1/schedules/{id}/regenerate`, `POST|PUT /api/v1/transactions`, `POST /api/v1/transactions/{id}/confirm`, `POST /api/v1/validation-runs` → 전부 403
3. DB 가 필요한 통합 테스트(지급 확정 동시성)
   ```bash
   ./gradlew test --tests '*CommissionPaymentIntegrationTest'
   ```
   * `confirm()` 에 `@PreAuthorize` 가 붙어 서비스를 직접 호출하는 이 테스트에 `@WithMockUser(roles = "SETTLEMENT")` 를 달았고, 워커 스레드에서 `confirm()` 을 호출하는 잠금 경합 케이스는 `DelegatingSecurityContextExecutorService` 로 감쌌습니다.
4. 화면 직접 URL 호출 (앱 실행 후)
   * `audit01` 로그인 → 사이드바에 "감사로그" 메뉴 있음 → `/audit-logs` 정상 진입 → 대신 `/contracts/new` 등 처리 화면 직접 입력 → 403 + `error/403.html`, 그리고 각 화면의 처리 버튼 숨김(`readOnly`)
   * `SETTLEMENT` 계정 로그인 → `/audit-logs` 직접 입력 → 403 / `/contracts/new` → 정상 진입
   * `COMPLIANCE` 계정 → 로그아웃 정상 동작 확인(아래 6번 참고)

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

1. **`SecurityConfig` 의 `POST /**` 굵은 규칙이 로그인·로그아웃을 막지 않는지** — `/login` 은 `permitAll` 매처가 앞에 있어 통과하고, `POST /logout` 은 `LogoutFilter` 가 `AuthorizationFilter` 보다 앞단이라 인가 검사에 닿지 않습니다. 그래도 `COMPLIANCE` 계정으로 로그아웃 한 번 확인해 주시면 좋겠습니다.
2. **`CAN_PROCESS` 가 `GA_ADMIN` 을 포함하지 않는 점** — 이슈 #82 표의 CONT-W01/W02(등록 `SETTLEMENT`·`GA_ADMIN`), LEDG-W01(역분개 `SETTLEMENT`·`GA_ADMIN`)과는 다릅니다. 현재 값은 PR #79·#101 에서 정해진 기존 동작을 그대로 상수로 옮긴 것이고, `GA_ADMIN` 을 열어야 한다면 이제 `Roles.CAN_PROCESS` 한 줄만 고치면 됩니다. **이번 PR 에서 바꿀지 별도 이슈로 뺄지 판단 부탁드립니다.**
3. **`Roles` 의 `String` 상수 접합 방식** — SpEL 을 상수로 조립하는 게 정책 클래스(`@Component` + `hasAuthority(@policy.can(..))`) 보다 나은 선택인지. 애노테이션 컴파일타임 상수 제약 때문에 이 방식을 택했습니다.
4. `@PreAuthorize` 를 서비스 계층까지 내린 범위 — 지급 확정 하나만 걸었습니다. 더 내려야 할 처리가 있는지.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다. (커밋 부모가 `develop` tip `38fd913`)
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다. (403 화면 렌더링은 리뷰어 확인 요청 — 4번 참고)
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음 (사이드바 감사로그 메뉴의 노출 **조건식**만 `canViewAuditLog` 로 교체 — 보이는 결과는 이전과 동일합니다.)

## 💬 9. 참고 사항

* **이슈 #82 잔여 항목 중 이번 PR 범위 밖:**
  * 역분개(LEDG-W01) 서비스 계층 인가 — IF-API-36 자체가 미구현. #134·#144 후속에서 구현과 함께 처리합니다.
  * 역할 4종 × **전체** API 403 매트릭스 — 이번엔 `COMPLIANCE`(= 정책상 가장 넓게 막히는 역할) 기준으로 주요 처리 엔드포인트를 덮었습니다. `GA_ADMIN` 케이스는 위 리뷰 요구사항 2번 결론에 따라 달라집니다.
* `SecurityConfig` 의 굵은 규칙은 `COMPLIANCE` **배제**만 담당합니다. 화면별 역할표 전체를 URL 매처로 옮기지 않은 것은 의도한 선택이며, 이유를 코드 주석에 남겼습니다.
* `login.js` 의 워크스페이스 탭 정리는 RBAC 과 직접 관련은 없지만, 역할이 다른 계정으로 재로그인했을 때 이전 역할에서 열어 둔 탭이 남는 문제와 맞닿아 있어 같이 넣었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **보안 강화**
  - 역할별 API 및 웹 기능 접근 권한을 세분화했습니다.
  - 처리 권한이 없는 요청은 일관된 오류 응답과 403 상태로 안내됩니다.
  - 감사 로그는 허용된 역할만 조회할 수 있습니다.
  - 지급 확정 등 주요 처리 작업에 추가 권한 검사를 적용했습니다.

- **화면 개선**
  - 권한이 없는 사용자에게 감사 로그 메뉴가 표시되지 않습니다.
  - 로그인 시 이전 워크스페이스 탭 정보가 초기화됩니다.

- **검증**
  - 계약, 일정, 지급, 검증 실행 기능의 권한 제한을 점검하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->