### PR TITLE
[Feat] CONT-W01 계약 목록 조직(orgId) 검색 조건 추가

### DIFF
--- a/src/main/java/com/susukkang/fgc/contract/dto/ContractSearchCondition.java
+++ b/src/main/java/com/susukkang/fgc/contract/dto/ContractSearchCondition.java
@@ -25,6 +25,7 @@ public class ContractSearchCondition {
     private Long insurerId; //보험사 ID
     private Long productOfferingId; //상품
     private Long agentId; //FC ID
+    private Long orgId; //조직 ID (IF-API-11, 계약 당시 소속 조직 기준)
     private CapResultStatus capResultStatus; //1,200% 한도 판정
     private ContractStatus currentStatus; //계약상태
     private LocalDate contractDateFrom; //계약일 시작

--- a/src/main/resources/mapper/contract/ContractMapper.xml
+++ b/src/main/resources/mapper/contract/ContractMapper.xml
@@ -50,6 +50,10 @@
                 AND ic.agent_id = #{condition.agentId}
             </if>
 
+            <if test="condition.orgId != null">
+                AND ic.organization_id = #{condition.orgId}
+            </if>
+
             <if test="condition.capResultStatus != null">
                 AND cc.result_status = #{condition.capResultStatus}
             </if>
@@ -109,6 +113,10 @@
 
             <if test="agentId != null">
                 AND ic.agent_id = #{agentId}
+            </if>
+
+            <if test="orgId != null">
+                AND ic.organization_id = #{orgId}
             </if>
 
             <if test="capResultStatus != null">

--- a/src/main/resources/templates/contract/list.html
+++ b/src/main/resources/templates/contract/list.html
@@ -18,6 +18,7 @@
       <label class="field"><span class="field-label">보험회사</span><select class="select-control" disabled title="보험회사 조회 API 연동 대기"><option>기준정보 연동 대기</option></select></label>
       <label class="field"><span class="field-label">상품</span><select class="select-control" disabled title="상품 조회 API 연동 대기"><option>기준정보 연동 대기</option></select></label>
       <label class="field"><span class="field-label">모집 설계사</span><select class="select-control" disabled title="설계사 조회 API 연동 대기"><option>기준정보 연동 대기</option></select></label>
+      <label class="field"><span class="field-label">조직</span><select class="select-control" disabled title="조직 조회 API 연동 대기"><option>기준정보 연동 대기</option></select></label>
       <label class="field"><span class="field-label">계약일 시작</span><input class="field-control tabular-nums" type="date" th:field="*{contractDateFrom}"></label>
       <label class="field"><span class="field-label">계약일 끝</span><input class="field-control tabular-nums" type="date" th:field="*{contractDateTo}"></label>
       <label class="field"><span class="field-label">계약상태</span><select class="select-control" th:field="*{currentStatus}"><option value="">전체</option><option th:each="status : ${contractStatuses}" th:value="${status}" th:text="${contractStatusLabels[status]}">유지</option></select></label>

--- a/src/test/java/com/susukkang/fgc/contract/controller/ContractControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/controller/ContractControllerTest.java
@@ -165,6 +165,12 @@ class ContractControllerTest {
                 .andExpect(jsonPath("$.data.size").value(20))
                 .andExpect(jsonPath("$.data.totalElements").value(1))
                 .andExpect(jsonPath("$.data.totalPages").value(1));
+
+        // orgId는 선택 파라미터 — 미전달 시 검색 조건에 null로 바인딩된다 (IF-API-11)
+        ArgumentCaptor<ContractSearchCondition> captor =
+                ArgumentCaptor.forClass(ContractSearchCondition.class);
+        verify(contractService).selectByCondition(captor.capture(), eq(1), eq(20));
+        assertThat(captor.getValue().getOrgId()).isNull();
     }
     @Test
     @DisplayName("orgId 요청 파라미터가 계약 목록 검색 조건에 바인딩된다")

--- a/src/test/java/com/susukkang/fgc/contract/controller/ContractControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/controller/ContractControllerTest.java
@@ -25,6 +25,7 @@ import com.susukkang.fgc.common.code.ArbitrageCheckStatus;
 import com.susukkang.fgc.common.code.PaymentStage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -39,8 +40,10 @@ import java.util.List;
 
 import static com.susukkang.fgc.contract.domain.ContractStatus.ACTIVE;
 import static com.susukkang.fgc.contract.domain.PaymentCycleCode.MONTHLY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
@@ -163,6 +166,26 @@ class ContractControllerTest {
                 .andExpect(jsonPath("$.data.totalElements").value(1))
                 .andExpect(jsonPath("$.data.totalPages").value(1));
     }
+    @Test
+    @DisplayName("orgId 요청 파라미터가 계약 목록 검색 조건에 바인딩된다")
+    void getContractsBindsOrgIdCondition() throws Exception {
+        // IF-API-11 · #168 — 조직(orgId) 검색 조건 API 계약 테스트
+        when(contractService.selectByCondition(
+                any(ContractSearchCondition.class), eq(1), eq(20)
+        )).thenReturn(PageResponse.of(List.of(), 1, 20, 0, "contractId,desc"));
+
+        mockMvc.perform(get("/api/v1/contracts")
+                        .param("orgId", "7")
+                        .with(user("admin").roles("GA_ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(0));
+
+        ArgumentCaptor<ContractSearchCondition> captor =
+                ArgumentCaptor.forClass(ContractSearchCondition.class);
+        verify(contractService).selectByCondition(captor.capture(), eq(1), eq(20));
+        assertThat(captor.getValue().getOrgId()).isEqualTo(7L);
+    }
+
     @Test
     @DisplayName("보험계약 상세정보를 조회한다")
     void getContractDetailReturnsSuccess() throws Exception {

--- a/src/test/java/com/susukkang/fgc/contract/mapper/ContractMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/mapper/ContractMapperIntegrationTest.java
@@ -99,8 +99,9 @@ class ContractMapperIntegrationTest {
     }
 
     @Test
-    @DisplayName("조직 ID 검색 조건으로 계약 목록과 건수를 거른다")
+    @DisplayName("조직 ID 검색 조건으로 계약 목록과 건수를 거른다 (IF-API-11)")
     void selectsContractByOrgId() {
+        // FGC-UI-CONT-W01 검색 조건 '조직' — FGC-FUN-018 화면의 기본 필터, 조직 필터 명세는 FGC-FUN-058(2차 통합검색)
         References refs = references();
         InsuranceContract contract = newContract(refs);
         contractMapper.insertContract(contract);

--- a/src/test/java/com/susukkang/fgc/contract/mapper/ContractMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/mapper/ContractMapperIntegrationTest.java
@@ -99,6 +99,25 @@ class ContractMapperIntegrationTest {
     }
 
     @Test
+    @DisplayName("조직 ID 검색 조건으로 계약 목록과 건수를 거른다")
+    void selectsContractByOrgId() {
+        References refs = references();
+        InsuranceContract contract = newContract(refs);
+        contractMapper.insertContract(contract);
+        ContractSearchCondition condition = new ContractSearchCondition();
+        condition.setContractNo(contract.getContractNo());
+        condition.setOrgId(refs.organizationId());
+
+        assertThat(contractMapper.selectByCondition(condition, 20, 0)).hasSize(1);
+        assertThat(contractMapper.countByCondition(condition)).isEqualTo(1);
+
+        // 존재하지 않는 조직으로 검색하면 걸러진다
+        condition.setOrgId(-1L);
+        assertThat(contractMapper.selectByCondition(condition, 20, 0)).isEmpty();
+        assertThat(contractMapper.countByCondition(condition)).isZero();
+    }
+
+    @Test
     @DisplayName("계약을 수정하면 계약번호는 유지되고 수정값이 반영된다")
     void updatesContractIncludingContractNumber() {
         References refs = references();


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* 계약 목록 조회(IF-API-11, `GET /api/v1/contracts`)에 조직(`orgId`) 검색 조건을 추가했습니다.
* 화면정의서 CONT-W01 검색 조건("계약번호, 보험회사, 상품, 설계사, **조직**, …")과 인터페이스정의서 IF-API-11의 `orgId=` 파라미터(PR #167)에 구현을 정합화한 작업입니다.

## 🔗 2. 관련 이슈

* Closes #168

## 🛠 3. 구현 내용

* `ContractSearchCondition`에 `orgId` 필드 추가 — API(`ContractController`)와 MPA(`ContractViewController`) 모두 `@ModelAttribute` 바인딩이라 DTO 수정만으로 요청 파라미터가 매퍼까지 전달됩니다.
* `ContractMapper.xml`의 목록(`selectByCondition`)·건수(`countByCondition`) 쿼리에 `ic.organization_id = #{orgId}` 동적 조건 추가 — `insurance_contract`에 `organization_id` 컬럼이 이미 있어 조인 없이 필터링합니다(#118 CAP-W01과 동일 방식, 계약 당시 소속 조직 기준).
* 계약 목록 화면 검색 폼에 "조직" 필드 추가 — 기존 보험회사·상품·설계사와 동일하게 기준정보 조회 API 연동 전까지 disabled 셀렉트로 배치했습니다.

## 🧪 4. 테스트 방법

1. `./gradlew test --tests "com.susukkang.fgc.contract.controller.ContractControllerTest" --tests "com.susukkang.fgc.contract.mapper.ContractMapperIntegrationTest"` 실행 → 통과 확인
2. `ContractControllerTest.getContractsBindsOrgIdCondition` — `orgId=7` 요청 파라미터가 검색 조건 객체에 바인딩되는지 확인 (API 계약 테스트)
3. `ContractMapperIntegrationTest.selectsContractByOrgId` — 실제 DB에서 조직 ID 일치 시 목록·건수 1건, 존재하지 않는 조직(-1) 시 0건 확인
4. (수동) `/contracts?orgId=<조직ID>` 호출 시 해당 조직 계약만 반환되는지 확인

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* 조직 필터를 `insurance_contract.organization_id` 동등 조건(계약 당시 소속 조직)으로 구현했습니다. 조직 트리(GA>본사>본부>지사>팀) 하위 조직 포함 검색은 화면정의서에 명시가 없어 범위에서 제외했는데, 필요 여부 의견 부탁드립니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* CONT-W01 검색 폼에 "조직" 필드 추가 (기준정보 연동 전까지 disabled — 기존 보험회사·상품·설계사 필드와 동일 상태)

## 💬 9. 참고 사항

* 조직 셀렉트 활성화는 조직 기준정보 조회 API(FUN-005) 프론트 연동 시 후속 작업으로 진행하면 됩니다.
* CAP-W01 쪽 동일 성격 작업은 #118에서 별도 진행 중입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 계약 검색 조건에 조직 필터가 추가되었습니다.
  * 특정 조직에 소속된 계약 목록과 계약 건수를 조회할 수 있습니다.
  * 조직 선택 항목이 제공되며, 조직 조회 기능 연동 전까지는 비활성화됩니다.

* **테스트**
  * 조직 ID가 계약 검색 조건에 올바르게 반영되는지 검증했습니다.
  * 유효한 조직과 존재하지 않는 조직에 따른 조회 결과를 확인했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->