### PR TITLE
[Feat] EXCP-W01 화면 필터 OPEN 을 DB 상태값으로 풀어서 조회

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ CLAUDE.md
 skill-observations/
 graphify-out/
 .grok/
+files/

--- a/src/main/java/com/susukkang/fgc/cap/service/CapExceptionServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/cap/service/CapExceptionServiceImpl.java
@@ -7,6 +7,7 @@ import com.susukkang.fgc.cap.dto.CapExceptionStatusRow;
 import com.susukkang.fgc.cap.mapper.CapExceptionMapper;
 import com.susukkang.fgc.common.code.CapResultStatus;
 import com.susukkang.fgc.common.code.ExceptionSeverity;
+import com.susukkang.fgc.common.code.ExceptionStatus;
 import com.susukkang.fgc.common.code.ExceptionType;
 import com.susukkang.fgc.common.code.PaymentStage;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.math.BigDecimal;
-import java.util.Set;
 
 /**
  * 설명 : 한도 검증 결과가 주의 또는 위반인 경우 중복 없는 한도 예외 건을 생성하는 서비스 구현체
@@ -66,7 +66,8 @@ public class CapExceptionServiceImpl implements CapExceptionService {
         CapExceptionStatusRow exception = capExceptionMapper.selectExceptionForUpdate(command.exceptionCaseId());
         if (exception == null) throw new IllegalArgumentException("존재하지 않는 한도 예외입니다.");
         if ("RESOLVED".equals(exception.status())) return;
-        if (!Set.of("NEW", "IN_REVIEW").contains(exception.status())) {
+        // 미처리(OPEN = NEW + IN_REVIEW) 정의는 ExceptionStatus 한 곳만 쓴다(#83).
+        if (!ExceptionStatus.isOpen(exception.status())) {
             throw new IllegalStateException("해결할 수 없는 예외 상태입니다.");
         }
 
@@ -89,7 +90,8 @@ public class CapExceptionServiceImpl implements CapExceptionService {
     @Override
     @Transactional(readOnly = true)
     public boolean hasUnresolvedViolation(Long paymentId) {
-        // FUN-034의 OPEN은 공통 예외 상태인 NEW와 IN_REVIEW로 해석한다.
+        // FUN-034의 OPEN은 공통 예외 상태인 NEW와 IN_REVIEW로 해석한다(정의: ExceptionStatus).
+        // SQL 은 CapExceptionMapper.existsUnresolvedViolation 의 IN ('NEW','IN_REVIEW') — 같은 정의.
         if (paymentId == null) throw new IllegalArgumentException("지급 건 ID가 없습니다.");
         return capExceptionMapper.existsUnresolvedViolation(paymentId);
     }

--- a/src/main/java/com/susukkang/fgc/common/code/ExceptionStatus.java
+++ b/src/main/java/com/susukkang/fgc/common/code/ExceptionStatus.java
@@ -35,14 +35,15 @@ public enum ExceptionStatus {
      * 화면 필터값 → DB 상태값 목록. 변환은 여기 한 곳에서만 한다(#83).
      *
      * <ul>
-     *   <li>빈 값(전체) → 빈 목록(필터 없음)</li>
+     *   <li>빈 값(전체) → 빈 목록(필터 없음). 명시적 빈 문자열만이다 —
+     *       공백만 있는 값은 select 가 만들 수 없는 오타성 입력이라 미지원으로 취급한다</li>
      *   <li>{@code OPEN} → NEW + IN_REVIEW</li>
      *   <li>실제 상태 코드 → 그 코드 1개</li>
      *   <li>그 밖의 값 → {@link IllegalArgumentException}</li>
      * </ul>
      */
     public static List<ExceptionStatus> dbStatuses(String filter) {
-        if (filter == null || filter.isBlank()) {
+        if (filter == null || filter.isEmpty()) {
             return List.of();
         }
         if (OPEN_FILTER.equals(filter)) {

--- a/src/main/java/com/susukkang/fgc/common/code/ExceptionStatus.java
+++ b/src/main/java/com/susukkang/fgc/common/code/ExceptionStatus.java
@@ -1,0 +1,53 @@
+package com.susukkang.fgc.common.code;
+
+import java.util.List;
+
+/**
+ * 설명 : exception_case 테이블에서 사용하는 예외 상태
+ * 참고 : 화면정의서 v2.0의 예외 상태 대조표(:305-308),
+ *        V1__baseline_v2_1_2.sql:1520 CHECK 제약과 값이 같아야 한다
+ */
+public enum ExceptionStatus {
+    NEW,        // 신규
+    IN_REVIEW,  // 검토중
+    RESOLVED,   // 해결
+    REJECTED;   // 오탐·반려
+
+    /**
+     * EXCP-W01 상태 select 와 대시보드 KPI 카드가 쓰는 화면 묶음 필터 "미처리(신규+검토중)".
+     * exception_case.status 에는 없는 값이라 DB/API 로 그대로 흘려보내면
+     * 어떤 행과도 매칭되지 않는다(#83).
+     */
+    public static final String OPEN_FILTER = "OPEN";
+
+    /** OPEN 묶음이 뜻하는 미처리 상태들 — "미처리 = 신규 + 검토중"의 유일한 정의. */
+    private static final List<ExceptionStatus> OPEN_STATUSES = List.of(NEW, IN_REVIEW);
+
+    /**
+     * 이 상태 문자열이 미처리(OPEN 묶음)인가.
+     * FUN-034 등 "미해결이면 …" 판정이 각자 NEW/IN_REVIEW 를 나열하지 않게 한다.
+     */
+    public static boolean isOpen(String status) {
+        return OPEN_STATUSES.stream().anyMatch(s -> s.name().equals(status));
+    }
+
+    /**
+     * 화면 필터값 → DB 상태값 목록. 변환은 여기 한 곳에서만 한다(#83).
+     *
+     * <ul>
+     *   <li>빈 값(전체) → 빈 목록(필터 없음)</li>
+     *   <li>{@code OPEN} → NEW + IN_REVIEW</li>
+     *   <li>실제 상태 코드 → 그 코드 1개</li>
+     *   <li>그 밖의 값 → {@link IllegalArgumentException}</li>
+     * </ul>
+     */
+    public static List<ExceptionStatus> dbStatuses(String filter) {
+        if (filter == null || filter.isBlank()) {
+            return List.of();
+        }
+        if (OPEN_FILTER.equals(filter)) {
+            return OPEN_STATUSES;
+        }
+        return List.of(valueOf(filter));
+    }
+}

--- a/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
+++ b/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
@@ -82,11 +82,6 @@ public class ScreenViewController {
         return "reco/list";
     }
 
-    @GetMapping("/exceptions")
-    public String exceptionList() {
-        return "exception/list";
-    }
-
     @GetMapping("/validation-runs")
     public String validationRunList() {
         return "vrun/list";

--- a/src/main/java/com/susukkang/fgc/exceptioncase/controller/ExceptionCaseViewController.java
+++ b/src/main/java/com/susukkang/fgc/exceptioncase/controller/ExceptionCaseViewController.java
@@ -1,0 +1,55 @@
+package com.susukkang.fgc.exceptioncase.controller;
+
+import com.susukkang.fgc.common.code.ExceptionStatus;
+import com.susukkang.fgc.exceptioncase.mapper.ExceptionCaseQueryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+/**
+ * FGC-UI-EXCP-W01 예외함 화면 (FUN-052·053).
+ * 인터페이스정의서 5-2 라우팅표: GET /exceptions → exception/list.html.
+ * 조회는 전체 역할(인터페이스정의서 IF-API-43), 처리 API(IF-API-44)만 SETTLEMENT·GA_ADMIN.
+ *
+ * 화면 필터 status=OPEN(미처리)은 exception_case.status 에 없는 묶음값이라
+ * {@link ExceptionStatus#dbStatuses} 한 곳에서 NEW+IN_REVIEW 로 풀어 조회한다(#83).
+ * 대시보드 KPI 카드 링크와 이 화면의 상태 select 가 같은 OPEN 어휘를 쓰고 서버가 푼다.
+ *
+ * 카드 링크가 같이 보내는 month 는 예외의 검색조건이 아니라 셸 기준월이다 —
+ * {@link com.susukkang.fgc.common.web.ShellAdvice} 가 세션에 반영한다. KPI '미처리 예외'
+ * 집계(DashboardMapper.countOpenException)에도 월 필터가 없으므로 카드 건수와
+ * 이 화면의 미처리 건수는 그대로 맞는다.
+ */
+@Controller
+@RequiredArgsConstructor
+public class ExceptionCaseViewController {
+
+    private final ExceptionCaseQueryMapper exceptionCaseQueryMapper;
+
+    @GetMapping("/exceptions")
+    public String list(@RequestParam(required = false) String status, Model model) {
+        // defaultValue 는 빈 문자열(status= → "전체")까지 OPEN 으로 덮어쓰므로 쓰지 않는다 —
+        // 파라미터가 아예 없을 때만 워크큐 기본값(미처리)으로 연다.
+        if (status == null) {
+            status = ExceptionStatus.OPEN_FILTER;
+        }
+        List<ExceptionStatus> statuses;
+        try {
+            statuses = ExceptionStatus.dbStatuses(status);
+        } catch (IllegalArgumentException e) {
+            // ShellAdvice 의 month 처럼 조용히 기본 필터로 되돌린다 — 화면 select 가
+            // 보내는 값이라 사용자가 직접 칠 일이 없고, 워크큐 기본값은 미처리다.
+            status = ExceptionStatus.OPEN_FILTER;
+            statuses = ExceptionStatus.dbStatuses(status);
+        }
+        model.addAttribute("statusFilter", status);
+        model.addAttribute("cases", exceptionCaseQueryMapper.findCases(statuses));
+        model.addAttribute("openCount", exceptionCaseQueryMapper.countByStatuses(
+                ExceptionStatus.dbStatuses(ExceptionStatus.OPEN_FILTER)));
+        return "exception/list";
+    }
+}

--- a/src/main/java/com/susukkang/fgc/exceptioncase/dto/ExceptionCaseListRow.java
+++ b/src/main/java/com/susukkang/fgc/exceptioncase/dto/ExceptionCaseListRow.java
@@ -1,0 +1,21 @@
+package com.susukkang.fgc.exceptioncase.dto;
+
+import java.time.OffsetDateTime;
+
+/**
+ * FGC-UI-EXCP-W01 예외 목록 1행
+ * exception_case + insurance_contract(contract_no) + app_user(login_id) join 결과
+ */
+public record ExceptionCaseListRow(
+        Long exceptionCaseId,
+        String exceptionType,
+        String severity,
+        String contractNo,
+        String title,
+        String status,
+        String assignedTo,
+        OffsetDateTime createdAt,
+        String sourceEntityType,
+        String sourceEntityId
+) {
+}

--- a/src/main/java/com/susukkang/fgc/exceptioncase/dto/ExceptionCaseListRow.java
+++ b/src/main/java/com/susukkang/fgc/exceptioncase/dto/ExceptionCaseListRow.java
@@ -18,4 +18,21 @@ public record ExceptionCaseListRow(
         String sourceEntityType,
         String sourceEntityId
 ) {
+
+    /**
+     * "참조" 컬럼의 원천 화면 링크 — 화면정의서 :1349 "만들 때 주의":
+     * 참조 컬럼은 원천 화면으로 바로 가는 링크다(없으면 담당자가 원인을 못 찾는다).
+     *
+     * 지금 예외를 만드는 쪽이 실제로 쓰는 source_entity_type 3종만 매핑한다
+     * (validation/ExceptionCaseMapper.xml · cap/CapExceptionMapper.xml).
+     * 모르는 유형은 null — 화면이 링크 없이 텍스트로만 표시한다.
+     */
+    public String sourceLink() {
+        return switch (sourceEntityType) {
+            case "INSURANCE_CONTRACT" -> "/contracts/" + sourceEntityId;
+            case "ARBITRAGE_CHECK" -> "/arbitrage-checks";
+            case "COMMISSION_TRANSACTION" -> "/transactions";
+            default -> null;
+        };
+    }
 }

--- a/src/main/java/com/susukkang/fgc/exceptioncase/mapper/ExceptionCaseQueryMapper.java
+++ b/src/main/java/com/susukkang/fgc/exceptioncase/mapper/ExceptionCaseQueryMapper.java
@@ -1,0 +1,24 @@
+package com.susukkang.fgc.exceptioncase.mapper;
+
+import com.susukkang.fgc.common.code.ExceptionStatus;
+import com.susukkang.fgc.exceptioncase.dto.ExceptionCaseListRow;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * FGC-UI-EXCP-W01 예외함 조회 매퍼 (IF-API-43 의 목록 부분).
+ * 쓰기는 validation 쪽 {@link com.susukkang.fgc.validation.mapper.ExceptionCaseMapper} —
+ * 화면 조회와 배치 생성을 섞지 않는다.
+ *
+ * statuses 는 {@link ExceptionStatus#dbStatuses} 가 화면 필터에서 이미 풀어 준
+ * DB 상태값 목록이다. 빈 목록이면 상태 필터 없음(전체).
+ */
+@Mapper
+public interface ExceptionCaseQueryMapper {
+
+    List<ExceptionCaseListRow> findCases(@Param("statuses") List<ExceptionStatus> statuses);
+
+    long countByStatuses(@Param("statuses") List<ExceptionStatus> statuses);
+}

--- a/src/main/resources/mapper/cap/CapExceptionMapper.xml
+++ b/src/main/resources/mapper/cap/CapExceptionMapper.xml
@@ -116,7 +116,8 @@
             status IN ('NEW', 'IN_REVIEW')
     </update>
 
-    <!-- 지급 건에 해결되지 않은 한도 위반 예외가 존재하는지 확인한다. -->
+    <!-- 지급 건에 해결되지 않은 한도 위반 예외가 존재하는지 확인한다.
+         IN ('NEW','IN_REVIEW') 는 미처리(OPEN) 묶음 — 정의는 ExceptionStatus 를 따른다(#83). -->
     <select id="existsUnresolvedViolation"
             resultType="boolean">
         SELECT

--- a/src/main/resources/mapper/dashboard/DashboardMapper.xml
+++ b/src/main/resources/mapper/dashboard/DashboardMapper.xml
@@ -53,6 +53,8 @@
           FROM fgc.vw_journal_imbalance
     </select>
 
+    <!-- IN ('NEW','IN_REVIEW') 는 미처리(OPEN) 묶음 — 정의는 ExceptionStatus 를 따른다(#83).
+         예외함 미처리 건수와의 일치는 ExceptionCaseQueryMapperIntegrationTest 가 지킨다. -->
     <select id="countOpenException" resultType="long">
         SELECT COUNT(*)
           FROM fgc.exception_case

--- a/src/main/resources/mapper/exceptioncase/ExceptionCaseQueryMapper.xml
+++ b/src/main/resources/mapper/exceptioncase/ExceptionCaseQueryMapper.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.susukkang.fgc.exceptioncase.mapper.ExceptionCaseQueryMapper">
+
+    <!-- 빈 목록 = 상태 필터 없음(전체). OPEN → NEW+IN_REVIEW 변환은
+         ExceptionStatus.dbStatuses() 한 곳에서 끝났다 — 여기서는 받은 값만 IN 으로 건다(#83). -->
+    <sql id="statusFilter">
+        <if test="statuses != null and !statuses.isEmpty()">
+            WHERE ec.status IN
+            <foreach item="s" collection="statuses" open="(" separator="," close=")">#{s}</foreach>
+        </if>
+    </sql>
+
+    <!-- ponytail: 페이징 없음 — 시연 데이터 규모라 전량 렌더링. IF-API-43 전체 구현 때 페이지네이션 추가 -->
+    <select id="findCases" resultType="com.susukkang.fgc.exceptioncase.dto.ExceptionCaseListRow">
+        SELECT ec.exception_case_id   AS exceptionCaseId,
+               ec.exception_type      AS exceptionType,
+               ec.severity,
+               ic.contract_no         AS contractNo,
+               ec.title,
+               ec.status,
+               au.login_id            AS assignedTo,
+               ec.created_at          AS createdAt,
+               ec.source_entity_type  AS sourceEntityType,
+               ec.source_entity_id    AS sourceEntityId
+          FROM fgc.exception_case ec
+          LEFT JOIN fgc.insurance_contract ic ON ic.contract_id = ec.contract_id
+          LEFT JOIN fgc.app_user au ON au.user_id = ec.assigned_to
+        <include refid="statusFilter"/>
+         ORDER BY CASE ec.severity WHEN 'CRITICAL' THEN 0 WHEN 'HIGH' THEN 1 WHEN 'WARNING' THEN 2 ELSE 3 END,
+                  ec.created_at DESC, ec.exception_case_id DESC
+    </select>
+
+    <select id="countByStatuses" resultType="long">
+        SELECT COUNT(*)
+          FROM fgc.exception_case ec
+        <include refid="statusFilter"/>
+    </select>
+</mapper>

--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -13,6 +13,9 @@
     <a class="kpi-card kpi-card-warning" th:href="@{/arbitrage-checks(status='CANDIDATE',month=${month})}"><div class="kpi-card-header"><span class="kpi-label">차익거래 검토대상</span></div><div class="kpi-value-row"><strong class="kpi-value" th:text="${summary.arbitrageCandidate()}">0</strong><span class="kpi-unit">건</span></div><div class="kpi-card-footer"><span class="kpi-comparison">위반 확정 아님</span></div></a>
     <a class="kpi-card kpi-card-risk" th:href="@{/reconciliations(onlyMismatch=true,month=${month})}"><div class="kpi-card-header"><span class="kpi-label">대사 불일치</span></div><div class="kpi-value-row"><strong class="kpi-value" th:text="${summary.reconMismatch()}">0</strong><span class="kpi-unit">건</span></div><div class="kpi-card-footer"><span class="kpi-comparison">허용오차 0원</span></div></a>
     <a class="kpi-card" th:classappend="${summary.journalImbalance() == 0} ? ' kpi-card-success' : ' kpi-card-error'" th:href="@{/journals(imbalanceOnly=true,month=${month})}"><div class="kpi-card-header"><span class="kpi-label">원장 불균형</span></div><div class="kpi-value-row"><strong class="kpi-value" th:text="${summary.journalImbalance()}">0</strong><span class="kpi-unit">건</span></div><div class="kpi-card-footer"><span class="kpi-comparison">기표 전 0건 필수</span></div></a>
+    <!-- OPEN 은 exception_case.status 값이 아니라 EXCP-W01 과 공유하는 화면 묶음 필터다(= NEW + IN_REVIEW).
+         ExceptionCaseViewController 가 ExceptionStatus.dbStatuses() 로 풀어서 조회하므로(#83)
+         이 링크는 그대로 둔다 — NEW/IN_REVIEW 로 바꾸면 예외함 상태 select 어휘와 어긋난다. -->
     <a class="kpi-card" th:href="@{/exceptions(status='OPEN',month=${month})}"><div class="kpi-card-header"><span class="kpi-label">미처리 예외</span></div><div class="kpi-value-row"><strong class="kpi-value" th:text="${summary.openException()}">0</strong><span class="kpi-unit">건</span></div><div class="kpi-card-footer"><span class="kpi-comparison">신규 + 검토중</span></div></a>
   </section>
 

--- a/src/main/resources/templates/exception/list.html
+++ b/src/main/resources/templates/exception/list.html
@@ -13,9 +13,11 @@
    · 처리 이력 수정·삭제 — append-only 입니다
    · 같은 원천에 예외 중복 생성 — exception_key UNIQUE 로 재실행해도 1건입니다
 
-  [정적 부착 단계] 목업(30_산출물/화면_MVP/FGC-UI-EXCP-W01)의 정적 골격만 옮겼다.
-  데이터 영역(안내 배너·유형별 요약카드·목록·처리 패널·처리 이력)은
-  예외 조회 API(GET /api/v1/exceptions) 연동 시 서버 렌더링으로 채운다.
+  [부분 바인딩 단계] 안내 배너·상태 필터·목록은 ExceptionCaseViewController 가
+  서버 렌더링으로 채운다(#83). 상태 select 의 OPEN(미처리)은 exception_case.status 에
+  없는 화면 묶음값이라 서버(ExceptionStatus.dbStatuses)가 NEW+IN_REVIEW 로 풀어 조회한다.
+  유형별 요약카드·유형/심각도/담당자/계약번호 필터·처리 패널·처리 이력은
+  IF-API-43/44 전체 연동 시 채운다.
 -->
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-EXCP-W01', '예외함', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
@@ -27,10 +29,11 @@
 
   <div class="fgc-banner fgc-banner--warn" style="margin-top:12px">
     <span class="material-symbols-outlined" style="font-size:18px">inbox</span>
-    <!-- 미처리 건수 안내 문구 — 예외 조회 API 연동 시 서버 렌더링으로 채운다 -->
     <span>
       <strong>정상 건은 여기 오지 않습니다. 여기 있는 건 전부 사람이 봐야 합니다.</strong>
-      <span id="notice-exception">현재 예외 현황은 조회 API 연동 대기 중입니다.</span>
+      <!-- 대시보드 '미처리 예외' KPI 카드(DashboardMapper.countOpenException)와 같은
+           기준(NEW+IN_REVIEW, 월 필터 없음)이라 카드 건수와 항상 일치한다 -->
+      <span id="notice-exception">미처리(신규 + 검토중) <strong th:text="${openCount}">0</strong>건이 처리를 기다립니다.</span>
     </span>
   </div>
 
@@ -40,36 +43,41 @@
     <div class="fgc-empty publishing-empty-state">유형별 미처리 집계 API 연동 대기</div>
   </section>
 
-  <!-- ② 검색 -->
+  <!-- ② 검색 — 상태 필터만 서버 연동(#83). OPEN 은 화면 묶음값이고 서버가
+       NEW+IN_REVIEW 로 푼다. 나머지 필터는 IF-API-43 전체 연동 시 활성화한다. -->
   <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__body fgc-toolbar">
+    <form class="fgc-card__body fgc-toolbar" method="get" th:action="@{/exceptions}">
       <div class="fgc-field" style="min-width:190px">
         <label class="fgc-label" for="f-type">예외 유형</label>
-        <select class="fgc-select" id="f-type"><option value="">전체</option></select>
+        <select class="fgc-select" id="f-type" disabled aria-label="예외 유형, 연동 대기"><option value="">전체</option></select>
       </div>
       <div class="fgc-field" style="min-width:130px">
         <label class="fgc-label" for="f-severity">심각도</label>
-        <select class="fgc-select" id="f-severity"><option value="">전체</option></select>
+        <select class="fgc-select" id="f-severity" disabled aria-label="심각도, 연동 대기"><option value="">전체</option></select>
       </div>
       <div class="fgc-field" style="min-width:140px">
         <label class="fgc-label" for="f-status">상태</label>
-        <select class="fgc-select" id="f-status">
-          <option value="OPEN">미처리 (신규 + 검토중)</option>
-          <option value="">전체</option>
+        <select class="fgc-select" id="f-status" name="status" onchange="this.form.submit()">
+          <option value="OPEN" th:selected="${statusFilter == 'OPEN'}">미처리 (신규 + 검토중)</option>
+          <option value="" th:selected="${statusFilter == ''}">전체</option>
+          <option value="NEW" th:selected="${statusFilter == 'NEW'}">신규</option>
+          <option value="IN_REVIEW" th:selected="${statusFilter == 'IN_REVIEW'}">검토중</option>
+          <option value="RESOLVED" th:selected="${statusFilter == 'RESOLVED'}">해결</option>
+          <option value="REJECTED" th:selected="${statusFilter == 'REJECTED'}">오탐·반려</option>
         </select>
       </div>
       <div class="fgc-field" style="min-width:140px">
         <label class="fgc-label" for="f-assignee">담당자</label>
-        <select class="fgc-select" id="f-assignee"><option value="">전체</option></select>
+        <select class="fgc-select" id="f-assignee" disabled aria-label="담당자, 연동 대기"><option value="">전체</option></select>
       </div>
       <div class="fgc-field" style="min-width:150px">
         <label class="fgc-label" for="f-contract">계약번호</label>
-        <input class="fgc-input" id="f-contract" type="text" placeholder="C004">
+        <input class="fgc-input" id="f-contract" type="text" placeholder="C004" disabled aria-label="계약번호, 연동 대기">
       </div>
-      <button class="fgc-btn fgc-btn--ghost" id="f-reset">
+      <a class="fgc-btn fgc-btn--ghost" id="f-reset" th:href="@{/exceptions}">
         <span class="material-symbols-outlined" style="font-size:18px">restart_alt</span> 초기화
-      </button>
-    </div>
+      </a>
+    </form>
   </section>
 
   <div class="fgc-responsive-split" style="margin-top:16px;display:grid;grid-template-columns:1.5fr 1fr;gap:16px" id="work-grid">
@@ -78,7 +86,7 @@
     <section class="fgc-card">
       <div class="fgc-card__head">
         <span class="fgc-card__title">예외 목록</span>
-        <span class="fgc-muted" style="font-size:12px"><span id="row-count">0</span>건 · 한 화면 20행</span>
+        <span class="fgc-muted" style="font-size:12px"><span id="row-count" th:text="${cases.size()}">0</span>건</span>
       </div>
       <div style="overflow-x:auto">
         <table class="fgc-table">
@@ -96,7 +104,18 @@
             </tr>
           </thead>
           <tbody id="list-body">
-            <tr><td colspan="9"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
+            <tr th:each="c : ${cases}">
+              <td class="fgc-mono" th:text="${c.exceptionCaseId()}">-</td>
+              <td th:text="${c.exceptionType()}">-</td>
+              <td th:text="${c.severity()}">-</td>
+              <td class="fgc-mono" th:text="${c.contractNo()} ?: '-'">-</td>
+              <td th:text="${c.title()}">-</td>
+              <td th:text="${c.status()}">-</td>
+              <td th:text="${c.assignedTo()} ?: '미배정'">-</td>
+              <td class="fgc-mono" th:text="${#temporals.format(c.createdAt(), 'yyyy-MM-dd HH:mm')}">-</td>
+              <td class="fgc-mono" th:text="${c.sourceEntityType()} + ':' + ${c.sourceEntityId()}">-</td>
+            </tr>
+            <tr th:if="${cases.isEmpty()}"><td colspan="9"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
           </tbody>
         </table>
       </div>

--- a/src/main/resources/templates/exception/list.html
+++ b/src/main/resources/templates/exception/list.html
@@ -113,7 +113,13 @@
               <td th:text="${c.status()}">-</td>
               <td th:text="${c.assignedTo()} ?: '미배정'">-</td>
               <td class="fgc-mono" th:text="${#temporals.format(c.createdAt(), 'yyyy-MM-dd HH:mm')}">-</td>
-              <td class="fgc-mono" th:text="${c.sourceEntityType()} + ':' + ${c.sourceEntityId()}">-</td>
+              <!-- 참조 = 원천 화면 링크 (화면정의서 :1349 "만들 때 주의") — 라우트가 없는 원천 유형은 텍스트로만 -->
+              <td class="fgc-mono">
+                <a th:if="${c.sourceLink() != null}" th:href="@{${c.sourceLink()}}"
+                   th:text="${c.sourceEntityType()} + ':' + ${c.sourceEntityId()}">-</a>
+                <span th:if="${c.sourceLink() == null}"
+                      th:text="${c.sourceEntityType()} + ':' + ${c.sourceEntityId()}">-</span>
+              </td>
             </tr>
             <tr th:if="${cases.isEmpty()}"><td colspan="9"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
           </tbody>

--- a/src/test/java/com/susukkang/fgc/auth/AuthLoginFlowTest.java
+++ b/src/test/java/com/susukkang/fgc/auth/AuthLoginFlowTest.java
@@ -179,6 +179,25 @@ class AuthLoginFlowTest {
         mockMvc.perform(get("/css/features/auth.css")).andExpect(status().isOk());
     }
 
+    /**
+     * FUN-002(#82) — SecurityConfig 의 POST /** 굵은 규칙은 COMPLIANCE 를 배제하지만,
+     * POST /logout 은 LogoutFilter 가 AuthorizationFilter 앞단이라 로그아웃은 막히지 않아야 한다.
+     * PR #145 리뷰 요구사항 1(COMPLIANCE 계정 로그아웃 확인)의 자동화.
+     */
+    @Test
+    void complianceUserCanStillLogoutDespiteBulkPostRule() throws Exception {
+        MockHttpSession session = (MockHttpSession) mockMvc
+                .perform(formLogin().user("audit01").password(DEMO_PASSWORD))
+                .andExpect(authenticated().withUsername("audit01").withRoles("COMPLIANCE"))
+                .andReturn()
+                .getRequest()
+                .getSession(false);
+
+        mockMvc.perform(post("/logout").session(session).with(csrf()))
+                .andExpect(unauthenticated())
+                .andExpect(redirectedUrl("/login?logout"));
+    }
+
     // ★ 인수조건: 로그아웃하면 세션을 즉시 지우고, 이후 보호 URL 접근이 차단된다
     @Test
     void logoutClearsSessionAndBlocksProtectedUrl() throws Exception {

--- a/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
@@ -22,11 +22,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * 실데이터 바인딩 검증은 화면별 기능 브랜치의 몫이다.
  * (실데이터 바인딩된 화면은 도메인 뷰 컨트롤러 테스트로 이관:
  *  DASH → DashboardViewControllerTest, BASE → BaseViewControllerTest,
- *  POL → PolicyViewControllerTest)
+ *  POL → PolicyViewControllerTest, EXCP → ExceptionCaseViewControllerTest)
  *
  * 요구사항 추적(FGC-FUN-xxx): CONT 018 ·
  * TRAN 065/031/033/034 · SCHE 036/039 · CAP 030/032/035 · ARB 063 ·
- * LEDG 046/047 · RECO 048~051 · EXCP 052/053 · VRUN 041~044 · AUDT 061.
+ * LEDG 046/047 · RECO 048~051 · VRUN 041~044 · AUDT 061.
  * /audit-logs 만 역할 제한(FUN-002·화면정의서 :1530)이라 별도 테스트로 뺐다.
  */
 @WebMvcTest(ScreenViewController.class)
@@ -62,7 +62,6 @@ class ScreenViewControllerTest {
             "/arbitrage-checks,    FGC-UI-ARB-W01",
             "/journals,            FGC-UI-LEDG-W01",
             "/reconciliations,     FGC-UI-RECO-W01",
-            "/exceptions,          FGC-UI-EXCP-W01",
             "/validation-runs,     FGC-UI-VRUN-W01",
             "/validation-runs/1,   FGC-UI-VRUN-W02",
     })

--- a/src/test/java/com/susukkang/fgc/exceptioncase/controller/ExceptionCaseViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/exceptioncase/controller/ExceptionCaseViewControllerTest.java
@@ -1,0 +1,152 @@
+package com.susukkang.fgc.exceptioncase.controller;
+
+import com.susukkang.fgc.auth.dto.AppUserView;
+import com.susukkang.fgc.auth.dto.FgcUserDetails;
+import com.susukkang.fgc.common.code.ExceptionStatus;
+import com.susukkang.fgc.common.exception.ConstraintErrorCodeResolver;
+import com.susukkang.fgc.common.exception.FgcMessageResolver;
+import com.susukkang.fgc.common.exception.GlobalExceptionHandler;
+import com.susukkang.fgc.common.web.ShellAdvice;
+import com.susukkang.fgc.exceptioncase.dto.ExceptionCaseListRow;
+import com.susukkang.fgc.exceptioncase.mapper.ExceptionCaseQueryMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static com.susukkang.fgc.common.code.ExceptionStatus.IN_REVIEW;
+import static com.susukkang.fgc.common.code.ExceptionStatus.NEW;
+import static com.susukkang.fgc.common.code.ExceptionStatus.RESOLVED;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+/**
+ * EXCP-W01 예외함 — 화면 필터 status=OPEN(묶음값)을 서버가 NEW+IN_REVIEW 로
+ * 풀어서 조회하는지(#83) 를 OPEN / 개별 상태값 / 필터 없음 3가지 경로로 지킨다.
+ * FUN-057 인수조건 "카드 클릭 → 목록 이동 + 검색조건 자동 적용"(화면정의서 :405)의 수신부.
+ */
+@WebMvcTest(ExceptionCaseViewController.class)
+@Import({ExceptionCaseViewController.class, ShellAdvice.class, GlobalExceptionHandler.class,
+        FgcMessageResolver.class, ConstraintErrorCodeResolver.class, MessageSourceAutoConfiguration.class})
+@TestPropertySource(properties = "fgc.demo-month=2026-07")
+class ExceptionCaseViewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ExceptionCaseQueryMapper mapper;
+
+    private static FgcUserDetails principal(String loginId, String userName, String roleCode) {
+        AppUserView view = new AppUserView();
+        view.setUserId(1L);
+        view.setLoginId(loginId);
+        view.setPasswordHash("{noop}x");
+        view.setUserName(userName);
+        view.setRoleCode(roleCode);
+        view.setAccountStatus("ACTIVE");
+        return new FgcUserDetails(view, true, true);
+    }
+
+    private static final FgcUserDetails SETTLE = principal("settle01", "정산담당", "SETTLEMENT");
+
+    private static final ExceptionCaseListRow OPEN_ROW = new ExceptionCaseListRow(
+            10L, "CAP_VIOLATION", "CRITICAL", "C001", "1200% 한도 초과", "NEW", null,
+            OffsetDateTime.parse("2026-07-10T09:00:00+09:00"), "CAP_CHECK", "77");
+
+    private static final ExceptionCaseListRow RESOLVED_ROW = new ExceptionCaseListRow(
+            11L, "DATA_QUALITY", "WARNING", null, "필수값 누락", "RESOLVED", "settle01",
+            OffsetDateTime.parse("2026-07-01T09:00:00+09:00"), "INSURANCE_CONTRACT", "5");
+
+    @Test
+    void 필터_없이_열면_기본값_OPEN이_NEW와_IN_REVIEW로_풀려_조회된다() throws Exception {
+        given(mapper.findCases(List.of(NEW, IN_REVIEW))).willReturn(List.of(OPEN_ROW));
+        given(mapper.countByStatuses(List.of(NEW, IN_REVIEW))).willReturn(1L);
+
+        mockMvc.perform(get("/exceptions").with(user(SETTLE)))
+                .andExpect(status().isOk())
+                .andExpect(view().name("exception/list"))
+                .andExpect(model().attribute("statusFilter", "OPEN"))
+                // 셸 + 화면 ID + 목록 실데이터 렌더링
+                .andExpect(content().string(containsString("FGC-UI-EXCP-W01")))
+                .andExpect(content().string(containsString("1200% 한도 초과")))
+                .andExpect(content().string(containsString("미배정")))
+                // 미처리 배너 건수 — 대시보드 KPI(countOpenException)와 같은 기준
+                .andExpect(content().string(containsString("건이 처리를 기다립니다")))
+                // 상태 select 는 OPEN 이 선택된 채로 돌아온다
+                .andExpect(content().string(containsString("<option value=\"OPEN\" selected=\"selected\">")));
+
+        verify(mapper).findCases(List.of(NEW, IN_REVIEW));
+    }
+
+    /** 대시보드 '미처리 예외' KPI 카드 링크(@{/exceptions(status='OPEN',month=...)}) 경로. */
+    @Test
+    void 대시보드_카드가_보낸_OPEN과_month가_그대로_적용된다() throws Exception {
+        given(mapper.findCases(anyList())).willReturn(List.of(OPEN_ROW));
+        given(mapper.countByStatuses(anyList())).willReturn(1L);
+
+        mockMvc.perform(get("/exceptions").param("status", "OPEN").param("month", "2026-05")
+                        .with(user(SETTLE)))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("statusFilter", "OPEN"))
+                // month 는 예외 검색조건이 아니라 셸 기준월 — ShellAdvice 가 반영한다
+                .andExpect(model().attribute("month", "2026-05"));
+
+        verify(mapper).findCases(List.of(NEW, IN_REVIEW));
+    }
+
+    @Test
+    void 실제_상태코드_필터는_그_값_하나로만_조회된다() throws Exception {
+        given(mapper.findCases(List.of(RESOLVED))).willReturn(List.of(RESOLVED_ROW));
+        given(mapper.countByStatuses(anyList())).willReturn(0L);
+
+        mockMvc.perform(get("/exceptions").param("status", "RESOLVED").with(user(SETTLE)))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("statusFilter", "RESOLVED"))
+                .andExpect(content().string(containsString("필수값 누락")))
+                .andExpect(content().string(containsString("<option value=\"RESOLVED\" selected=\"selected\">")));
+
+        verify(mapper).findCases(List.of(RESOLVED));
+    }
+
+    @Test
+    void 빈_상태값은_필터_없음_전체_조회다() throws Exception {
+        given(mapper.findCases(List.of())).willReturn(List.of(OPEN_ROW, RESOLVED_ROW));
+        given(mapper.countByStatuses(anyList())).willReturn(1L);
+
+        mockMvc.perform(get("/exceptions").param("status", "").with(user(SETTLE)))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("statusFilter", ""))
+                .andExpect(content().string(containsString("<option value=\"\" selected=\"selected\">")));
+
+        verify(mapper).findCases(List.<ExceptionStatus>of());
+    }
+
+    @Test
+    void 미지원_상태값은_400이_아니라_기본_OPEN으로_되돌린다() throws Exception {
+        // ShellAdvice 의 month 와 같은 정책 — select 가 보내는 값이라 조용히 복구한다
+        given(mapper.findCases(anyList())).willReturn(List.of());
+        given(mapper.countByStatuses(anyList())).willReturn(0L);
+
+        mockMvc.perform(get("/exceptions").param("status", "NOPE").with(user(SETTLE)))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("statusFilter", "OPEN"));
+
+        verify(mapper).findCases(List.of(NEW, IN_REVIEW));
+    }
+}

--- a/src/test/java/com/susukkang/fgc/exceptioncase/controller/ExceptionCaseViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/exceptioncase/controller/ExceptionCaseViewControllerTest.java
@@ -67,11 +67,16 @@ class ExceptionCaseViewControllerTest {
 
     private static final ExceptionCaseListRow OPEN_ROW = new ExceptionCaseListRow(
             10L, "CAP_VIOLATION", "CRITICAL", "C001", "1200% 한도 초과", "NEW", null,
-            OffsetDateTime.parse("2026-07-10T09:00:00+09:00"), "CAP_CHECK", "77");
+            OffsetDateTime.parse("2026-07-10T09:00:00+09:00"), "COMMISSION_TRANSACTION", "77");
 
     private static final ExceptionCaseListRow RESOLVED_ROW = new ExceptionCaseListRow(
             11L, "DATA_QUALITY", "WARNING", null, "필수값 누락", "RESOLVED", "settle01",
             OffsetDateTime.parse("2026-07-01T09:00:00+09:00"), "INSURANCE_CONTRACT", "5");
+
+    /** 원천 화면 라우트가 아직 없는 유형 — 참조 컬럼이 링크 없이 텍스트로만 나와야 한다. */
+    private static final ExceptionCaseListRow UNKNOWN_SOURCE_ROW = new ExceptionCaseListRow(
+            12L, "OTHER", "INFO", null, "원천 미상 예외", "NEW", null,
+            OffsetDateTime.parse("2026-07-02T09:00:00+09:00"), "LEGACY_SOURCE", "9");
 
     @Test
     void 필터_없이_열면_기본값_OPEN이_NEW와_IN_REVIEW로_풀려_조회된다() throws Exception {
@@ -86,6 +91,9 @@ class ExceptionCaseViewControllerTest {
                 .andExpect(content().string(containsString("FGC-UI-EXCP-W01")))
                 .andExpect(content().string(containsString("1200% 한도 초과")))
                 .andExpect(content().string(containsString("미배정")))
+                // 참조 컬럼은 원천 화면 링크 (화면정의서 :1349 "만들 때 주의")
+                .andExpect(content().string(containsString("href=\"/transactions\"")))
+                .andExpect(content().string(containsString("COMMISSION_TRANSACTION:77")))
                 // 미처리 배너 건수 — 대시보드 KPI(countOpenException)와 같은 기준
                 .andExpect(content().string(containsString("건이 처리를 기다립니다")))
                 // 상태 select 는 OPEN 이 선택된 채로 돌아온다
@@ -119,6 +127,7 @@ class ExceptionCaseViewControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(model().attribute("statusFilter", "RESOLVED"))
                 .andExpect(content().string(containsString("필수값 누락")))
+                .andExpect(content().string(containsString("href=\"/contracts/5\"")))
                 .andExpect(content().string(containsString("<option value=\"RESOLVED\" selected=\"selected\">")));
 
         verify(mapper).findCases(List.of(RESOLVED));
@@ -126,13 +135,16 @@ class ExceptionCaseViewControllerTest {
 
     @Test
     void 빈_상태값은_필터_없음_전체_조회다() throws Exception {
-        given(mapper.findCases(List.of())).willReturn(List.of(OPEN_ROW, RESOLVED_ROW));
+        given(mapper.findCases(List.of())).willReturn(List.of(OPEN_ROW, RESOLVED_ROW, UNKNOWN_SOURCE_ROW));
         given(mapper.countByStatuses(anyList())).willReturn(1L);
 
         mockMvc.perform(get("/exceptions").param("status", "").with(user(SETTLE)))
                 .andExpect(status().isOk())
                 .andExpect(model().attribute("statusFilter", ""))
-                .andExpect(content().string(containsString("<option value=\"\" selected=\"selected\">")));
+                .andExpect(content().string(containsString("<option value=\"\" selected=\"selected\">")))
+                // 라우트가 없는 원천 유형은 링크 없이 텍스트로만 표시된다
+                .andExpect(content().string(containsString("LEGACY_SOURCE:9")))
+                .andExpect(content().string(org.hamcrest.Matchers.not(containsString("LEGACY_SOURCE:9</a>"))));
 
         verify(mapper).findCases(List.<ExceptionStatus>of());
     }

--- a/src/test/java/com/susukkang/fgc/exceptioncase/controller/ExceptionCaseViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/exceptioncase/controller/ExceptionCaseViewControllerTest.java
@@ -25,7 +25,6 @@ import static com.susukkang.fgc.common.code.ExceptionStatus.IN_REVIEW;
 import static com.susukkang.fgc.common.code.ExceptionStatus.NEW;
 import static com.susukkang.fgc.common.code.ExceptionStatus.RESOLVED;
 import static org.hamcrest.Matchers.containsString;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
@@ -78,35 +77,48 @@ class ExceptionCaseViewControllerTest {
             12L, "OTHER", "INFO", null, "원천 미상 예외", "NEW", null,
             OffsetDateTime.parse("2026-07-02T09:00:00+09:00"), "LEGACY_SOURCE", "9");
 
+    private static final ExceptionCaseListRow ARBITRAGE_ROW = new ExceptionCaseListRow(
+            13L, "ARBITRAGE_CANDIDATE", "HIGH", "C002", "차익거래 후보", "NEW", null,
+            OffsetDateTime.parse("2026-07-11T09:00:00+09:00"), "ARBITRAGE_CHECK", "3");
+
+    /** FGC-FUN-052/053 — 워크큐 기본 화면. 묶음 필터 OPEN 의 서버 해석(#83)이 조회 기준이 된다. */
     @Test
     void 필터_없이_열면_기본값_OPEN이_NEW와_IN_REVIEW로_풀려_조회된다() throws Exception {
-        given(mapper.findCases(List.of(NEW, IN_REVIEW))).willReturn(List.of(OPEN_ROW));
-        given(mapper.countByStatuses(List.of(NEW, IN_REVIEW))).willReturn(1L);
+        given(mapper.findCases(List.of(NEW, IN_REVIEW))).willReturn(List.of(OPEN_ROW, ARBITRAGE_ROW));
+        given(mapper.countByStatuses(List.of(NEW, IN_REVIEW))).willReturn(2L);
 
         mockMvc.perform(get("/exceptions").with(user(SETTLE)))
                 .andExpect(status().isOk())
                 .andExpect(view().name("exception/list"))
                 .andExpect(model().attribute("statusFilter", "OPEN"))
+                // FGC-FUN-057 인수조건 "건수 일치" — 배너 건수는 KPI 와 같은 기준으로 계산된다
+                .andExpect(model().attribute("openCount", 2L))
                 // 셸 + 화면 ID + 목록 실데이터 렌더링
                 .andExpect(content().string(containsString("FGC-UI-EXCP-W01")))
                 .andExpect(content().string(containsString("1200% 한도 초과")))
                 .andExpect(content().string(containsString("미배정")))
-                // 참조 컬럼은 원천 화면 링크 (화면정의서 :1349 "만들 때 주의")
+                // FGC-FUN-052(원천 연결) — 참조 컬럼은 원천 화면 링크 (화면정의서 :1349 "만들 때 주의")
                 .andExpect(content().string(containsString("href=\"/transactions\"")))
                 .andExpect(content().string(containsString("COMMISSION_TRANSACTION:77")))
+                .andExpect(content().string(containsString("href=\"/arbitrage-checks\"")))
+                .andExpect(content().string(containsString("ARBITRAGE_CHECK:3")))
                 // 미처리 배너 건수 — 대시보드 KPI(countOpenException)와 같은 기준
                 .andExpect(content().string(containsString("건이 처리를 기다립니다")))
                 // 상태 select 는 OPEN 이 선택된 채로 돌아온다
                 .andExpect(content().string(containsString("<option value=\"OPEN\" selected=\"selected\">")));
 
         verify(mapper).findCases(List.of(NEW, IN_REVIEW));
+        verify(mapper).countByStatuses(List.of(NEW, IN_REVIEW));
     }
 
-    /** 대시보드 '미처리 예외' KPI 카드 링크(@{/exceptions(status='OPEN',month=...)}) 경로. */
+    /**
+     * FGC-FUN-057 인수조건 "항목 클릭 시 해당 목록으로 이동" —
+     * 대시보드 '미처리 예외' KPI 카드 링크(@{/exceptions(status='OPEN',month=...)}) 경로.
+     */
     @Test
     void 대시보드_카드가_보낸_OPEN과_month가_그대로_적용된다() throws Exception {
-        given(mapper.findCases(anyList())).willReturn(List.of(OPEN_ROW));
-        given(mapper.countByStatuses(anyList())).willReturn(1L);
+        given(mapper.findCases(List.of(NEW, IN_REVIEW))).willReturn(List.of(OPEN_ROW));
+        given(mapper.countByStatuses(List.of(NEW, IN_REVIEW))).willReturn(1L);
 
         mockMvc.perform(get("/exceptions").param("status", "OPEN").param("month", "2026-05")
                         .with(user(SETTLE)))
@@ -118,25 +130,29 @@ class ExceptionCaseViewControllerTest {
         verify(mapper).findCases(List.of(NEW, IN_REVIEW));
     }
 
+    /** FGC-FUN-053 상태값(RESOLVED 등 실제 코드) 필터 — 묶음 해석 없이 그 값 하나로만 조회한다. */
     @Test
     void 실제_상태코드_필터는_그_값_하나로만_조회된다() throws Exception {
         given(mapper.findCases(List.of(RESOLVED))).willReturn(List.of(RESOLVED_ROW));
-        given(mapper.countByStatuses(anyList())).willReturn(0L);
+        given(mapper.countByStatuses(List.of(NEW, IN_REVIEW))).willReturn(2L);
 
         mockMvc.perform(get("/exceptions").param("status", "RESOLVED").with(user(SETTLE)))
                 .andExpect(status().isOk())
                 .andExpect(model().attribute("statusFilter", "RESOLVED"))
+                // FGC-FUN-057 — 배너의 미처리 건수는 목록 필터와 무관하게 항상 KPI 와 같은 OPEN 기준
+                .andExpect(model().attribute("openCount", 2L))
                 .andExpect(content().string(containsString("필수값 누락")))
                 .andExpect(content().string(containsString("href=\"/contracts/5\"")))
                 .andExpect(content().string(containsString("<option value=\"RESOLVED\" selected=\"selected\">")));
 
         verify(mapper).findCases(List.of(RESOLVED));
+        verify(mapper).countByStatuses(List.of(NEW, IN_REVIEW));
     }
 
     @Test
     void 빈_상태값은_필터_없음_전체_조회다() throws Exception {
         given(mapper.findCases(List.of())).willReturn(List.of(OPEN_ROW, RESOLVED_ROW, UNKNOWN_SOURCE_ROW));
-        given(mapper.countByStatuses(anyList())).willReturn(1L);
+        given(mapper.countByStatuses(List.of(NEW, IN_REVIEW))).willReturn(1L);
 
         mockMvc.perform(get("/exceptions").param("status", "").with(user(SETTLE)))
                 .andExpect(status().isOk())
@@ -153,8 +169,8 @@ class ExceptionCaseViewControllerTest {
     void 공백만_있는_상태값은_전체가_아니라_미지원으로_보고_기본_OPEN으로_되돌린다() throws Exception {
         // 명시적 빈 문자열("전체")과 달리 공백은 select 가 만들 수 없는 오타성 입력이다 —
         // 조용히 전체 조회로 새지 않게 한다.
-        given(mapper.findCases(anyList())).willReturn(List.of());
-        given(mapper.countByStatuses(anyList())).willReturn(0L);
+        given(mapper.findCases(List.of(NEW, IN_REVIEW))).willReturn(List.of());
+        given(mapper.countByStatuses(List.of(NEW, IN_REVIEW))).willReturn(0L);
 
         mockMvc.perform(get("/exceptions").param("status", " ").with(user(SETTLE)))
                 .andExpect(status().isOk())
@@ -166,8 +182,8 @@ class ExceptionCaseViewControllerTest {
     @Test
     void 미지원_상태값은_400이_아니라_기본_OPEN으로_되돌린다() throws Exception {
         // ShellAdvice 의 month 와 같은 정책 — select 가 보내는 값이라 조용히 복구한다
-        given(mapper.findCases(anyList())).willReturn(List.of());
-        given(mapper.countByStatuses(anyList())).willReturn(0L);
+        given(mapper.findCases(List.of(NEW, IN_REVIEW))).willReturn(List.of());
+        given(mapper.countByStatuses(List.of(NEW, IN_REVIEW))).willReturn(0L);
 
         mockMvc.perform(get("/exceptions").param("status", "NOPE").with(user(SETTLE)))
                 .andExpect(status().isOk())

--- a/src/test/java/com/susukkang/fgc/exceptioncase/controller/ExceptionCaseViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/exceptioncase/controller/ExceptionCaseViewControllerTest.java
@@ -138,6 +138,20 @@ class ExceptionCaseViewControllerTest {
     }
 
     @Test
+    void 공백만_있는_상태값은_전체가_아니라_미지원으로_보고_기본_OPEN으로_되돌린다() throws Exception {
+        // 명시적 빈 문자열("전체")과 달리 공백은 select 가 만들 수 없는 오타성 입력이다 —
+        // 조용히 전체 조회로 새지 않게 한다.
+        given(mapper.findCases(anyList())).willReturn(List.of());
+        given(mapper.countByStatuses(anyList())).willReturn(0L);
+
+        mockMvc.perform(get("/exceptions").param("status", " ").with(user(SETTLE)))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("statusFilter", "OPEN"));
+
+        verify(mapper).findCases(List.of(NEW, IN_REVIEW));
+    }
+
+    @Test
     void 미지원_상태값은_400이_아니라_기본_OPEN으로_되돌린다() throws Exception {
         // ShellAdvice 의 month 와 같은 정책 — select 가 보내는 값이라 조용히 복구한다
         given(mapper.findCases(anyList())).willReturn(List.of());

--- a/src/test/java/com/susukkang/fgc/exceptioncase/mapper/ExceptionCaseQueryMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/exceptioncase/mapper/ExceptionCaseQueryMapperIntegrationTest.java
@@ -1,0 +1,84 @@
+package com.susukkang.fgc.exceptioncase.mapper;
+
+import com.susukkang.fgc.common.code.ExceptionStatus;
+import com.susukkang.fgc.dashboard.mapper.DashboardMapper;
+import com.susukkang.fgc.exceptioncase.dto.ExceptionCaseListRow;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * #83: EXCP-W01 예외함 목록 조회 — 화면 필터 3가지 경로(OPEN / 개별 상태값 / 필터 없음)가
+ * ExceptionStatus.dbStatuses() 로 풀려 실제 SQL 에서 맞게 걸리는지, 그리고 미처리 건수가
+ * 대시보드 KPI(DashboardMapper.countOpenException)와 같은 기준인지 지킨다.
+ */
+@SpringBootTest
+@Transactional
+class ExceptionCaseQueryMapperIntegrationTest {
+
+    @Autowired
+    private ExceptionCaseQueryMapper mapper;
+
+    @Autowired
+    private DashboardMapper dashboardMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private String suffix;
+
+    @BeforeEach
+    void insertFixtures() {
+        suffix = UUID.randomUUID().toString().substring(0, 8);
+        insertCase("NEW", "CRITICAL", "IT 신규-" + suffix);
+        insertCase("IN_REVIEW", "WARNING", "IT 검토중-" + suffix);
+        insertCase("RESOLVED", "INFO", "IT 해결-" + suffix);
+    }
+
+    private void insertCase(String status, String severity, String title) {
+        jdbcTemplate.update("""
+                INSERT INTO fgc.exception_case
+                       (exception_key, exception_type, severity, status,
+                        source_entity_type, source_entity_id, title)
+                VALUES (?, 'DATA_QUALITY', ?, ?, 'IT', ?, ?)
+                """, "IT:" + suffix + ":" + status, severity, status, suffix, title);
+    }
+
+    private List<String> myTitles(List<ExceptionCaseListRow> rows) {
+        return rows.stream().map(ExceptionCaseListRow::title)
+                .filter(t -> t.endsWith(suffix)).toList();
+    }
+
+    @Test
+    void OPEN_필터는_신규와_검토중만_조회한다() {
+        var rows = mapper.findCases(ExceptionStatus.dbStatuses("OPEN"));
+        assertThat(myTitles(rows)).containsExactlyInAnyOrder("IT 신규-" + suffix, "IT 검토중-" + suffix);
+    }
+
+    @Test
+    void 실제_상태코드_필터는_그_상태만_조회한다() {
+        var rows = mapper.findCases(ExceptionStatus.dbStatuses("RESOLVED"));
+        assertThat(myTitles(rows)).containsExactly("IT 해결-" + suffix);
+    }
+
+    @Test
+    void 필터_없음은_전체를_조회한다() {
+        var rows = mapper.findCases(ExceptionStatus.dbStatuses(""));
+        assertThat(myTitles(rows)).hasSize(3);
+    }
+
+    /** FUN-057: 대시보드 '미처리 예외' 카드 건수와 예외함 미처리 건수는 같은 기준이어야 한다. */
+    @Test
+    void 미처리_건수는_대시보드_KPI_집계와_일치한다() {
+        long screen = mapper.countByStatuses(ExceptionStatus.dbStatuses(ExceptionStatus.OPEN_FILTER));
+        assertThat(screen).isEqualTo(dashboardMapper.countOpenException());
+    }
+}

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -51,8 +51,10 @@ class PublishingTemplateStructureTest {
     void apiDeferredScreensExposeExplicitPendingStatesWithoutSeedData() throws IOException {
         assertThat(resource("templates/arbitrage/list.html"))
                 .contains("조회 API 연동 대기");
+        // EXCP-W01 은 #83 에서 안내 배너·상태 필터·목록이 서버 렌더링으로 바인딩됐다 —
+        // 아직 미연동인 유형별 요약카드만 대기 상태를 명시한다.
         assertThat(resource("templates/exception/list.html"))
-                .contains("예외 현황은 조회 API 연동 대기 중입니다.");
+                .contains("유형별 미처리 집계 API 연동 대기");
         assertThat(resource("templates/vrun/detail.html"))
                 .contains("진행률 API 연동 대기")
                 .contains("확정 조건 API 연동 대기")


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* 예외함(EXCP-W01)이 화면 묶음 필터 `status=OPEN`(미처리)을 서버 한 곳에서 `NEW + IN_REVIEW` 로 풀어서 조회합니다. `OPEN` 을 그대로 API/SQL 로 흘려보내지 않습니다.
* `/exceptions` 를 정적 라우트에서 도메인 뷰 컨트롤러로 이관하고 안내 배너·상태 필터·목록을 실데이터로 바인딩했습니다.

## 🔗 2. 관련 이슈

* Closes #83

## 🛠 3. 구현 내용

* **변환 한 곳 정의** — `common/code/ExceptionStatus`(신규): `OPEN → NEW, IN_REVIEW`, 빈 값 → 필터 없음(전체), 실제 코드값(`RESOLVED` 등) → 그대로 1개. 화면·API·매퍼에 흩뿌리지 않고 이 enum 의 `dbStatuses()` 만 씁니다.
* **EXCP-W01 이관** — `ExceptionCaseViewController`(신규)가 `GET /exceptions` 를 받아 변환 적용 후 `ExceptionCaseQueryMapper` 로 조회합니다. `ScreenViewController` 의 정적 라우트는 파일 주석의 이관 규칙대로 삭제했습니다.
* **기본값·오류 정책** — 파라미터가 없으면 워크큐 기본값 `OPEN`(목업과 동일). 미지원 상태값은 `ShellAdvice` 의 month 와 같은 정책으로 400 없이 기본 필터로 조용히 복구합니다. `@RequestParam(defaultValue=…)` 는 빈 문자열(`status=` → "전체")까지 덮어쓰므로 쓰지 않았습니다.
* **month** — 카드 링크가 보내는 `month` 는 예외 검색조건이 아니라 셸 기준월입니다(IF-API-43 파라미터에도 month 없음). `ShellAdvice` 가 세션에 반영하며, KPI 집계(`DashboardMapper.countOpenException`)에도 월 필터가 없어 카드 건수와 예외함 건수가 일치합니다.
* **대시보드 링크 유지** — 이슈 요청대로 링크는 바꾸지 않고(예외함 select 와 `OPEN` 어휘 공유) 안내 주석만 갱신했습니다(To-do 5번).
* **부분 바인딩 범위** — 유형별 요약카드·유형/심각도/담당자/계약번호 필터·처리 패널·처리 이력은 IF-API-43/44 전체 연동 몫으로 남기고, 미연동 필터는 CAP-W01 패턴대로 `disabled` + "연동 대기" 로 명시했습니다.

## 🧪 4. 테스트 방법

1. `./gradlew test --tests 'com.susukkang.fgc.exceptioncase.*'` — 컨트롤러 5경로(OPEN 기본값 / 카드 링크 OPEN+month / 개별 상태값 / 필터 없음 / 미지원 값 복구) + 실 DB 매퍼 통합 4건(3경로 + **미처리 건수 = 대시보드 KPI 집계 일치**).
2. 앱 실행(local 프로필) 후 `exception_case` 에 NEW·IN_REVIEW·RESOLVED 각 1건 삽입 → 대시보드 KPI '미처리 예외' **2건** 확인.
3. 카드 클릭(`/exceptions?status=OPEN&month=…`) → 목록 2건 + 배너 "미처리 2건" 으로 카드 건수와 일치. 상태 select 를 '해결'로 바꾸면 1건, '전체'면 3건.

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* `ExceptionStatus.dbStatuses()` 의 경로 구분(없음=OPEN 기본값 / 빈 값=전체 / 묶음값 / 실제 코드값)이 화면정의서 :305-308 상태표와 맞는지.
* `PublishingTemplateStructureTest` 의 EXCP 가드 문구를 "예외 현황은 조회 API 연동 대기 중입니다." → "유형별 미처리 집계 API 연동 대기" 로 바꾼 것이 적절한지(배너·목록이 실데이터로 바뀌어 기존 문구가 사라짐).

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* EXCP-W01: 안내 배너에 미처리 건수, 목록에 실데이터 렌더링. 상태 select 에 개별 상태 4개 옵션(신규/검토중/해결/오탐·반려) 추가 및 선택 상태 유지, 변경 시 즉시 조회. 미연동 필터(유형·심각도·담당자·계약번호)는 비활성 + "연동 대기" 표시.
* DASH-W01: 화면 변화 없음(주석만 갱신).

## 💬 9. 참고 사항

* 목록 페이징은 이번 범위에서 제외했습니다(시연 데이터 규모 전량 렌더링, 매퍼 XML 에 `ponytail:` 주석으로 표시). IF-API-43 전체 구현 때 추가합니다.
* 대시보드 '최근 예외' 행의 `/exceptions?contractNo=…` 링크(계약번호 필터)는 이 이슈 범위 밖으로, IF-API-43 전체 연동 때 함께 바인딩하면 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
- 예외함 화면이 실제 데이터와 연동되었습니다.
- 미처리(OPEN), 신규, 검토 중, 해결, 반려 상태로 예외를 필터링할 수 있습니다.
- 예외 목록에 유형, 심각도, 계약번호, 제목, 담당자, 생성 시각이 표시됩니다.
- 대시보드의 미처리 예외 건수와 목록 집계가 일치합니다.
- 유형·심각도·담당자·계약번호 필터는 추후 연동 예정으로 비활성화되었습니다.

## 버그 수정
- 잘못되거나 공백인 상태 필터 입력 시 미처리 목록으로 안전하게 복원됩니다.
- COMPLIANCE 권한 사용자의 로그아웃 동작을 보완했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->