### PR TITLE
[Bug] 사이드바 메뉴 하위 메뉴 초기화 문제 수정

### DIFF
--- a/src/main/resources/static/js/features/auth/login.js
+++ b/src/main/resources/static/js/features/auth/login.js
@@ -2,9 +2,13 @@
   "use strict";
 
   // 로그아웃 직후든 세션 만료든, 로그인 화면은 미인증 상태에서만 뜬다.
-  // 이전 세션의 워크스페이스 탭이 다음 로그인까지 남아있지 않도록 여기서 지운다.
-  // (fgc.workspace-tabs.v1 은 common/workspace-tabs.js STORAGE_KEY와 같은 값)
-  sessionStorage.removeItem("fgc.workspace-tabs.v1");
+  // 이전 사용자의 UI 상태(워크스페이스 탭 fgc.workspace-tabs.v1, 사이드바 펼침
+  // fgc.sidebar.open-sections.v1 등)가 다음 로그인까지 남지 않도록 fgc.* 키를 전부 지운다.
+  // 키를 하나씩 나열하면 새 키가 생길 때마다 여기도 같이 고쳐야 해서 접두사로 쓸어낸다.
+  for (let i = sessionStorage.length - 1; i >= 0; i--) {
+    const key = sessionStorage.key(i);
+    if (key && key.startsWith("fgc.")) sessionStorage.removeItem(key);
+  }
 
   const form = document.querySelector("[data-login-form]");
   const passwordInput = document.querySelector("[data-password-input]");


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* PR #145 테스트 중 로그아웃 이후 다시 로그인 시 이전 사용자가 열어놓았던 사이드바 하위 메뉴가 초기화 되지 않은 상태 그대로 드러나는 문제 수정

## 🛠 3. 구현 내용

* 같은 유형의 누락이 두 번째라(탭 키는 잡고 사이드바 키는 놓침), 키를 하나씩 나열하는 대신 로그인 화면에서 `fgc.` 접두사 sessionStorage 키를 전부 지우도록 `login.js`를 바꿨습니다:

```javascript
for (let i = sessionStorage.length - 1; i >= 0; i--) {
const key = sessionStorage.key(i);
if (key && key.startsWith("fgc.")) sessionStorage.removeItem(key);
}
```

* 로그인 화면은 미인증 상태에서만 뜨므로(로그아웃 직후·세션 만료 모두) 여기서 지우는 것이 안전하고, 앞으로 새 UI 상태 키가 생겨도 `fgc.` 접두사만 지키면 이 코드를 다시 고칠 필요가 없습니다.

* 전체 JS를 확인한 결과 sessionStorage를 쓰는 곳은 이 두 키뿐이고 둘 다 사용자별 UI 상태라 로그인 시 지워지는 게 맞으며, localStorage는 아예 쓰지 않습니다.

## 🧪 4. 테스트 방법

1. 아무 계정으로 로그인 → 사이드바 하위 메뉴 몇 개 펼침 → 로그아웃 → 다른 계정으로 로그인 → 사이드바가 초기 상태(접힘)로 나오면 정상입니다.

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

1. **`SecurityConfig` 의 `POST /**` 굵은 규칙이 로그인·로그아웃을 막지 않는지** — `/login` 은 `permitAll` 매처가 앞에 있어 통과하고, `POST /logout` 은 `LogoutFilter` 가 `AuthorizationFilter` 보다 앞단이라 인가 검사에 닿지 않습니다. 그래도 `COMPLIANCE` 계정으로 로그아웃 한 번 확인해 주시면 좋겠습니다.
2. **`CAN_PROCESS` 가 `GA_ADMIN` 을 포함하지 않는 점** — 이슈 #82 표의 CONT-W01/W02(등록 `SETTLEMENT`·`GA_ADMIN`), LEDG-W01(역분개 `SETTLEMENT`·`GA_ADMIN`)과는 다릅니다. 현재 값은 PR #79·#101 에서 정해진 기존 동작을 그대로 상수로 옮긴 것이고, `GA_ADMIN` 을 열어야 한다면 이제 `Roles.CAN_PROCESS` 한 줄만 고치면 됩니다. **이번 PR 에서 바꿀지 별도 이슈로 뺄지 판단 부탁드립니다.**
3. **`Roles` 의 `String` 상수 접합 방식** — SpEL 을 상수로 조립하는 게 정책 클래스(`@Component` + `hasAuthority(@policy.can(..))`) 보다 나은 선택인지. 애노테이션 컴파일타임 상수 제약 때문에 이 방식을 택했습니다.
4. `@PreAuthorize` 를 서비스 계층까지 내린 범위 — 지급 확정 하나만 걸었습니다. 더 내려야 할 처리가 있는지.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 로그인 화면 진입 시 이전 세션 설정이 남지 않도록 관련 `sessionStorage` 항목을 모두 정리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->