### PR TITLE
[Feat] FUN-052 불일치 예외 자동 생성

### DIFF
--- a/src/main/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobConfig.java
+++ b/src/main/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobConfig.java
@@ -3,6 +3,7 @@ package com.susukkang.fgc.validation.batch;
 import com.susukkang.fgc.cap.dto.CapCalculationCommand;
 import com.susukkang.fgc.validation.batch.contract.ArbitrageCheckBatchPort;
 import com.susukkang.fgc.validation.batch.contract.CapCheckBatchPort;
+import com.susukkang.fgc.validation.batch.contract.ExceptionGenerationPort;
 import com.susukkang.fgc.validation.batch.contract.LedgerImbalanceCheckPort;
 import com.susukkang.fgc.validation.batch.tasklet.*;
 import com.susukkang.fgc.validation.service.*;
@@ -38,6 +39,7 @@ public class MonthlyValidationJobConfig {
     private final ArbitrageCheckBatchPort arbitrageCheckBatchPort;
     private final ValidationRunScheduleService validationRunScheduleService;
     private final CapCheckBatchPort capCheckBatchPort;
+    private final ExceptionGenerationPort exceptionGenerationPort;
     // #98: imbalanceCheckStep(⑥균형검사)이 쓴다. journalPostingStep(⑥기표)은 아직
     // JournalPostingPort 구현체가 없어 PlaceholderStepTasklet 그대로 둔다.
     private final LedgerImbalanceCheckPort ledgerImbalanceCheckPort;
@@ -157,7 +159,7 @@ public class MonthlyValidationJobConfig {
     @Bean
     public Step exceptionGenerationStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
         return new StepBuilder("exceptionGenerationStep", jobRepository)
-                .tasklet(new PlaceholderStepTasklet("⑧예외 생성"), transactionManager)
+                .tasklet(new ExceptionGenerationTasklet(exceptionGenerationPort), transactionManager)
                 .listener(progressListener(8, false))
                 .build();
     }

--- a/src/main/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobConfig.java
+++ b/src/main/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobConfig.java
@@ -155,7 +155,6 @@ public class MonthlyValidationJobConfig {
                 .listener(progressListener(7, false))
                 .build();
     }
-    // TODO FUN-052 예소
     @Bean
     public Step exceptionGenerationStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
         return new StepBuilder("exceptionGenerationStep", jobRepository)

--- a/src/main/java/com/susukkang/fgc/validation/batch/contract/ValidationStepContext.java
+++ b/src/main/java/com/susukkang/fgc/validation/batch/contract/ValidationStepContext.java
@@ -3,7 +3,10 @@ package com.susukkang.fgc.validation.batch.contract;
 import java.util.Objects;
 
 /** validation_run 생성 이후 Step 2~8이 공통으로 받는 실행 컨텍스트다. */
-public record ValidationStepContext(Long validationRunId, ValidationJobContext job) {
+public record ValidationStepContext(
+        Long validationRunId,
+        ValidationJobContext job
+    ) {
     public ValidationStepContext {
         if (validationRunId == null || validationRunId <= 0) {
             throw new IllegalArgumentException("validationRunId는 1 이상이어야 합니다.");

--- a/src/main/java/com/susukkang/fgc/validation/batch/tasklet/ArbitrageCheckTasklet.java
+++ b/src/main/java/com/susukkang/fgc/validation/batch/tasklet/ArbitrageCheckTasklet.java
@@ -25,8 +25,14 @@ public class ArbitrageCheckTasklet implements Tasklet {
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
         Long validationRunId = ValidationRunBatchContext.getValidationRunId(chunkContext);
-        MonthlyValidationJobParameters parameters = MonthlyValidationJobParameters.from(
-                chunkContext.getStepContext().getStepExecution().getJobParameters());
+        MonthlyValidationJobParameters parameters =
+                MonthlyValidationJobParameters.
+                        from(
+                                chunkContext
+                                        .getStepContext()
+                                        .getStepExecution()
+                                        .getJobParameters()
+                        );
         ValidationJobContext jobContext = new ValidationJobContext(
                 parameters.validationMonth(),
                 parameters.runNo(),

--- a/src/main/java/com/susukkang/fgc/validation/batch/tasklet/ExceptionGenerationTasklet.java
+++ b/src/main/java/com/susukkang/fgc/validation/batch/tasklet/ExceptionGenerationTasklet.java
@@ -1,0 +1,28 @@
+package com.susukkang.fgc.validation.batch.tasklet;
+
+import com.susukkang.fgc.validation.batch.contract.ExceptionGenerationPort;
+import com.susukkang.fgc.validation.service.ValidationRunExceptionServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+/**
+ * 설명 : ExceptionGenerationTasklet
+ *
+ * @author hjKang
+ * @version 1.0
+ * @since 2026-08-14
+ */
+@RequiredArgsConstructor
+public class ExceptionGenerationTasklet implements Tasklet {
+    private final ExceptionGenerationPort exceptionGenerationPort;
+    @Override
+    public @Nullable RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+
+
+        return null;
+    }
+}

--- a/src/main/java/com/susukkang/fgc/validation/batch/tasklet/ExceptionGenerationTasklet.java
+++ b/src/main/java/com/susukkang/fgc/validation/batch/tasklet/ExceptionGenerationTasklet.java
@@ -1,13 +1,17 @@
 package com.susukkang.fgc.validation.batch.tasklet;
 
+import com.susukkang.fgc.validation.batch.ValidationRunBatchContext;
 import com.susukkang.fgc.validation.batch.contract.ExceptionGenerationPort;
-import com.susukkang.fgc.validation.service.ValidationRunExceptionServiceImpl;
+import com.susukkang.fgc.validation.batch.contract.StepProcessingResult;
+import com.susukkang.fgc.validation.batch.contract.ValidationJobContext;
+import com.susukkang.fgc.validation.batch.contract.ValidationStepContext;
+import com.susukkang.fgc.validation.dto.MonthlyValidationJobParameters;
 import lombok.RequiredArgsConstructor;
-import org.jspecify.annotations.Nullable;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.lang.NonNull;
 
 /**
  * 설명 : ExceptionGenerationTasklet
@@ -20,9 +24,33 @@ import org.springframework.batch.repeat.RepeatStatus;
 public class ExceptionGenerationTasklet implements Tasklet {
     private final ExceptionGenerationPort exceptionGenerationPort;
     @Override
-    public @Nullable RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+    public RepeatStatus execute(@NonNull StepContribution contribution, @NonNull ChunkContext chunkContext) {
+        Long validationRunId =
+                ValidationRunBatchContext.getValidationRunId(chunkContext);
 
+        MonthlyValidationJobParameters parameters =
+                MonthlyValidationJobParameters.from(
+                        chunkContext.getStepContext()
+                                .getStepExecution()
+                                .getJobParameters()
+                );
 
-        return null;
+        ValidationJobContext jobContext = new ValidationJobContext(
+                parameters.validationMonth(),
+                parameters.runNo(),
+                parameters.runType(),
+                parameters.triggeredBy(),
+                parameters.requestId()
+        );
+
+        ValidationStepContext stepContext =
+                new ValidationStepContext(validationRunId, jobContext);
+
+        StepProcessingResult result =
+                exceptionGenerationPort.generate(stepContext);
+
+        contribution.incrementWriteCount(result.processedCount());
+
+        return RepeatStatus.FINISHED;
     }
 }

--- a/src/main/java/com/susukkang/fgc/validation/mapper/ExceptionCaseMapper.java
+++ b/src/main/java/com/susukkang/fgc/validation/mapper/ExceptionCaseMapper.java
@@ -45,4 +45,19 @@ public interface ExceptionCaseMapper {
             @Param("paymentStage") String paymentStage,
             @Param("title") String title,
             @Param("description") String description);
+
+    /**
+     * 설명 : 예외건 처리를 위해 만든 메서드들
+     *
+     * @param  validationRunId 배치 실행 ID
+     * @return 처리된 건수
+     * @author hjKang
+     * @since 2026-08-15
+     */
+    // Cap 1200%관련
+    long insertFromCapChecks(@Param("validationRunId") Long validationRunId);
+    // 차익거래 관련
+    long insertFromArbitrageChecks(@Param("validationRunId") Long validationRunId);
+    // 대사 일치 관련
+    long insertFromReconciliationResults(@Param("validationRunId") Long validationRunId);
 }

--- a/src/main/java/com/susukkang/fgc/validation/mapper/ExceptionCaseMapper.java
+++ b/src/main/java/com/susukkang/fgc/validation/mapper/ExceptionCaseMapper.java
@@ -60,4 +60,6 @@ public interface ExceptionCaseMapper {
     long insertFromArbitrageChecks(@Param("validationRunId") Long validationRunId);
     // 대사 일치 관련
     long insertFromReconciliationResults(@Param("validationRunId") Long validationRunId);
+    // 검증원장 차변·대변 불균형 관련
+    long insertFromJournalImbalances(@Param("validationRunId") Long validationRunId);
 }

--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationRunExceptionServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationRunExceptionServiceImpl.java
@@ -1,0 +1,26 @@
+package com.susukkang.fgc.validation.service;
+
+import com.susukkang.fgc.validation.batch.contract.ExceptionGenerationPort;
+import com.susukkang.fgc.validation.batch.contract.StepProcessingResult;
+import com.susukkang.fgc.validation.batch.contract.ValidationStepContext;
+import com.susukkang.fgc.validation.mapper.ExceptionCaseMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 설명 : ValidationRunExceptionServiceImpl
+ *
+ * @author hjKang
+ * @version 1.0
+ * @since 2026-08-14
+ */
+@Service
+@RequiredArgsConstructor
+public class ValidationRunExceptionServiceImpl implements ExceptionGenerationPort {
+    private final ExceptionCaseMapper exceptionMapper;
+    @Override
+    public StepProcessingResult generate(ValidationStepContext context) {
+
+        return null;
+    }
+}

--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationRunExceptionServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationRunExceptionServiceImpl.java
@@ -6,6 +6,8 @@ import com.susukkang.fgc.validation.batch.contract.ValidationStepContext;
 import com.susukkang.fgc.validation.mapper.ExceptionCaseMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 
 /**
  * 설명 : ValidationRunExceptionServiceImpl
@@ -19,8 +21,15 @@ import org.springframework.stereotype.Service;
 public class ValidationRunExceptionServiceImpl implements ExceptionGenerationPort {
     private final ExceptionCaseMapper exceptionMapper;
     @Override
+    @Transactional
     public StepProcessingResult generate(ValidationStepContext context) {
+        Long validationRunId = context.validationRunId();
 
-        return null;
+        long createdCount = 0;
+        createdCount += exceptionMapper.insertFromCapChecks(validationRunId);
+        createdCount += exceptionMapper.insertFromArbitrageChecks(validationRunId);
+        createdCount += exceptionMapper.insertFromReconciliationResults(validationRunId);
+
+        return StepProcessingResult.success(createdCount);
     }
 }

--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationRunExceptionServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationRunExceptionServiceImpl.java
@@ -29,6 +29,7 @@ public class ValidationRunExceptionServiceImpl implements ExceptionGenerationPor
         createdCount += exceptionMapper.insertFromCapChecks(validationRunId);
         createdCount += exceptionMapper.insertFromArbitrageChecks(validationRunId);
         createdCount += exceptionMapper.insertFromReconciliationResults(validationRunId);
+        createdCount += exceptionMapper.insertFromJournalImbalances(validationRunId);
 
         return StepProcessingResult.success(createdCount);
     }

--- a/src/main/resources/mapper/validation/ExceptionCaseMapper.xml
+++ b/src/main/resources/mapper/validation/ExceptionCaseMapper.xml
@@ -48,7 +48,6 @@
         ON CONFLICT ON CONSTRAINT uq_exception_key DO NOTHING
     </insert>
 
-    <!-- 위 TODO와 동일한 키 정책을 적용한다. -->
     <insert id="insertArbitrageReviewCase">
         INSERT INTO fgc.exception_case
             (exception_key, exception_type, severity, status,
@@ -63,4 +62,168 @@
         ON CONFLICT ON CONSTRAINT uq_exception_key DO NOTHING
     </insert>
 
+    <insert id="insertFromCapChecks">
+        INSERT INTO fgc.exception_case (
+            exception_key,
+            exception_type,
+            severity,
+            status,
+            validation_run_id,
+            contract_id,
+            source_entity_type,
+            source_entity_id,
+            title,
+            description
+        )
+        SELECT
+            CONCAT(
+                    CASE cc.result_status
+                        WHEN 'VIOLATION' THEN 'CAP_VIOLATION'
+                        WHEN 'REVIEW_REQUIRED' THEN 'CAP_REVIEW_REQUIRED'
+                        END,
+                    ':',
+                    cc.validation_run_id,
+                    ':cap_check:',
+                    cc.cap_check_id,
+                    ':',
+                    cc.payment_stage
+            ),
+            CASE cc.result_status
+                WHEN 'VIOLATION' THEN 'CAP_VIOLATION'
+                WHEN 'REVIEW_REQUIRED' THEN 'CAP_REVIEW_REQUIRED'
+                END,
+            CASE cc.result_status
+                WHEN 'VIOLATION' THEN 'CRITICAL'
+                WHEN 'REVIEW_REQUIRED' THEN 'WARNING'
+                END,
+            'NEW',
+            cc.validation_run_id,
+            cc.contract_id,
+            'CAP_CHECK',
+            CAST(cc.cap_check_id AS varchar),
+            CASE cc.result_status
+                WHEN 'VIOLATION' THEN '1,200% 한도 초과'
+                WHEN 'REVIEW_REQUIRED' THEN '1,200% 한도 검토 필요'
+                END,
+            CONCAT(
+                    '지급단계=', cc.payment_stage,
+                    ', 한도액=', cc.limit_amount,
+                    ', 산입액=', cc.included_amount,
+                    ', 사용률=', COALESCE(CAST(cc.usage_pct AS varchar), '-')
+            )
+        FROM
+            fgc.cap_check cc
+        WHERE
+            cc.validation_run_id = #{validationRunId}
+        AND
+            cc.result_status IN ('VIOLATION', 'REVIEW_REQUIRED')
+        ON CONFLICT ON CONSTRAINT uq_exception_key DO NOTHING
+    </insert>
+
+    <insert id="insertFromArbitrageChecks">
+        INSERT INTO fgc.exception_case (
+            exception_key, exception_type, severity, status,
+            validation_run_id, contract_id, source_entity_type, source_entity_id,
+            title, description
+        )
+        SELECT
+            CONCAT(
+                CASE
+                    WHEN ac.result_status = 'CANDIDATE' THEN 'ARBITRAGE_CANDIDATE'
+                    WHEN COALESCE(ac.calculation_snapshot ->> 'decisionReason', '')
+                            LIKE '%환급률표 후보가 없습니다%'
+                      OR COALESCE(ac.calculation_snapshot ->> 'decisionReason', '')
+                            LIKE '%환급률표 ID가 없습니다%'
+                        THEN 'REFUND_TABLE_MISSING'
+                    WHEN COALESCE(ac.calculation_snapshot ->> 'decisionReason', '')
+                            LIKE '%상품코드%'
+                      OR COALESCE(ac.calculation_snapshot ->> 'decisionReason', '')
+                            LIKE '%환급률표가 일치하지 않습니다%'
+                        THEN 'PRODUCT_CODE_MISMATCH'
+                    WHEN COALESCE(ac.calculation_snapshot ->> 'decisionReason', '')
+                            LIKE '%여러 건%'
+                        THEN 'POLICY_DUPLICATE'
+                    ELSE 'DATA_QUALITY'
+                END,
+                ':', ac.validation_run_id,
+                ':ARBITRAGE_CHECK:', ac.arbitrage_check_id,
+                ':', ac.payment_stage
+            ),
+            CASE
+                WHEN ac.result_status = 'CANDIDATE' THEN 'ARBITRAGE_CANDIDATE'
+                WHEN COALESCE(ac.calculation_snapshot ->> 'decisionReason', '')
+                        LIKE '%환급률표 후보가 없습니다%'
+                  OR COALESCE(ac.calculation_snapshot ->> 'decisionReason', '')
+                        LIKE '%환급률표 ID가 없습니다%'
+                    THEN 'REFUND_TABLE_MISSING'
+                WHEN COALESCE(ac.calculation_snapshot ->> 'decisionReason', '')
+                        LIKE '%상품코드%'
+                  OR COALESCE(ac.calculation_snapshot ->> 'decisionReason', '')
+                        LIKE '%환급률표가 일치하지 않습니다%'
+                    THEN 'PRODUCT_CODE_MISMATCH'
+                WHEN COALESCE(ac.calculation_snapshot ->> 'decisionReason', '')
+                        LIKE '%여러 건%'
+                    THEN 'POLICY_DUPLICATE'
+                ELSE 'DATA_QUALITY'
+            END,
+            CASE ac.result_status
+                WHEN 'CANDIDATE' THEN 'HIGH'
+                WHEN 'REVIEW_REQUIRED' THEN 'WARNING'
+            END,
+            'NEW',
+            ac.validation_run_id,
+            ac.contract_id,
+            'ARBITRAGE_CHECK',
+            CAST(ac.arbitrage_check_id AS varchar),
+            CASE ac.result_status
+                WHEN 'CANDIDATE' THEN '차익거래 검토대상'
+                WHEN 'REVIEW_REQUIRED' THEN '차익거래 검증 자료 확인 필요'
+            END,
+            COALESCE(
+                ac.calculation_snapshot ->> 'decisionReason',
+                CONCAT('지급단계=', ac.payment_stage, ', 순차액=', ac.net_difference_amount)
+            )
+        FROM fgc.arbitrage_check ac
+        WHERE ac.validation_run_id = #{validationRunId}
+          AND ac.result_status IN ('CANDIDATE', 'REVIEW_REQUIRED')
+        ON CONFLICT ON CONSTRAINT uq_exception_key DO NOTHING
+    </insert>
+
+    <insert id="insertFromReconciliationResults">
+        INSERT INTO fgc.exception_case (
+            exception_key, exception_type, severity, status,
+            validation_run_id, contract_id, source_entity_type, source_entity_id,
+            title, description
+        )
+        SELECT
+            CONCAT(
+                'RECONCILIATION_MISMATCH:', rrn.validation_run_id,
+                ':reconciliation_result:', rr.reconciliation_result_id
+            ),
+            'RECONCILIATION_MISMATCH',
+            CASE rr.result_type
+                WHEN 'REVIEW_REQUIRED' THEN 'WARNING'
+                ELSE 'HIGH'
+            END,
+            'NEW',
+            rrn.validation_run_id,
+            rr.contract_id,
+            'RECONCILIATION_RESULT',
+            CAST(rr.reconciliation_result_id AS varchar),
+            '대사 불일치',
+            CONCAT(
+                '지급단계=', rrn.payment_stage,
+                ', 결과유형=', rr.result_type,
+                ', 예상금액=', rr.expected_total_amount,
+                ', 실제금액=', rr.actual_total_amount,
+                ', 차액=', rr.difference_amount,
+                ', 주원인=', COALESCE(rr.primary_reason_code, '-')
+            )
+        FROM fgc.reconciliation_result rr
+        INNER JOIN fgc.reconciliation_run rrn
+            ON rrn.reconciliation_run_id = rr.reconciliation_run_id
+        WHERE rrn.validation_run_id = #{validationRunId}
+          AND rr.result_type &lt;&gt; 'MATCHED'
+        ON CONFLICT ON CONSTRAINT uq_exception_key DO NOTHING
+    </insert>
 </mapper>

--- a/src/main/resources/mapper/validation/ExceptionCaseMapper.xml
+++ b/src/main/resources/mapper/validation/ExceptionCaseMapper.xml
@@ -83,7 +83,7 @@
                         END,
                     ':',
                     cc.validation_run_id,
-                    ':cap_check:',
+                    ':CAP_CHECK:',
                     cc.cap_check_id,
                     ':',
                     cc.payment_stage
@@ -198,7 +198,7 @@
         SELECT
             CONCAT(
                 'RECONCILIATION_MISMATCH:', rrn.validation_run_id,
-                ':reconciliation_result:', rr.reconciliation_result_id
+                ':RECONCILIATION_RESULT:', rr.reconciliation_result_id
             ),
             'RECONCILIATION_MISMATCH',
             CASE rr.result_type
@@ -224,6 +224,38 @@
             ON rrn.reconciliation_run_id = rr.reconciliation_run_id
         WHERE rrn.validation_run_id = #{validationRunId}
           AND rr.result_type &lt;&gt; 'MATCHED'
+        ON CONFLICT ON CONSTRAINT uq_exception_key DO NOTHING
+    </insert>
+
+    <insert id="insertFromJournalImbalances">
+        INSERT INTO fgc.exception_case (
+            exception_key, exception_type, severity, status,
+            validation_run_id, contract_id, source_entity_type, source_entity_id,
+            title, description
+        )
+        SELECT
+            CONCAT(
+                'JOURNAL_IMBALANCE:', h.validation_run_id,
+                ':JOURNAL_HEADER:', vw.journal_header_id
+            ),
+            'JOURNAL_IMBALANCE',
+            'CRITICAL',
+            'NEW',
+            h.validation_run_id,
+            h.contract_id,
+            'JOURNAL_HEADER',
+            CAST(vw.journal_header_id AS varchar),
+            '검증원장 차변·대변 불균형',
+            CONCAT(
+                '분개번호=', vw.journal_no,
+                ', 차변합계=', vw.debit_total,
+                ', 대변합계=', vw.credit_total,
+                ', 차액=', vw.difference_amount
+            )
+        FROM fgc.vw_journal_imbalance vw
+        INNER JOIN fgc.journal_header h
+            ON h.journal_header_id = vw.journal_header_id
+        WHERE h.validation_run_id = #{validationRunId}
         ON CONFLICT ON CONSTRAINT uq_exception_key DO NOTHING
     </insert>
 </mapper>

--- a/src/test/java/com/susukkang/fgc/validation/batch/tasklet/ExceptionGenerationTaskletTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/batch/tasklet/ExceptionGenerationTaskletTest.java
@@ -1,0 +1,72 @@
+package com.susukkang.fgc.validation.batch.tasklet;
+
+import com.susukkang.fgc.validation.batch.ValidationRunBatchContext;
+import com.susukkang.fgc.validation.batch.contract.ExceptionGenerationPort;
+import com.susukkang.fgc.validation.batch.contract.StepProcessingResult;
+import com.susukkang.fgc.validation.batch.contract.ValidationStepContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.repeat.RepeatStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ExceptionGenerationTaskletTest {
+
+    @Mock
+    private ExceptionGenerationPort exceptionGenerationPort;
+
+    @Test
+    void delegatesValidationContextAndRecordsCreatedCount() {
+        TestContext testContext = context(118L);
+        given(exceptionGenerationPort.generate(any(ValidationStepContext.class)))
+                .willReturn(StepProcessingResult.success(7));
+
+        RepeatStatus status = new ExceptionGenerationTasklet(exceptionGenerationPort)
+                .execute(testContext.contribution(), testContext.chunkContext());
+
+        ArgumentCaptor<ValidationStepContext> captor =
+                ArgumentCaptor.forClass(ValidationStepContext.class);
+        verify(exceptionGenerationPort).generate(captor.capture());
+
+        ValidationStepContext actual = captor.getValue();
+        assertThat(actual.validationRunId()).isEqualTo(118L);
+        assertThat(actual.job().validationMonth()).isEqualTo(java.time.LocalDate.of(2026, 8, 1));
+        assertThat(actual.job().runNo()).isEqualTo(1L);
+        assertThat(actual.job().requestId()).isEqualTo("req-exception-tasklet");
+        assertThat(status).isEqualTo(RepeatStatus.FINISHED);
+        assertThat(testContext.contribution().getWriteCount()).isEqualTo(7L);
+    }
+
+    private TestContext context(Long validationRunId) {
+        JobExecution jobExecution = new JobExecution(
+                new JobInstance(1L, "MonthlyValidationJob"),
+                new JobParametersBuilder()
+                        .addString("validationMonth", "2026-08")
+                        .addLong("runNo", 1L)
+                        .addString("runType", "MONTHLY")
+                        .addLong("triggeredBy", 1L)
+                        .addString("requestId", "req-exception-tasklet")
+                        .toJobParameters());
+        StepExecution stepExecution = new StepExecution("exceptionGenerationStep", jobExecution);
+        ChunkContext chunkContext = new ChunkContext(new StepContext(stepExecution));
+        ValidationRunBatchContext.putValidationRunId(chunkContext, validationRunId);
+        return new TestContext(chunkContext, new StepContribution(stepExecution));
+    }
+
+    private record TestContext(ChunkContext chunkContext, StepContribution contribution) {
+    }
+}

--- a/src/test/java/com/susukkang/fgc/validation/mapper/ExceptionGenerationMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/mapper/ExceptionGenerationMapperIntegrationTest.java
@@ -1,0 +1,207 @@
+package com.susukkang.fgc.validation.mapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class ExceptionGenerationMapperIntegrationTest {
+
+    private static final LocalDate TEST_MONTH = LocalDate.of(2099, 8, 1);
+
+    @Autowired
+    private ExceptionCaseMapper exceptionCaseMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void createsCapArbitrageAndReconciliationExceptionsIdempotently() {
+        List<Long> contractIds = jdbcTemplate.queryForList("""
+                SELECT contract_id
+                  FROM fgc.insurance_contract
+                 ORDER BY contract_id
+                 LIMIT 3
+                """, Long.class);
+        assertThat(contractIds).hasSizeGreaterThanOrEqualTo(3);
+
+        Long validationRunId = insertValidationRun();
+        insertCapChecks(validationRunId, contractIds);
+        insertArbitrageChecks(validationRunId, contractIds.get(0));
+        insertReconciliationResults(validationRunId, contractIds.get(0));
+
+        long capCreated = exceptionCaseMapper.insertFromCapChecks(validationRunId);
+        long arbitrageCreated = exceptionCaseMapper.insertFromArbitrageChecks(validationRunId);
+        long reconciliationCreated =
+                exceptionCaseMapper.insertFromReconciliationResults(validationRunId);
+
+        assertThat(capCreated).isEqualTo(2L);
+        assertThat(arbitrageCreated).isEqualTo(3L);
+        assertThat(reconciliationCreated).isEqualTo(2L);
+
+        List<Map<String, Object>> exceptions = jdbcTemplate.queryForList("""
+                SELECT exception_type, severity, source_entity_type
+                  FROM fgc.exception_case
+                 WHERE validation_run_id = ?
+                 ORDER BY exception_type
+                """, validationRunId);
+
+        assertThat(exceptions).hasSize(7);
+        assertThat(exceptions).extracting(row -> row.get("exception_type"))
+                .containsExactlyInAnyOrder(
+                        "CAP_VIOLATION",
+                        "CAP_REVIEW_REQUIRED",
+                        "ARBITRAGE_CANDIDATE",
+                        "REFUND_TABLE_MISSING",
+                        "PRODUCT_CODE_MISMATCH",
+                        "RECONCILIATION_MISMATCH",
+                        "RECONCILIATION_MISMATCH");
+        assertThat(exceptions)
+                .anySatisfy(row -> {
+                    assertThat(row.get("exception_type")).isEqualTo("CAP_VIOLATION");
+                    assertThat(row.get("severity")).isEqualTo("CRITICAL");
+                    assertThat(row.get("source_entity_type")).isEqualTo("CAP_CHECK");
+                });
+
+        assertThat(exceptionCaseMapper.insertFromCapChecks(validationRunId)).isZero();
+        assertThat(exceptionCaseMapper.insertFromArbitrageChecks(validationRunId)).isZero();
+        assertThat(exceptionCaseMapper.insertFromReconciliationResults(validationRunId)).isZero();
+
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM fgc.exception_case WHERE validation_run_id = ?",
+                Integer.class,
+                validationRunId);
+        assertThat(count).isEqualTo(7);
+    }
+
+    private Long insertValidationRun() {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.validation_run (validation_month, run_no, run_type, status)
+                SELECT ?, COALESCE(MAX(run_no), 0) + 1, 'MONTHLY', 'CREATED'
+                  FROM fgc.validation_run
+                 WHERE validation_month = ?
+                RETURNING validation_run_id
+                """, Long.class, TEST_MONTH, TEST_MONTH);
+    }
+
+    private void insertCapChecks(Long validationRunId, List<Long> contractIds) {
+        Long capRuleSetId = jdbcTemplate.queryForObject(
+                "SELECT cap_rule_set_id FROM fgc.cap_rule_set ORDER BY cap_rule_set_id LIMIT 1",
+                Long.class);
+
+        insertCapCheck(validationRunId, contractIds.get(0), capRuleSetId,
+                "INSURER_TO_GA", "VIOLATION", 130.0);
+        insertCapCheck(validationRunId, contractIds.get(1), capRuleSetId,
+                "GA_TO_FC", "REVIEW_REQUIRED", null);
+        insertCapCheck(validationRunId, contractIds.get(2), capRuleSetId,
+                "GA_TO_FC", "NORMAL", 50.0);
+    }
+
+    private void insertCapCheck(
+            Long validationRunId,
+            Long contractId,
+            Long capRuleSetId,
+            String paymentStage,
+            String resultStatus,
+            Double usagePct) {
+        jdbcTemplate.update("""
+                INSERT INTO fgc.cap_check (
+                    validation_run_id, contract_id, payment_stage, cap_rule_set_id,
+                    check_kind, as_of_date, base_premium_amount, refund_12m_amount,
+                    compliance_deduction_amount, limit_amount, included_amount,
+                    remaining_amount, usage_pct, result_status, calculation_snapshot
+                ) VALUES (?, ?, ?, ?, 'MONTHLY', ?, 100000, 0, 0,
+                          1200000, 1300000, -100000, ?, ?, '{}'::jsonb)
+                """, validationRunId, contractId, paymentStage, capRuleSetId,
+                TEST_MONTH, usagePct, resultStatus);
+    }
+
+    private void insertArbitrageChecks(Long validationRunId, Long contractId) {
+        insertArbitrageCheck(validationRunId, contractId, TEST_MONTH,
+                "CANDIDATE", "차익거래 후보입니다");
+        insertArbitrageCheck(validationRunId, contractId, TEST_MONTH.plusDays(1),
+                "REVIEW_REQUIRED", "환급률표 후보가 없습니다");
+        insertArbitrageCheck(validationRunId, contractId, TEST_MONTH.plusDays(2),
+                "REVIEW_REQUIRED", "상품코드와 환급률표가 일치하지 않습니다");
+        insertArbitrageCheck(validationRunId, contractId, TEST_MONTH.plusDays(3),
+                "CLEAR", "이상 없음");
+    }
+
+    private void insertArbitrageCheck(
+            Long validationRunId,
+            Long contractId,
+            LocalDate asOfDate,
+            String resultStatus,
+            String reason) {
+        jdbcTemplate.update("""
+                INSERT INTO fgc.arbitrage_check (
+                    validation_run_id, contract_id, payment_stage, as_of_date,
+                    contract_month_no, cumulative_paid_premium,
+                    paid_commission_amount, planned_commission_amount,
+                    included_surrender_value_amount, refund_addition_applied_yn,
+                    surrender_value_source_type, net_difference_amount,
+                    standard_deduction_80_yn, result_status, calculation_snapshot
+                ) VALUES (?, ?, 'GA_TO_FC', ?, 40, 1000000,
+                          600000, 500000, 0, false,
+                          'NOT_APPLICABLE', 100000, false, ?,
+                          jsonb_build_object('decisionReason', ?))
+                """, validationRunId, contractId, asOfDate, resultStatus, reason);
+    }
+
+    private void insertReconciliationResults(Long validationRunId, Long contractId) {
+        Long reconciliationRunId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.reconciliation_run (
+                    validation_run_id, settlement_month, payment_stage, status
+                ) VALUES (?, ?, 'GA_TO_FC', 'CREATED')
+                RETURNING reconciliation_run_id
+                """, Long.class, validationRunId, TEST_MONTH);
+
+        jdbcTemplate.update("""
+                UPDATE fgc.reconciliation_run
+                   SET status = 'RUNNING',
+                       started_at = clock_timestamp()
+                 WHERE reconciliation_run_id = ?
+                """, reconciliationRunId);
+
+        jdbcTemplate.update("""
+                UPDATE fgc.reconciliation_run
+                   SET status = 'COMPLETED',
+                       completed_at = clock_timestamp()
+                 WHERE reconciliation_run_id = ?
+                """, reconciliationRunId);
+
+        insertReconciliationResult(reconciliationRunId, contractId,
+                "match-amount", "AMOUNT_DIFFERENCE", 100000, 90000);
+        insertReconciliationResult(reconciliationRunId, contractId,
+                "match-review", "REVIEW_REQUIRED", 100000, 0);
+        insertReconciliationResult(reconciliationRunId, contractId,
+                "match-normal", "MATCHED", 100000, 100000);
+    }
+
+    private void insertReconciliationResult(
+            Long reconciliationRunId,
+            Long contractId,
+            String matchGroupKey,
+            String resultType,
+            long expectedAmount,
+            long actualAmount) {
+        jdbcTemplate.update("""
+                INSERT INTO fgc.reconciliation_result (
+                    reconciliation_run_id, match_group_key, contract_id,
+                    result_type, expected_total_amount, actual_total_amount,
+                    difference_amount, primary_reason_code
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """, reconciliationRunId, matchGroupKey, contractId,
+                resultType, expectedAmount, actualAmount,
+                expectedAmount - actualAmount, resultType);
+    }
+}

--- a/src/test/java/com/susukkang/fgc/validation/mapper/ExceptionGenerationMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/mapper/ExceptionGenerationMapperIntegrationTest.java
@@ -25,7 +25,7 @@ class ExceptionGenerationMapperIntegrationTest {
     private JdbcTemplate jdbcTemplate;
 
     @Test
-    void createsCapArbitrageAndReconciliationExceptionsIdempotently() {
+    void createsAllValidationExceptionsIdempotently() {
         List<Long> contractIds = jdbcTemplate.queryForList("""
                 SELECT contract_id
                   FROM fgc.insurance_contract
@@ -38,15 +38,18 @@ class ExceptionGenerationMapperIntegrationTest {
         insertCapChecks(validationRunId, contractIds);
         insertArbitrageChecks(validationRunId, contractIds.get(0));
         insertReconciliationResults(validationRunId, contractIds.get(0));
+        insertJournalImbalance(validationRunId, contractIds.get(0));
 
         long capCreated = exceptionCaseMapper.insertFromCapChecks(validationRunId);
         long arbitrageCreated = exceptionCaseMapper.insertFromArbitrageChecks(validationRunId);
         long reconciliationCreated =
                 exceptionCaseMapper.insertFromReconciliationResults(validationRunId);
+        long journalCreated = exceptionCaseMapper.insertFromJournalImbalances(validationRunId);
 
         assertThat(capCreated).isEqualTo(2L);
         assertThat(arbitrageCreated).isEqualTo(3L);
         assertThat(reconciliationCreated).isEqualTo(2L);
+        assertThat(journalCreated).isEqualTo(1L);
 
         List<Map<String, Object>> exceptions = jdbcTemplate.queryForList("""
                 SELECT exception_type, severity, source_entity_type
@@ -55,7 +58,7 @@ class ExceptionGenerationMapperIntegrationTest {
                  ORDER BY exception_type
                 """, validationRunId);
 
-        assertThat(exceptions).hasSize(7);
+        assertThat(exceptions).hasSize(8);
         assertThat(exceptions).extracting(row -> row.get("exception_type"))
                 .containsExactlyInAnyOrder(
                         "CAP_VIOLATION",
@@ -63,6 +66,7 @@ class ExceptionGenerationMapperIntegrationTest {
                         "ARBITRAGE_CANDIDATE",
                         "REFUND_TABLE_MISSING",
                         "PRODUCT_CODE_MISMATCH",
+                        "JOURNAL_IMBALANCE",
                         "RECONCILIATION_MISMATCH",
                         "RECONCILIATION_MISMATCH");
         assertThat(exceptions)
@@ -75,12 +79,13 @@ class ExceptionGenerationMapperIntegrationTest {
         assertThat(exceptionCaseMapper.insertFromCapChecks(validationRunId)).isZero();
         assertThat(exceptionCaseMapper.insertFromArbitrageChecks(validationRunId)).isZero();
         assertThat(exceptionCaseMapper.insertFromReconciliationResults(validationRunId)).isZero();
+        assertThat(exceptionCaseMapper.insertFromJournalImbalances(validationRunId)).isZero();
 
         Integer count = jdbcTemplate.queryForObject(
                 "SELECT COUNT(*) FROM fgc.exception_case WHERE validation_run_id = ?",
                 Integer.class,
                 validationRunId);
-        assertThat(count).isEqualTo(7);
+        assertThat(count).isEqualTo(8);
     }
 
     private Long insertValidationRun() {
@@ -203,5 +208,40 @@ class ExceptionGenerationMapperIntegrationTest {
                 """, reconciliationRunId, matchGroupKey, contractId,
                 resultType, expectedAmount, actualAmount,
                 expectedAmount - actualAmount, resultType);
+    }
+
+    private void insertJournalImbalance(Long validationRunId, Long contractId) {
+        Long journalHeaderId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.journal_header (
+                    journal_no, journal_date, journal_type,
+                    source_entity_type, source_entity_id,
+                    validation_run_id, contract_id, status
+                ) VALUES (?, ?, 'EXPECTED_FC_PAYOUT',
+                          'VALIDATION_RUN', ?, ?, ?, 'DRAFT')
+                RETURNING journal_header_id
+                """, Long.class,
+                "TEST-IMBALANCE-" + validationRunId,
+                TEST_MONTH,
+                String.valueOf(validationRunId),
+                validationRunId,
+                contractId);
+
+        List<Long> accountIds = jdbcTemplate.queryForList("""
+                SELECT journal_account_id
+                  FROM fgc.journal_account
+                 ORDER BY journal_account_id
+                 LIMIT 2
+                """, Long.class);
+        assertThat(accountIds).hasSize(2);
+
+        jdbcTemplate.update("""
+                INSERT INTO fgc.journal_line (
+                    journal_header_id, line_no, journal_account_id,
+                    debit_amount, credit_amount, contract_id
+                ) VALUES (?, 1, ?, 100000, 0, ?),
+                         (?, 2, ?, 0, 90000, ?)
+                """,
+                journalHeaderId, accountIds.get(0), contractId,
+                journalHeaderId, accountIds.get(1), contractId);
     }
 }

--- a/src/test/java/com/susukkang/fgc/validation/service/ValidationRunExceptionServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ValidationRunExceptionServiceImplTest.java
@@ -29,11 +29,12 @@ class ValidationRunExceptionServiceImplTest {
         given(exceptionCaseMapper.insertFromCapChecks(validationRunId)).willReturn(2L);
         given(exceptionCaseMapper.insertFromArbitrageChecks(validationRunId)).willReturn(3L);
         given(exceptionCaseMapper.insertFromReconciliationResults(validationRunId)).willReturn(4L);
+        given(exceptionCaseMapper.insertFromJournalImbalances(validationRunId)).willReturn(5L);
 
         StepProcessingResult result = new ValidationRunExceptionServiceImpl(exceptionCaseMapper)
                 .generate(context(validationRunId));
 
-        assertThat(result.processedCount()).isEqualTo(9L);
+        assertThat(result.processedCount()).isEqualTo(14L);
         assertThat(result.skippedCount()).isZero();
         assertThat(result.failureCount()).isZero();
         assertThat(result.skips()).isEmpty();
@@ -42,6 +43,7 @@ class ValidationRunExceptionServiceImplTest {
         calls.verify(exceptionCaseMapper).insertFromCapChecks(validationRunId);
         calls.verify(exceptionCaseMapper).insertFromArbitrageChecks(validationRunId);
         calls.verify(exceptionCaseMapper).insertFromReconciliationResults(validationRunId);
+        calls.verify(exceptionCaseMapper).insertFromJournalImbalances(validationRunId);
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/validation/service/ValidationRunExceptionServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ValidationRunExceptionServiceImplTest.java
@@ -1,0 +1,67 @@
+package com.susukkang.fgc.validation.service;
+
+import com.susukkang.fgc.common.code.ValidationRunType;
+import com.susukkang.fgc.validation.batch.contract.StepProcessingResult;
+import com.susukkang.fgc.validation.batch.contract.ValidationJobContext;
+import com.susukkang.fgc.validation.batch.contract.ValidationStepContext;
+import com.susukkang.fgc.validation.mapper.ExceptionCaseMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+
+@ExtendWith(MockitoExtension.class)
+class ValidationRunExceptionServiceImplTest {
+
+    @Mock
+    private ExceptionCaseMapper exceptionCaseMapper;
+
+    @Test
+    void generatesAllExceptionSourcesAndReturnsCreatedCount() {
+        Long validationRunId = 118L;
+        given(exceptionCaseMapper.insertFromCapChecks(validationRunId)).willReturn(2L);
+        given(exceptionCaseMapper.insertFromArbitrageChecks(validationRunId)).willReturn(3L);
+        given(exceptionCaseMapper.insertFromReconciliationResults(validationRunId)).willReturn(4L);
+
+        StepProcessingResult result = new ValidationRunExceptionServiceImpl(exceptionCaseMapper)
+                .generate(context(validationRunId));
+
+        assertThat(result.processedCount()).isEqualTo(9L);
+        assertThat(result.skippedCount()).isZero();
+        assertThat(result.failureCount()).isZero();
+        assertThat(result.skips()).isEmpty();
+
+        InOrder calls = inOrder(exceptionCaseMapper);
+        calls.verify(exceptionCaseMapper).insertFromCapChecks(validationRunId);
+        calls.verify(exceptionCaseMapper).insertFromArbitrageChecks(validationRunId);
+        calls.verify(exceptionCaseMapper).insertFromReconciliationResults(validationRunId);
+    }
+
+    @Test
+    void succeedsWithZeroWhenNoExceptionIsCreated() {
+        Long validationRunId = 119L;
+
+        StepProcessingResult result = new ValidationRunExceptionServiceImpl(exceptionCaseMapper)
+                .generate(context(validationRunId));
+
+        assertThat(result).isEqualTo(StepProcessingResult.success(0));
+    }
+
+    private ValidationStepContext context(Long validationRunId) {
+        return new ValidationStepContext(
+                validationRunId,
+                new ValidationJobContext(
+                        LocalDate.of(2026, 8, 1),
+                        1L,
+                        ValidationRunType.MONTHLY,
+                        1L,
+                        "req-exception-service"));
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- 월 통합검증 배치 8단계의 불일치·위반 예외 자동 생성 기능을 구현했습니다.

## 🔗 2. 관련 이슈

* Closes #156

## 🛠 3. 구현 내용

- 한도 위반, 차익거래 후보, 대사 불일치 결과를 `exception_case`로 일괄 생성했습니다.
- `exception_key`와 UNIQUE 제약으로 재실행 시 중복 생성을 방지했습니다.
- `ValidationStepContext`를 통해 실행 정보를 전달하고 생성 건수를 배치 결과에 반영했습니다.

## 🧪 4. 테스트 방법

1. 관련 단위 테스트를 실행합니다.
2. Mapper 통합 테스트로 예외 유형 및 심각도 매핑을 확인합니다.
3. 동일 검증 결과를 재처리해 신규 예외가 생성되지 않는지 확인합니다.

```powershell
.\gradlew.bat test --tests "com.susukkang.fgc.validation.*"
```

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

- 검증 상태별 예외 유형·심각도 매핑과 `exception_key` 생성 규칙을 확인해 주세요.
- CAP·차익거래·대사 결과의 예외 생성 대상이 적절한지 확인해 주세요.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음

## 💬 9. 참고 사항

- 원장 및 대사 선행 단계의 구현 상태에 따라 전체 배치 테스트 결과가 영향을 받을 수 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 월별 검증 결과에서 한도, 차익거래, 대사 불일치, 원장 불균형 관련 예외 항목을 자동 생성합니다.
  * 예외 유형, 심각도, 제목, 상세 설명 및 원천 정보를 저장합니다.
  * 동일한 검증 실행에서 중복 예외가 생성되지 않습니다.

* **버그 수정**
  * 검증 배치의 예외 생성 단계가 실제 예외 생성 처리로 동작하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->