### PR TITLE
[Feat] FUN-033 지급 전 한도 사전검증 - IF-API-24 사전검증 미리보기 API

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,12 +39,15 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
-
+          #
+          # 아래 설정은 Gradle 테스트 명령을 "미리 허용(allow)"해서,
+          # Claude가 매번 승인을 기다리지 않고 바로 ./gradlew test 를 실행하게 합니다.
+          # - Bash(./gradlew test)     : ./gradlew test  (옵션 없는 그대로의 명령)
+          # - Bash(./gradlew test:*)   : ./gradlew test  뒤에 옵션이 붙는 경우 (예: --info, --stacktrace)
+          claude_args: '--allowed-tools "Bash(./gradlew test),Bash(./gradlew test:*)"'

--- a/src/main/java/com/susukkang/fgc/transaction/controller/CommissionPaymentApiController.java
+++ b/src/main/java/com/susukkang/fgc/transaction/controller/CommissionPaymentApiController.java
@@ -5,9 +5,12 @@ import com.susukkang.fgc.common.web.ApiResponse;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentCreateRequest;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentResponse;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentUpdateRequest;
+import com.susukkang.fgc.transaction.dto.TransactionPrecheckResponse;
 import com.susukkang.fgc.transaction.service.CommissionPaymentService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -124,5 +127,30 @@ public class CommissionPaymentApiController {
             @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey
     ) {
         return ApiResponse.success(commissionPaymentService.confirm(paymentId, idempotencyKey));
+    }
+
+    @Operation(
+            summary = "지급 전 한도 사전검증 미리보기 (IF-API-24)",
+            description = "저장·상태 변경 없이 DRAFT 지급 건을 제31조 확정 게이트로 검사해 "
+                    + "계약·지급단계별 1,200% 게이지(capPreview)와 확정 차단 사유(blockers)를 반환합니다. "
+                    + "차단 사유가 있어도 200으로 응답합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200", description = "사전검증 결과 (차단 사유가 있어도 200 + blockers[])",
+                    content = @Content(schema = @Schema(implementation = TransactionPrecheckResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400", description = "지급 건 없음 (FGC-COMMON-002)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409", description = "DRAFT 상태가 아님 (FGC-TRAN-005)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403", description = "정산담당자 권한 없음")
+    })
+    @PostMapping("/{paymentId}/precheck")
+    public ApiResponse<TransactionPrecheckResponse> precheck(
+            @Parameter(description = "지급 건 ID", required = true)
+            @PathVariable Long paymentId
+    ) {
+        return ApiResponse.success(commissionPaymentService.precheck(paymentId));
     }
 }

--- a/src/main/java/com/susukkang/fgc/transaction/domain/AttributedContractNo.java
+++ b/src/main/java/com/susukkang/fgc/transaction/domain/AttributedContractNo.java
@@ -1,0 +1,14 @@
+package com.susukkang.fgc.transaction.domain;
+
+/**
+ * 설명 : 지급 건 귀속 계약의 계약번호 조회 결과 (IF-API-24 capPreview 표시용)
+ *
+ * @author yslee
+ * @since 2026-08-16
+ * @version 1.0
+ */
+public record AttributedContractNo(
+        Long contractId,
+        String contractNo
+) {
+}

--- a/src/main/java/com/susukkang/fgc/transaction/dto/TransactionPrecheckResponse.java
+++ b/src/main/java/com/susukkang/fgc/transaction/dto/TransactionPrecheckResponse.java
@@ -1,0 +1,89 @@
+package com.susukkang.fgc.transaction.dto;
+
+import com.susukkang.fgc.common.code.CapResultStatus;
+import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.common.util.DisplayFormat;
+import com.susukkang.fgc.transaction.domain.CapCheckCommand;
+import com.susukkang.fgc.transaction.domain.CapRuleSnapshot;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 설명 : IF-API-24 지급 전 한도 사전검증 미리보기 응답 (FGC-FUN-033)
+ *
+ * 저장 없이 계산한 결과라 capCheckId 는 항상 null 이다.
+ * blockers 문구는 confirm(IF-API-25) 실패 응답과 같은 메시지 카탈로그에서 나온다.
+ *
+ * @author yslee
+ * @since 2026-08-16
+ * @version 1.0
+ */
+public record TransactionPrecheckResponse(
+        Long paymentId,
+        List<CapPreviewItem> capPreview,
+        List<Blocker> blockers,
+        boolean confirmable
+) {
+
+    /** 귀속 계약 × 지급단계별 1,200% 게이지 1행 (화면 ③ 검증 결과 패널) — 표시 형식은 SIR-008. */
+    public record CapPreviewItem(
+            Long contractId,
+            String contractNo,
+            PaymentStage paymentStage,
+            String paymentStageLabel,
+            LocalDate asOfDate,
+            long basePremiumAmount,
+            long refund12mAmount,
+            long complianceDeductionAmount,
+            long limitAmount,
+            long existingIncludedAmount,
+            long candidateAmount,
+            long includedAmount,
+            long remainingAmount,
+            String usagePct,
+            CapResultStatus resultStatus,
+            String resultStatusLabel,
+            Long capRuleSetId,
+            Long capCheckId
+    ) {
+        /** 확정 경로와 같은 buildCapCheck 결과를 저장하지 않고 그대로 표시 형식으로 변환한다. */
+        public static CapPreviewItem from(
+                CapCheckCommand check,
+                CapRuleSnapshot rule,
+                String contractNo
+        ) {
+            PaymentStage stage = PaymentStage.valueOf(check.getPaymentStage());
+            CapResultStatus status = check.getResultStatus();
+            return new CapPreviewItem(
+                    check.getContractId(),
+                    contractNo,
+                    stage,
+                    stage.label(),
+                    check.getAsOfDate(),
+                    DisplayFormat.won(check.getBasePremiumAmount()),
+                    DisplayFormat.won(check.getRefund12mAmount()),
+                    DisplayFormat.won(check.getComplianceDeductionAmount()),
+                    DisplayFormat.won(check.getLimitAmount()),
+                    DisplayFormat.won(rule.existingIncludedAmount()),
+                    DisplayFormat.won(check.getCandidateAmount()),
+                    DisplayFormat.won(check.getIncludedAmount()),
+                    DisplayFormat.won(check.getRemainingAmount()),
+                    DisplayFormat.rate(check.getUsagePct()),
+                    status,
+                    status.label(),
+                    check.getCapRuleSetId(),
+                    null
+            );
+        }
+    }
+
+    /** 현재 상태로 확정하면 실패할 사유 1건 — code 는 3장 오류 카탈로그, message 는 부록 A 표준 문구. */
+    public record Blocker(
+            String code,
+            String message,
+            Long contractId,
+            Long transactionAttributionId
+    ) {
+    }
+}

--- a/src/main/java/com/susukkang/fgc/transaction/mapper/CommissionPaymentMapper.java
+++ b/src/main/java/com/susukkang/fgc/transaction/mapper/CommissionPaymentMapper.java
@@ -1,5 +1,6 @@
 package com.susukkang.fgc.transaction.mapper;
 
+import com.susukkang.fgc.transaction.domain.AttributedContractNo;
 import com.susukkang.fgc.transaction.domain.CapCheckCommand;
 import com.susukkang.fgc.transaction.domain.CapRuleSnapshot;
 import com.susukkang.fgc.transaction.domain.CommissionItemReference;
@@ -68,6 +69,11 @@ public interface CommissionPaymentMapper {
     List<CommissionPaymentAttributionRow> findAttributions(@Param("paymentId") Long paymentId);
 
     List<ConfirmationData> findConfirmationDataForUpdate(@Param("paymentId") Long paymentId);
+
+    // IF-API-24 사전검증 전용 무잠금 조회 — 같은 SELECT의 FOR UPDATE 없는 버전
+    List<ConfirmationData> findConfirmationData(@Param("paymentId") Long paymentId);
+
+    List<AttributedContractNo> findAttributedContractNumbers(@Param("paymentId") Long paymentId);
 
     List<Long> lockAttributedContracts(@Param("paymentId") Long paymentId);
 

--- a/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentService.java
+++ b/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentService.java
@@ -3,6 +3,7 @@ package com.susukkang.fgc.transaction.service;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentCreateRequest;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentResponse;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentUpdateRequest;
+import com.susukkang.fgc.transaction.dto.TransactionPrecheckResponse;
 
 /**
  * 설명 : 수수료 지급 건 등록·수정·확정 서비스 계약
@@ -18,4 +19,7 @@ public interface CommissionPaymentService {
     CommissionPaymentResponse update(Long paymentId, CommissionPaymentUpdateRequest request);
 
     CommissionPaymentResponse confirm(Long paymentId, String idempotencyKey);
+
+    // IF-API-24 — 저장·상태 변경 없이 확정 게이트를 미리 계산한다 (FGC-FUN-033)
+    TransactionPrecheckResponse precheck(Long paymentId);
 }

--- a/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
@@ -211,6 +211,9 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
     public TransactionPrecheckResponse precheck(Long paymentId) {
         List<ConfirmationData> attributions = requireConfirmationData(paymentId, false);
         ConfirmationData first = attributions.get(0);
+        // 비DRAFT는 미리보기 대상 자체가 아니라 TRAN_005로 먼저 끊는다. confirm은 CAP_003 검사가
+        // 순서상 앞이지만 precheck에서 CAP_003은 던지지 않고 수집하는 사유라, 순서를 맞춰도
+        // 비DRAFT 응답은 409로 같다 — DRAFT 건에서는 두 경로의 게이트 판정이 동일하다.
         requireDraft(first);
 
         List<GateFailure> failures = new ArrayList<>();
@@ -237,12 +240,11 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                         data.transactionAttributionId()
                 );
                 GateFailure ruleFailure = capRuleFailure(rule, data);
-                if (rule == null) {
-                    failures.add(ruleFailure);
-                    continue;
-                }
                 if (ruleFailure != null) {
                     failures.add(ruleFailure);
+                }
+                if (rule == null) {
+                    continue;
                 }
                 CapCalculationResult calculation = calculateLimit(
                         data.contractId(),

--- a/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
@@ -271,6 +271,19 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                         actualValidation,
                         rule.warningUsagePct()
                 );
+                // 룰 판정 불일치·룰셋 불일치(CAP_002) 행은 confirm이 계산에 도달하지 못하는 행이다.
+                // CapValidator는 귀속 스냅샷만 보므로 정책 드리프트 시 NORMAL로 계산될 수 있는데,
+                // 게이지 수치는 참고용으로 남기되 판정만은 검토필요로 강제해 "정상" 오인을 막는다.
+                if (ruleFailure != null || consistencyFailure != null) {
+                    validation = new CapValidationResult(
+                            validation.limitAmount(),
+                            validation.candidateIncludedAmount(),
+                            validation.includedAmount(),
+                            validation.remainingAmount(),
+                            validation.usagePct(),
+                            CapResultStatus.REVIEW_REQUIRED
+                    );
+                }
                 CapCheckCommand check = buildCapCheck(data, rule, calculation, validation);
                 previews.add(TransactionPrecheckResponse.CapPreviewItem.from(
                         check,

--- a/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
@@ -305,6 +305,9 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                             paymentLevel ? null : failure.data().transactionAttributionId()
                     );
                 })
+                // 같은 근본 원인(예: REVIEW_REQUIRED)이 여러 게이트에서 재검출되면 code·message·ID가
+                // 전부 같은 Blocker가 반복된다 — record 값 동등성으로 같은 사유는 한 줄로 접는다
+                .distinct()
                 .toList();
     }
 

--- a/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
@@ -19,8 +19,10 @@ import com.susukkang.fgc.common.code.ExceptionType;
 import com.susukkang.fgc.common.code.InclusionDecisionStatus;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.exception.FgcMessageResolver;
 import com.susukkang.fgc.common.security.Roles;
 import com.susukkang.fgc.common.util.MoneyUtil;
+import com.susukkang.fgc.transaction.domain.AttributedContractNo;
 import com.susukkang.fgc.transaction.domain.CapCheckCommand;
 import com.susukkang.fgc.transaction.domain.CapRuleSnapshot;
 import com.susukkang.fgc.transaction.domain.CommissionItemReference;
@@ -34,6 +36,7 @@ import com.susukkang.fgc.transaction.dto.CommissionPaymentCreateRequest;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentAttributionRequest;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentResponse;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentUpdateRequest;
+import com.susukkang.fgc.transaction.dto.TransactionPrecheckResponse;
 import com.susukkang.fgc.transaction.mapper.CommissionPaymentMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -66,6 +69,7 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
     private final CapValidator capValidator;
     private final CapCalculator capCalculator;
     private final CapExceptionService capExceptionService;
+    private final FgcMessageResolver messageResolver;
 
     @Override
     @Transactional
@@ -130,12 +134,12 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
          * 개선: 지급확정 전에 미해결 CAP_VIOLATION 존재 여부를 확인하여 확정을 차단
          */
         if (capExceptionService.hasUnresolvedViolation(paymentId)) {
-            throw new CommissionPaymentConfirmationRejectedException(FgcErrorCode.CAP_003);
+            failFirst(unresolvedViolationFailure(first));
         }
 
         requireDraft(attributions.get(0));
         mapper.lockAttributedContracts(paymentId);
-        validateConfirmationRequiredValues(attributions);
+        failFirst(requiredValueFailures(attributions));
 
         List<Long> capCheckIds = new ArrayList<>();
 
@@ -144,15 +148,19 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
         // 문제: 다중 계약 배부 시 두 번째 이후 귀속금액이 한도 판정에서 누락
         // 개선: 귀속행별 정책·한도·증빙 공제를 계산하고 하나라도 실패하면 확정을 차단
         for (ConfirmationData data : attributions) {
-            validateAttributionForConfirmation(data);
-            CapRuleSnapshot rule = requireCapRule(paymentId, data);
+            failFirst(attributionFailures(data));
+            CapRuleSnapshot rule = mapper.findCapRuleSnapshot(
+                    paymentId,
+                    data.transactionAttributionId()
+            );
+            failFirst(capRuleFailure(rule, data));
             CapCalculationResult calculation = calculateLimit(
                     data.contractId(),
                     data.paymentStage(),
                     data.attributionDate(),
                     rule.complianceEvidenceAmount()
             );
-            validateRuleConsistency(rule, calculation, data);
+            failFirst(ruleConsistencyFailure(rule, calculation, data));
 
             CapValidationResult actualValidation = capValidator.validate(new CapValidationRequest(
                     calculation.limitAmount(),
@@ -182,32 +190,7 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
              */
             capExceptionService.createIfNecessary(capExceptionCommand(data, check));
 
-            /**
-             * @author hjKang
-             * @since 2026-08-12
-             *
-             * 2026-08-12 - 예외 유형과 심각도 공통 enum 적용
-             * 기존 코드: 예외 유형과 심각도를 문자열 리터럴로 전달
-             * 문제: DB 허용값 오타를 컴파일 시점에 확인할 수 없음
-             * 개선: ExceptionType과 ExceptionSeverity의 name()을 사용하여 DB 코드값을 통일
-             */
-            if (check.getResultStatus() == CapResultStatus.REVIEW_REQUIRED) {
-                rejectWithException(
-                        data,
-                        ExceptionType.CAP_REVIEW_REQUIRED.name(),
-                        ExceptionSeverity.HIGH.name(),
-                        "산입 판단 검토 필요",
-                        "검토필요 귀속행 또는 준법경영비 증빙을 확인해야 합니다.",
-                        FgcErrorCode.CAP_002,
-                        Map.of()
-                );
-            }
-            if (check.getResultStatus() == CapResultStatus.VIOLATION) {
-                throw new CommissionPaymentConfirmationRejectedException(
-                        FgcErrorCode.CAP_001,
-                        Map.of("n", check.getUsagePct())
-                );
-            }
+            failFirst(capResultFailure(data, check));
         }
 
         String capCheckIdsCsv = capCheckIds.stream()
@@ -217,6 +200,101 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
             throw new FgcBusinessException(FgcErrorCode.TRAN_005);
         }
         return requirePayment(paymentId, capCheckIds);
+    }
+
+    @Override
+    // 2026-08-16 yslee - IF-API-24 지급 전 한도 사전검증 미리보기 (FGC-FUN-033)
+    // confirm()과 같은 판정 메서드·계산 엔진(REALTIME)을 재사용하되 아무것도 저장하지 않는다.
+    // cap_check·exception_case 기록 생성은 확정(IF-API-25) 경로 전용이며(운영정책서 제31조),
+    // confirm은 첫 실패에서 차단하지만 미리보기는 모든 차단 사유를 blockers[]로 수집한다.
+    @Transactional(readOnly = true)
+    public TransactionPrecheckResponse precheck(Long paymentId) {
+        List<ConfirmationData> attributions = requireConfirmationData(paymentId, false);
+        ConfirmationData first = attributions.get(0);
+        requireDraft(first);
+
+        List<GateFailure> failures = new ArrayList<>();
+        if (capExceptionService.hasUnresolvedViolation(paymentId)) {
+            failures.add(unresolvedViolationFailure(first));
+        }
+        failures.addAll(requiredValueFailures(attributions));
+
+        List<TransactionPrecheckResponse.CapPreviewItem> previews = new ArrayList<>();
+        if (first.totalAttributedAmount() != null) {
+            Map<Long, String> contractNos = mapper.findAttributedContractNumbers(paymentId)
+                    .stream()
+                    .collect(Collectors.toMap(
+                            AttributedContractNo::contractId,
+                            AttributedContractNo::contractNo
+                    ));
+            for (ConfirmationData data : attributions) {
+                failures.addAll(attributionFailures(data));
+                if (data.contractId() == null || data.attributedAmount() == null) {
+                    continue;
+                }
+                CapRuleSnapshot rule = mapper.findCapRuleSnapshot(
+                        paymentId,
+                        data.transactionAttributionId()
+                );
+                GateFailure ruleFailure = capRuleFailure(rule, data);
+                if (rule == null) {
+                    failures.add(ruleFailure);
+                    continue;
+                }
+                if (ruleFailure != null) {
+                    failures.add(ruleFailure);
+                }
+                CapCalculationResult calculation = calculateLimit(
+                        data.contractId(),
+                        data.paymentStage(),
+                        data.attributionDate(),
+                        rule.complianceEvidenceAmount()
+                );
+                GateFailure consistencyFailure = ruleConsistencyFailure(rule, calculation, data);
+                if (consistencyFailure != null) {
+                    failures.add(consistencyFailure);
+                }
+                CapValidationResult actualValidation = capValidator.validate(new CapValidationRequest(
+                        calculation.limitAmount(),
+                        rule.warningUsagePct(),
+                        rule.existingIncludedAmount(),
+                        data.attributedAmount(),
+                        data.inclusionDecisionStatus()
+                ));
+                CapValidationResult validation = mergeScheduleAndActualValidation(
+                        calculation,
+                        actualValidation,
+                        rule.warningUsagePct()
+                );
+                CapCheckCommand check = buildCapCheck(data, rule, calculation, validation);
+                previews.add(TransactionPrecheckResponse.CapPreviewItem.from(
+                        check,
+                        rule,
+                        contractNos.get(data.contractId())
+                ));
+                GateFailure resultFailure = capResultFailure(data, check);
+                if (resultFailure != null) {
+                    failures.add(resultFailure);
+                }
+            }
+        }
+        return new TransactionPrecheckResponse(
+                paymentId,
+                previews,
+                toBlockers(failures),
+                failures.isEmpty()
+        );
+    }
+
+    private List<TransactionPrecheckResponse.Blocker> toBlockers(List<GateFailure> failures) {
+        return failures.stream()
+                .map(failure -> new TransactionPrecheckResponse.Blocker(
+                        failure.errorCode().getCode(),
+                        messageResolver.resolve(failure.errorCode(), failure.params()),
+                        failure.data().contractId(),
+                        failure.data().transactionAttributionId()
+                ))
+                .toList();
     }
 
     private ExceptionCaseCommand exceptionCommand(
@@ -560,10 +638,56 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
         mapper.insertAttributions(attributions);
     }
 
-    private void validateConfirmationRequiredValues(List<ConfirmationData> attributions) {
+    /**
+     * 확정 게이트 판정 실패 서술자. confirm()은 첫 실패에서 예외 이력을 남기고 차단하며(failFirst),
+     * precheck는 같은 판정 메서드의 결과를 저장 없이 전부 수집한다 — 두 경로의 판정 일치 보장.
+     * exceptionType이 null이면 exception_case를 저장하지 않고 차단만 한다 (CAP_001·CAP_003 경로).
+     */
+    private record GateFailure(
+            ConfirmationData data,
+            String exceptionType,
+            String severity,
+            String title,
+            String description,
+            FgcErrorCode errorCode,
+            Map<String, Object> params
+    ) {}
+
+    private void failFirst(GateFailure failure) {
+        if (failure != null) {
+            failFirst(List.of(failure));
+        }
+    }
+
+    private void failFirst(List<GateFailure> failures) {
+        if (failures.isEmpty()) {
+            return;
+        }
+        GateFailure failure = failures.get(0);
+        if (failure.exceptionType() != null) {
+            saveException(
+                    failure.data(),
+                    failure.exceptionType(),
+                    failure.severity(),
+                    failure.title(),
+                    failure.description()
+            );
+        }
+        throw new CommissionPaymentConfirmationRejectedException(
+                failure.errorCode(),
+                failure.params()
+        );
+    }
+
+    private GateFailure unresolvedViolationFailure(ConfirmationData first) {
+        return new GateFailure(first, null, null, null, null, FgcErrorCode.CAP_003, Map.of());
+    }
+
+    private List<GateFailure> requiredValueFailures(List<ConfirmationData> attributions) {
+        List<GateFailure> failures = new ArrayList<>();
         ConfirmationData first = attributions.get(0);
         if (first.totalAttributedAmount() == null) {
-            rejectWithException(
+            failures.add(new GateFailure(
                     first,
                     "DATA_QUALITY",
                     "HIGH",
@@ -571,14 +695,12 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                     "지급 건을 확정하려면 하나 이상의 귀속행이 필요합니다.",
                     FgcErrorCode.TRAN_002,
                     Map.of()
-            );
-        }
-
-        if (first.amount().compareTo(first.totalAttributedAmount()) != 0) {
+            ));
+        } else if (first.amount().compareTo(first.totalAttributedAmount()) != 0) {
             BigDecimal difference = first.amount()
                     .subtract(first.totalAttributedAmount())
                     .abs();
-            rejectWithException(
+            failures.add(new GateFailure(
                     first,
                     "DATA_QUALITY",
                     "HIGH",
@@ -590,11 +712,11 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                             "b", first.amount(),
                             "c", difference
                     )
-            );
+            ));
         }
 
         if (first.policyVersionId() == null) {
-            rejectWithException(
+            failures.add(new GateFailure(
                     first,
                     "ALLOCATION_EVIDENCE_MISSING",
                     "HIGH",
@@ -602,15 +724,17 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                     "확정하려면 적용 정책 버전이 필요합니다.",
                     FgcErrorCode.TRAN_004,
                     Map.of()
-            );
+            ));
         }
+        return failures;
     }
 
-    private void validateAttributionForConfirmation(ConfirmationData data) {
+    private List<GateFailure> attributionFailures(ConfirmationData data) {
+        List<GateFailure> failures = new ArrayList<>();
         if (data.attributedAmount() == null
                 || (data.contractId() == null
                 && data.attributionMethod() != AttributionMethod.NEWCOMER_NON_CONTRACT)) {
-            rejectWithException(
+            failures.add(new GateFailure(
                     data,
                     "DATA_QUALITY",
                     "HIGH",
@@ -618,11 +742,11 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                     "계약 귀속행에는 귀속계약이 필요합니다.",
                     FgcErrorCode.TRAN_002,
                     Map.of()
-            );
+            ));
         }
         if (data.inclusionDecisionStatus() == InclusionDecisionStatus.REVIEW_REQUIRED
                 || data.contractId() == null) {
-            rejectWithException(
+            failures.add(new GateFailure(
                     data,
                     "CAP_REVIEW_REQUIRED",
                     "HIGH",
@@ -630,7 +754,7 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                     "검토필요 또는 비계약 귀속행은 자동 확정할 수 없습니다.",
                     FgcErrorCode.CAP_002,
                     Map.of()
-            );
+            ));
         }
         // 2026-08-11 yslee - 배부 방식 전체의 확정 전 배부근거 검증
         // 기존 코드: APPROVED_ALLOCATION만 배부기준을 요구하고 정착지원금 월배부·이월배부는 누락
@@ -640,7 +764,7 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                 || data.attributionMethod() == AttributionMethod.SETTLEMENT_SUPPORT_MONTHLY
                 || data.attributionMethod() == AttributionMethod.FIRST_CONTRACT_CARRY_FORWARD;
         if (allocationBasisRequired && !StringUtils.hasText(data.allocationBasis())) {
-            rejectWithException(
+            failures.add(new GateFailure(
                     data,
                     "ALLOCATION_EVIDENCE_MISSING",
                     "HIGH",
@@ -648,12 +772,12 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                     "배부 귀속행에는 배부기준이 필요합니다.",
                     FgcErrorCode.TRAN_004,
                     Map.of()
-            );
+            ));
         }
         if (data.inclusionDecisionStatus() == InclusionDecisionStatus.EXCLUDED
                 && (data.exclusionType() == ExclusionType.NONE
                 || !StringUtils.hasText(data.evidenceRef()))) {
-            rejectWithException(
+            failures.add(new GateFailure(
                     data,
                     "ALLOCATION_EVIDENCE_MISSING",
                     "HIGH",
@@ -661,8 +785,32 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                     "산입 제외 건에는 증빙 참조 정보가 필요합니다.",
                     FgcErrorCode.TRAN_004,
                     Map.of()
+            ));
+        }
+        return failures;
+    }
+
+    // 2026-08-12 hjKang - 예외 유형과 심각도 공통 enum 적용 (ExceptionType·ExceptionSeverity의 name() 사용)
+    private GateFailure capResultFailure(ConfirmationData data, CapCheckCommand check) {
+        if (check.getResultStatus() == CapResultStatus.REVIEW_REQUIRED) {
+            return new GateFailure(
+                    data,
+                    ExceptionType.CAP_REVIEW_REQUIRED.name(),
+                    ExceptionSeverity.HIGH.name(),
+                    "산입 판단 검토 필요",
+                    "검토필요 귀속행 또는 준법경영비 증빙을 확인해야 합니다.",
+                    FgcErrorCode.CAP_002,
+                    Map.of()
             );
         }
+        if (check.getResultStatus() == CapResultStatus.VIOLATION) {
+            return new GateFailure(
+                    data, null, null, null, null,
+                    FgcErrorCode.CAP_001,
+                    Map.of("n", check.getUsagePct())
+            );
+        }
+        return null;
     }
 
     private CapCheckCommand buildCapCheck(
@@ -806,13 +954,13 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
         ));
     }
 
-    private void validateRuleConsistency(
+    private GateFailure ruleConsistencyFailure(
             CapRuleSnapshot rule,
             CapCalculationResult calculation,
             ConfirmationData data
     ) {
         if (!rule.capRuleSetId().equals(calculation.capRuleSetId())) {
-            rejectWithException(
+            return new GateFailure(
                     data,
                     "CAP_RULE_MISMATCH",
                     "HIGH",
@@ -822,15 +970,12 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                     Map.of()
             );
         }
+        return null;
     }
 
-    private CapRuleSnapshot requireCapRule(Long paymentId, ConfirmationData data) {
-        CapRuleSnapshot rule = mapper.findCapRuleSnapshot(
-                paymentId,
-                data.transactionAttributionId()
-        );
+    private GateFailure capRuleFailure(CapRuleSnapshot rule, ConfirmationData data) {
         if (rule == null) {
-            rejectWithException(
+            return new GateFailure(
                     data,
                     "POLICY_MISSING",
                     "HIGH",
@@ -842,7 +987,7 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
         }
         if (rule.ruleInclusionStatus() != data.inclusionDecisionStatus()
                 || rule.ruleInclusionStatus() == InclusionDecisionStatus.REVIEW_REQUIRED) {
-            rejectWithException(
+            return new GateFailure(
                     data,
                     "CAP_REVIEW_REQUIRED",
                     "HIGH",
@@ -852,20 +997,7 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                     Map.of()
             );
         }
-        return rule;
-    }
-
-    private void rejectWithException(
-            ConfirmationData data,
-            String exceptionType,
-            String severity,
-            String title,
-            String description,
-            FgcErrorCode errorCode,
-            Map<String, Object> params
-    ) {
-        saveException(data, exceptionType, severity, title, description);
-        throw new CommissionPaymentConfirmationRejectedException(errorCode, params);
+        return null;
     }
 
     private void saveException(
@@ -891,7 +1023,13 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
     }
 
     private List<ConfirmationData> requireConfirmationData(Long paymentId) {
-        List<ConfirmationData> data = mapper.findConfirmationDataForUpdate(paymentId);
+        return requireConfirmationData(paymentId, true);
+    }
+
+    private List<ConfirmationData> requireConfirmationData(Long paymentId, boolean forUpdate) {
+        List<ConfirmationData> data = forUpdate
+                ? mapper.findConfirmationDataForUpdate(paymentId)
+                : mapper.findConfirmationData(paymentId);
         if (data == null || data.isEmpty()) {
             invalid("paymentId", "지급 건을 찾을 수 없습니다.");
         }

--- a/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
@@ -211,9 +211,12 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
     public TransactionPrecheckResponse precheck(Long paymentId) {
         List<ConfirmationData> attributions = requireConfirmationData(paymentId, false);
         ConfirmationData first = attributions.get(0);
-        // 비DRAFT는 미리보기 대상 자체가 아니라 TRAN_005로 먼저 끊는다. confirm은 CAP_003 검사가
-        // 순서상 앞이지만 precheck에서 CAP_003은 던지지 않고 수집하는 사유라, 순서를 맞춰도
-        // 비DRAFT 응답은 409로 같다 — DRAFT 건에서는 두 경로의 게이트 판정이 동일하다.
+        // [의도된 차이] 비DRAFT는 미리보기 대상 자체가 아니라 TRAN_005(409)로 먼저 끊는다.
+        // 그래서 "비DRAFT + 미해결 CAP_VIOLATION" 엣지케이스는 confirm=CAP_003(422) / precheck=TRAN_005(409)로
+        // 갈리며, 이는 수용한다: precheck에서 CAP_003은 던지지 않고 blockers로 수집하는 사유라 검사 순서를
+        // confirm과 맞춰도 비DRAFT 응답은 409 그대로이고, 완전 일치의 유일한 방법(CAP_003을 422로 던지기)은
+        // IF-API-24의 "차단 사유는 200 + blockers[]" 계약을 깬다. "판정 일치" 원칙의 범위는 DRAFT 건의
+        // 게이트 판정이며, DRAFT 건에서는 두 경로가 같은 판정 메서드로 항상 같은 결과를 낸다.
         requireDraft(first);
 
         List<GateFailure> failures = new ArrayList<>();

--- a/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
@@ -293,12 +293,18 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
 
     private List<TransactionPrecheckResponse.Blocker> toBlockers(List<GateFailure> failures) {
         return failures.stream()
-                .map(failure -> new TransactionPrecheckResponse.Blocker(
-                        failure.errorCode().getCode(),
-                        messageResolver.resolve(failure.errorCode(), failure.params()),
-                        failure.data().contractId(),
-                        failure.data().transactionAttributionId()
-                ))
+                .map(failure -> {
+                    // CAP_003(미해결 위반)은 hasUnresolvedViolation의 지급 건 단위 판정이라 어느 귀속행이
+                    // 원인인지 알 수 없다 — 임의의 첫 귀속행 ID를 노출하면 사용자가 엉뚱한 예외 건을
+                    // 찾게 되므로 계약·귀속행 ID를 비운다
+                    boolean paymentLevel = failure.errorCode() == FgcErrorCode.CAP_003;
+                    return new TransactionPrecheckResponse.Blocker(
+                            failure.errorCode().getCode(),
+                            messageResolver.resolve(failure.errorCode(), failure.params()),
+                            paymentLevel ? null : failure.data().contractId(),
+                            paymentLevel ? null : failure.data().transactionAttributionId()
+                    );
+                })
                 .toList();
     }
 

--- a/src/main/resources/mapper/transaction/CommissionPaymentMapper.xml
+++ b/src/main/resources/mapper/transaction/CommissionPaymentMapper.xml
@@ -237,8 +237,8 @@
          ORDER BY ta.attribution_seq
     </select>
 
-    <select id="findConfirmationDataForUpdate"
-            resultType="com.susukkang.fgc.transaction.domain.ConfirmationData">
+    <!-- 2026-08-16 yslee - IF-API-24 사전검증(무잠금)과 확정(FOR UPDATE)이 같은 SELECT를 공유 -->
+    <sql id="confirmationDataSelect">
         SELECT ct.commission_transaction_id AS payment_id,
                ct.status,
                ct.amount,
@@ -280,7 +280,29 @@
             ON ta.commission_transaction_id = ct.commission_transaction_id
          WHERE ct.commission_transaction_id = #{paymentId}
          ORDER BY ta.attribution_seq
-         FOR UPDATE OF ct
+    </sql>
+
+    <select id="findConfirmationDataForUpdate"
+            resultType="com.susukkang.fgc.transaction.domain.ConfirmationData">
+        <include refid="confirmationDataSelect"/>
+        FOR UPDATE OF ct
+    </select>
+
+    <!-- IF-API-24 사전검증 전용 무잠금 조회 — 미리보기가 확정과 행 잠금을 다투지 않는다 -->
+    <select id="findConfirmationData"
+            resultType="com.susukkang.fgc.transaction.domain.ConfirmationData">
+        <include refid="confirmationDataSelect"/>
+    </select>
+
+    <!-- IF-API-24 capPreview 표시용 귀속 계약번호 조회 -->
+    <select id="findAttributedContractNumbers"
+            resultType="com.susukkang.fgc.transaction.domain.AttributedContractNo">
+        SELECT DISTINCT ta.contract_id,
+               c.contract_no
+          FROM fgc.transaction_attribution ta
+          JOIN fgc.insurance_contract c
+            ON c.contract_id = ta.contract_id
+         WHERE ta.commission_transaction_id = #{paymentId}
     </select>
 
     <!-- 2026-08-11 yslee - 동일 계약의 여러 DRAFT 확정을 계약 행 기준으로 직렬화 -->

--- a/src/test/java/com/susukkang/fgc/transaction/CommissionPaymentIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/CommissionPaymentIntegrationTest.java
@@ -14,6 +14,7 @@ import com.susukkang.fgc.transaction.dto.CommissionPaymentCreateRequest;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentAttributionRequest;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentResponse;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentUpdateRequest;
+import com.susukkang.fgc.transaction.dto.TransactionPrecheckResponse;
 import com.susukkang.fgc.transaction.service.CommissionPaymentService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -116,6 +118,73 @@ class CommissionPaymentIntegrationTest {
                  LIMIT 1
                 """, LocalDate.class, created.paymentId()))
                 .isEqualTo(LocalDate.of(2026, 7, 31));
+    }
+
+    // IF-API-24 (FGC-FUN-033) — 사전검증 미리보기는 호출 전후 DB 상태가 동일해야 한다
+    // (지급 건 상태·updated_at·cap_check·exception_case 무변화, 기록 생성은 확정 경로 전용)
+    @Test
+    void precheckLeavesDatabaseUntouched() {
+        CommissionPaymentResponse created = commissionPaymentService.create(request(
+                "IT-FUN033-" + UUID.randomUUID()
+        ));
+        OffsetDateTime updatedAtBefore = jdbcTemplate.queryForObject("""
+                SELECT updated_at
+                  FROM fgc.commission_transaction
+                 WHERE commission_transaction_id = ?
+                """, OffsetDateTime.class, created.paymentId());
+
+        TransactionPrecheckResponse response = commissionPaymentService.precheck(created.paymentId());
+
+        assertThat(response.confirmable()).isTrue();
+        assertThat(response.blockers()).isEmpty();
+        assertThat(response.capPreview()).isNotEmpty();
+        assertThat(response.capPreview().get(0).capCheckId()).isNull();
+        assertThat(jdbcTemplate.queryForObject("""
+                SELECT status
+                  FROM fgc.commission_transaction
+                 WHERE commission_transaction_id = ?
+                """, String.class, created.paymentId())).isEqualTo("DRAFT");
+        assertThat(jdbcTemplate.queryForObject("""
+                SELECT updated_at
+                  FROM fgc.commission_transaction
+                 WHERE commission_transaction_id = ?
+                """, OffsetDateTime.class, created.paymentId())).isEqualTo(updatedAtBefore);
+        assertThat(jdbcTemplate.queryForObject("""
+                SELECT COUNT(*)
+                  FROM fgc.cap_check
+                 WHERE candidate_transaction_id = ?
+                """, Integer.class, created.paymentId())).isZero();
+        assertThat(jdbcTemplate.queryForObject("""
+                SELECT COUNT(*)
+                  FROM fgc.exception_case
+                 WHERE exception_key LIKE 'PRE_CONFIRM:' || ? || ':%'
+                """, Integer.class, created.paymentId())).isZero();
+    }
+
+    // IF-API-24 완료 조건 — precheck의 판정과 같은 지급 건 confirm 판정이 일치한다
+    @Test
+    void precheckVerdictMatchesConfirmOnRealData() {
+        CommissionPaymentResponse created = commissionPaymentService.create(request(
+                "IT-FUN033-MATCH-" + UUID.randomUUID()
+        ));
+
+        TransactionPrecheckResponse preview = commissionPaymentService.precheck(created.paymentId());
+        CommissionPaymentResponse confirmed = commissionPaymentService.confirm(
+                created.paymentId(),
+                "IT-FUN033-CONFIRM-" + created.paymentId()
+        );
+
+        assertThat(preview.confirmable()).isTrue();
+        assertThat(confirmed.status()).isEqualTo(CommissionPaymentStatus.CONFIRMED);
+        BigDecimal confirmedUsagePct = jdbcTemplate.queryForObject("""
+                SELECT usage_pct
+                  FROM fgc.cap_check
+                 WHERE candidate_transaction_id = ?
+                 ORDER BY cap_check_id DESC
+                 LIMIT 1
+                """, BigDecimal.class, created.paymentId());
+        assertThat(preview.capPreview().get(0).usagePct())
+                .isEqualTo(confirmedUsagePct.toPlainString());
     }
 
     // 2026-08-11 yslee - 귀속행 입력 전 DRAFT의 PostgreSQL 저장·확정 경계 검증

--- a/src/test/java/com/susukkang/fgc/transaction/CommissionPaymentIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/CommissionPaymentIntegrationTest.java
@@ -154,10 +154,12 @@ class CommissionPaymentIntegrationTest {
                   FROM fgc.cap_check
                  WHERE candidate_transaction_id = ?
                 """, Integer.class, created.paymentId())).isZero();
+        // source_entity 기준 집계 — saveException·CapExceptionService 두 저장 경로를 모두 잡는다
         assertThat(jdbcTemplate.queryForObject("""
                 SELECT COUNT(*)
                   FROM fgc.exception_case
-                 WHERE exception_key LIKE 'PRE_CONFIRM:' || ? || ':%'
+                 WHERE source_entity_type = 'COMMISSION_TRANSACTION'
+                   AND source_entity_id = CAST(? AS varchar)
                 """, Integer.class, created.paymentId())).isZero();
     }
 

--- a/src/test/java/com/susukkang/fgc/transaction/controller/CommissionPaymentApiControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/controller/CommissionPaymentApiControllerTest.java
@@ -9,6 +9,8 @@ import com.susukkang.fgc.common.code.InclusionDecisionStatus;
 import com.susukkang.fgc.common.code.PaymentStage;
 import com.susukkang.fgc.common.config.SecurityConfig;
 import com.susukkang.fgc.common.exception.ConstraintErrorCodeResolver;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
 import com.susukkang.fgc.common.exception.FgcMessageResolver;
 import com.susukkang.fgc.common.exception.GlobalExceptionHandler;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentResponse;
@@ -200,6 +202,27 @@ class CommissionPaymentApiControllerTest {
                 .andExpect(jsonPath("$.data.capPreview[0].capCheckId")
                         .value(org.hamcrest.Matchers.nullValue()))
                 .andExpect(jsonPath("$.data.blockers[0].code").value("FGC-CAP-001"));
+    }
+
+    // IF-API-24 문서 계약 — 지급 건 없음 400(FGC-COMMON-002), 비DRAFT 409(FGC-TRAN-005)
+    @Test
+    void mapsPrecheckBusinessErrorsToDocumentedStatuses() throws Exception {
+        given(commissionPaymentService.precheck(404L))
+                .willThrow(new FgcBusinessException(FgcErrorCode.COMMON_002));
+        given(commissionPaymentService.precheck(409L))
+                .willThrow(new FgcBusinessException(FgcErrorCode.TRAN_005));
+
+        mockMvc.perform(post("/api/v1/transactions/404/precheck")
+                        .with(user("settlement01").roles("SETTLEMENT"))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("FGC-COMMON-002"));
+
+        mockMvc.perform(post("/api/v1/transactions/409/precheck")
+                        .with(user("settlement01").roles("SETTLEMENT"))
+                        .with(csrf()))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("FGC-TRAN-005"));
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/transaction/controller/CommissionPaymentApiControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/controller/CommissionPaymentApiControllerTest.java
@@ -2,6 +2,7 @@ package com.susukkang.fgc.transaction.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.susukkang.fgc.common.code.AttributionMethod;
+import com.susukkang.fgc.common.code.CapResultStatus;
 import com.susukkang.fgc.common.code.CommissionPaymentStatus;
 import com.susukkang.fgc.common.code.ExclusionType;
 import com.susukkang.fgc.common.code.InclusionDecisionStatus;
@@ -12,6 +13,7 @@ import com.susukkang.fgc.common.exception.FgcMessageResolver;
 import com.susukkang.fgc.common.exception.GlobalExceptionHandler;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentResponse;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentAttributionResponse;
+import com.susukkang.fgc.transaction.dto.TransactionPrecheckResponse;
 import com.susukkang.fgc.transaction.service.CommissionPaymentService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -178,6 +180,47 @@ class CommissionPaymentApiControllerTest {
                 .andExpect(jsonPath("$.data.capCheckIds[0]").value(55));
     }
 
+    // IF-API-24 (FGC-FUN-033) — 사전검증 미리보기는 차단 사유가 있어도 200 + blockers[]로 응답한다
+    @Test
+    void settlementRolePrechecksPayment() throws Exception {
+        given(commissionPaymentService.precheck(101L)).willReturn(precheckResponse());
+
+        mockMvc.perform(post("/api/v1/transactions/101/precheck")
+                        .with(user("settlement01").roles("SETTLEMENT"))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.paymentId").value(101))
+                .andExpect(jsonPath("$.data.confirmable").value(false))
+                // SIR-008 — 금액은 JSON 숫자, 사용률은 문자열, 코드에는 한글 라벨 동봉
+                .andExpect(jsonPath("$.data.capPreview[0].limitAmount").value(1200000))
+                .andExpect(jsonPath("$.data.capPreview[0].usagePct").value("108.333333"))
+                .andExpect(jsonPath("$.data.capPreview[0].paymentStageLabel")
+                        .value(PaymentStage.GA_TO_FC.label()))
+                // 저장하지 않으므로 capCheckId는 항상 null
+                .andExpect(jsonPath("$.data.capPreview[0].capCheckId")
+                        .value(org.hamcrest.Matchers.nullValue()))
+                .andExpect(jsonPath("$.data.blockers[0].code").value("FGC-CAP-001"));
+    }
+
+    @Test
+    void rejectsPrecheckWithoutCsrfToken() throws Exception {
+        mockMvc.perform(post("/api/v1/transactions/101/precheck")
+                        .with(user("settlement01").roles("SETTLEMENT")))
+                .andExpect(status().isForbidden());
+
+        verify(commissionPaymentService, never()).precheck(any());
+    }
+
+    // IF-API-24 완료 조건 — 비로그인은 401
+    @Test
+    void rejectsUnauthenticatedPrecheck() throws Exception {
+        mockMvc.perform(post("/api/v1/transactions/101/precheck")
+                        .with(csrf()))
+                .andExpect(status().isUnauthorized());
+
+        verify(commissionPaymentService, never()).precheck(any());
+    }
+
     @Test
     void rejectsNonSettlementRole() throws Exception {
         mockMvc.perform(post("/api/v1/transactions")
@@ -198,6 +241,11 @@ class CommissionPaymentApiControllerTest {
                 .andExpect(status().isForbidden());
 
         mockMvc.perform(post("/api/v1/transactions/101/confirm")
+                        .with(user("ga-admin").roles("GA_ADMIN"))
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/v1/transactions/101/precheck")
                         .with(user("ga-admin").roles("GA_ADMIN"))
                         .with(csrf()))
                 .andExpect(status().isForbidden());
@@ -224,6 +272,11 @@ class CommissionPaymentApiControllerTest {
                 .andExpect(status().isForbidden());
 
         mockMvc.perform(post("/api/v1/transactions/101/confirm")
+                        .with(user("comp01").roles("COMPLIANCE"))
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/v1/transactions/101/precheck")
                         .with(user("comp01").roles("COMPLIANCE"))
                         .with(csrf()))
                 .andExpect(status().isForbidden());
@@ -297,6 +350,39 @@ class CommissionPaymentApiControllerTest {
                 }
         );
         return objectMapper.writeValueAsString(values);
+    }
+
+    private TransactionPrecheckResponse precheckResponse() {
+        return new TransactionPrecheckResponse(
+                101L,
+                List.of(new TransactionPrecheckResponse.CapPreviewItem(
+                        3L,
+                        "CT-2026-0003",
+                        PaymentStage.GA_TO_FC,
+                        PaymentStage.GA_TO_FC.label(),
+                        LocalDate.of(2026, 7, 3),
+                        100000L,
+                        0L,
+                        0L,
+                        1200000L,
+                        0L,
+                        1300000L,
+                        1300000L,
+                        -100000L,
+                        "108.333333",
+                        CapResultStatus.VIOLATION,
+                        CapResultStatus.VIOLATION.label(),
+                        31L,
+                        null
+                )),
+                List.of(new TransactionPrecheckResponse.Blocker(
+                        "FGC-CAP-001",
+                        "지급 확정 불가 — 1,200% 한도 초과(사용률 108.333333%). 예외함에서 정정·감액·취소를 선택하세요.",
+                        3L,
+                        201L
+                )),
+                false
+        );
     }
 
     private CommissionPaymentResponse response(CommissionPaymentStatus status) {

--- a/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
@@ -1345,6 +1345,29 @@ class CommissionPaymentServiceImplTest {
         assertPrecheckSavesNothing();
     }
 
+    // 분류정책이 없는 귀속행은 FGC-CAP-002 blocker로 표시되고 preview 행·한도 계산은 생략된다
+    @Test
+    void precheckReportsMissingCapRuleAndSkipsPreview() {
+        ConfirmationData data = confirmation(
+                201L, 3L, "500000", "500000", InclusionDecisionStatus.INCLUDED,
+                ExclusionType.NONE, AttributionMethod.DIRECT, "EVIDENCE"
+        );
+        given(mapper.findConfirmationData(101L)).willReturn(List.of(data));
+        given(mapper.findAttributedContractNumbers(101L))
+                .willReturn(List.of(new AttributedContractNo(3L, "CT-2026-0003")));
+        given(mapper.findCapRuleSnapshot(101L, 201L)).willReturn(null);
+
+        TransactionPrecheckResponse response = service.precheck(101L);
+
+        assertThat(response.confirmable()).isFalse();
+        assertThat(response.blockers())
+                .extracting(TransactionPrecheckResponse.Blocker::code)
+                .containsExactly("FGC-CAP-002");
+        assertThat(response.capPreview()).isEmpty();
+        verify(capCalculator, never()).calculate(any());
+        assertPrecheckSavesNothing();
+    }
+
     @Test
     void precheckRejectsNonDraftPayment() {
         ConfirmationData confirmed = withStatus(confirmation(

--- a/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
@@ -77,6 +77,7 @@ class CommissionPaymentServiceImplTest {
     private CapExceptionService capExceptionService;
 
     private CommissionPaymentServiceImpl service;
+    private FgcMessageResolver messageResolver;
 
     @BeforeEach
     void setUp() {
@@ -85,13 +86,14 @@ class CommissionPaymentServiceImplTest {
         ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
         messageSource.setBasename("messages");
         messageSource.setDefaultEncoding("UTF-8");
+        messageResolver = new FgcMessageResolver(messageSource);
         service = new CommissionPaymentServiceImpl(
                 mapper,
                 new ObjectMapper(),
                 capValidator,
                 capCalculator,
                 capExceptionService,
-                new FgcMessageResolver(messageSource)
+                messageResolver
         );
     }
 
@@ -1274,9 +1276,13 @@ class CommissionPaymentServiceImplTest {
         TransactionPrecheckResponse preview = service.precheck(101L);
 
         assertThatThrownBy(() -> service.confirm(101L, null))
-                .isInstanceOfSatisfying(FgcBusinessException.class,
-                        exception -> assertThat(exception.getErrorCode().getCode())
-                                .isEqualTo(preview.blockers().get(0).code()));
+                .isInstanceOfSatisfying(FgcBusinessException.class, exception -> {
+                    assertThat(exception.getErrorCode().getCode())
+                            .isEqualTo(preview.blockers().get(0).code());
+                    // blocker 문구 == confirm 실패 응답이 렌더링할 문구 (같은 카탈로그·같은 파라미터)
+                    assertThat(messageResolver.resolve(exception.getErrorCode(), exception.getParams()))
+                            .isEqualTo(preview.blockers().get(0).message());
+                });
 
         ArgumentCaptor<CapCheckCommand> captor = ArgumentCaptor.forClass(CapCheckCommand.class);
         verify(mapper).insertCapCheck(captor.capture());
@@ -1284,7 +1290,7 @@ class CommissionPaymentServiceImplTest {
                 .isEqualTo(captor.getValue().getUsagePct().toPlainString());
     }
 
-    // 제31조 게이트 ② — 귀속행 없는 DRAFT는 FGC-TRAN-002 blocker로 표시된다
+    // FGC-FUN-033 · 제31조 게이트 ② — 귀속행 없는 DRAFT는 FGC-TRAN-002 blocker로 표시된다
     @Test
     void precheckReportsMissingAttributionBlocker() {
         given(mapper.findConfirmationData(101L)).willReturn(List.of(emptyDraftConfirmation()));
@@ -1300,7 +1306,7 @@ class CommissionPaymentServiceImplTest {
         assertPrecheckSavesNothing();
     }
 
-    // 제31조 게이트 ③·④ — 귀속합계 불일치와 REVIEW_REQUIRED 귀속을 한 번에 전부 수집한다 (fail-fast 아님)
+    // FGC-FUN-033 · 제31조 게이트 ③·④ — 귀속합계 불일치와 REVIEW_REQUIRED 귀속을 한 번에 전부 수집한다 (fail-fast 아님)
     @Test
     void precheckCollectsMultipleBlockers() {
         ConfirmationData data = withPaymentAmount(confirmation(
@@ -1324,7 +1330,7 @@ class CommissionPaymentServiceImplTest {
         assertPrecheckSavesNothing();
     }
 
-    // 미해결 CAP_VIOLATION 예외가 남아 있으면 FGC-CAP-003 blocker로 표시된다
+    // FGC-FUN-033·FGC-FUN-034 연계 — 미해결 CAP_VIOLATION 예외가 남아 있으면 FGC-CAP-003 blocker로 표시된다
     @Test
     void precheckReportsUnresolvedViolationBlocker() {
         ConfirmationData data = confirmation(
@@ -1354,7 +1360,7 @@ class CommissionPaymentServiceImplTest {
         assertPrecheckSavesNothing();
     }
 
-    // 분류정책이 없는 귀속행은 FGC-CAP-002 blocker로 표시되고 preview 행·한도 계산은 생략된다
+    // FGC-FUN-033 — 분류정책이 없는 귀속행은 FGC-CAP-002 blocker로 표시되고 preview 행·한도 계산은 생략된다
     @Test
     void precheckReportsMissingCapRuleAndSkipsPreview() {
         ConfirmationData data = confirmation(
@@ -1377,6 +1383,7 @@ class CommissionPaymentServiceImplTest {
         assertPrecheckSavesNothing();
     }
 
+    // IF-API-24 — 비DRAFT는 미리보기 대상이 아니라 FGC-TRAN-005(409)로 거부된다
     @Test
     void precheckRejectsNonDraftPayment() {
         ConfirmationData confirmed = withStatus(confirmation(
@@ -1392,6 +1399,7 @@ class CommissionPaymentServiceImplTest {
         assertPrecheckSavesNothing();
     }
 
+    // IF-API-24 — 미존재 지급 건은 FGC-COMMON-002(400), 이 경로에서도 아무것도 저장하지 않는다
     @Test
     void precheckRejectsUnknownPayment() {
         given(mapper.findConfirmationData(999L)).willReturn(List.of());
@@ -1400,6 +1408,44 @@ class CommissionPaymentServiceImplTest {
                 .isInstanceOfSatisfying(FgcBusinessException.class,
                         exception -> assertThat(exception.getErrorCode())
                                 .isEqualTo(FgcErrorCode.COMMON_002));
+        assertPrecheckSavesNothing();
+    }
+
+    // FGC-FUN-033 — 정책 드리프트: 귀속 스냅샷(INCLUDED)과 룰 현재 판정(EXCLUDED)이 어긋나면
+    // preview 판정은 검토필요로 강제되고 CAP-002 blocker가 수집된다 (게이지 "정상" 오인 방지 —
+    // confirm은 이 행에서 계산에 도달하지 못하므로 NORMAL 게이지는 확정 경로에 존재하지 않는 값)
+    @Test
+    void precheckForcesReviewRequiredWhenRuleDisagreesWithSnapshot() {
+        ConfirmationData data = confirmation(
+                201L, 3L, "500000", "500000", InclusionDecisionStatus.INCLUDED,
+                ExclusionType.NONE, AttributionMethod.DIRECT, "EVIDENCE"
+        );
+        given(mapper.findConfirmationData(101L)).willReturn(List.of(data));
+        given(mapper.findAttributedContractNumbers(101L))
+                .willReturn(List.of(new AttributedContractNo(3L, "CT-2026-0003")));
+        given(mapper.findCapRuleSnapshot(101L, 201L)).willReturn(new CapRuleSnapshot(
+                31L,
+                41L,
+                InclusionDecisionStatus.EXCLUDED,
+                "정책 변경으로 제외",
+                new BigDecimal("100000"),
+                new BigDecimal("12"),
+                new BigDecimal("90"),
+                BigDecimal.ZERO,
+                null
+        ));
+        given(capCalculator.calculate(any())).willReturn(capCalculation(3L));
+
+        TransactionPrecheckResponse response = service.precheck(101L);
+
+        assertThat(response.confirmable()).isFalse();
+        assertThat(response.blockers())
+                .extracting(TransactionPrecheckResponse.Blocker::code)
+                .containsExactly("FGC-CAP-002");
+        assertThat(response.capPreview()).hasSize(1);
+        assertThat(response.capPreview().get(0).resultStatus())
+                .isEqualTo(CapResultStatus.REVIEW_REQUIRED);
+        assertPrecheckSavesNothing();
     }
 
     /** precheck의 무저장·무잠금 계약 — 확정 경로 전용 부작용이 하나도 호출되지 않아야 한다. */

--- a/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
@@ -1316,9 +1316,11 @@ class CommissionPaymentServiceImplTest {
         TransactionPrecheckResponse response = service.precheck(101L);
 
         assertThat(response.confirmable()).isFalse();
+        // REVIEW_REQUIRED는 귀속행 상태·룰 불일치·병합 판정 세 게이트에서 재검출되지만
+        // 같은 사유는 blockers에 한 번만 나타나야 한다 (중복 접기)
         assertThat(response.blockers())
                 .extracting(TransactionPrecheckResponse.Blocker::code)
-                .contains("FGC-TRAN-003", "FGC-CAP-002");
+                .containsExactly("FGC-TRAN-003", "FGC-CAP-002");
         assertPrecheckSavesNothing();
     }
 

--- a/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
@@ -16,6 +16,8 @@ import com.susukkang.fgc.common.code.InclusionDecisionStatus;
 import com.susukkang.fgc.common.code.PaymentStage;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.exception.FgcMessageResolver;
+import com.susukkang.fgc.transaction.domain.AttributedContractNo;
 import com.susukkang.fgc.transaction.domain.CapCheckCommand;
 import com.susukkang.fgc.transaction.domain.CapRuleSnapshot;
 import com.susukkang.fgc.transaction.domain.CommissionItemReference;
@@ -29,6 +31,7 @@ import com.susukkang.fgc.transaction.dto.CommissionPaymentAttributionRequest;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentCreateRequest;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentResponse;
 import com.susukkang.fgc.transaction.dto.CommissionPaymentUpdateRequest;
+import com.susukkang.fgc.transaction.dto.TransactionPrecheckResponse;
 import com.susukkang.fgc.transaction.mapper.CommissionPaymentMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +39,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -77,12 +81,17 @@ class CommissionPaymentServiceImplTest {
     @BeforeEach
     void setUp() {
         CapValidator capValidator = new CapValidatorImpl();
+        // 실제 메시지 카탈로그를 사용해 precheck blockers 문구가 confirm 오류 문구와 같은지 검증한다
+        ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
+        messageSource.setBasename("messages");
+        messageSource.setDefaultEncoding("UTF-8");
         service = new CommissionPaymentServiceImpl(
                 mapper,
                 new ObjectMapper(),
                 capValidator,
                 capCalculator,
-                capExceptionService
+                capExceptionService,
+                new FgcMessageResolver(messageSource)
         );
     }
 
@@ -1180,6 +1189,222 @@ class CommissionPaymentServiceImplTest {
                 "DIRECT",
                 "EVIDENCE",
                 method
+        );
+    }
+
+    /*
+     * IF-API-24 (FGC-FUN-033) — 지급 전 한도 사전검증 미리보기.
+     * precheck는 confirm과 같은 판정 메서드를 재사용하되 아무것도 저장하지 않는다.
+     */
+
+    @Test
+    void precheckPassesCleanDraftWithoutSaving() {
+        ConfirmationData data = confirmation(
+                201L, 3L, "500000", "500000", InclusionDecisionStatus.INCLUDED,
+                ExclusionType.NONE, AttributionMethod.DIRECT, "EVIDENCE"
+        );
+        given(mapper.findConfirmationData(101L)).willReturn(List.of(data));
+        given(mapper.findAttributedContractNumbers(101L))
+                .willReturn(List.of(new AttributedContractNo(3L, "CT-2026-0003")));
+        given(mapper.findCapRuleSnapshot(101L, 201L)).willReturn(capRule("0", null));
+        given(capCalculator.calculate(any())).willReturn(capCalculation(3L));
+
+        TransactionPrecheckResponse response = service.precheck(101L);
+
+        assertThat(response.confirmable()).isTrue();
+        assertThat(response.blockers()).isEmpty();
+        assertThat(response.capPreview()).hasSize(1);
+        TransactionPrecheckResponse.CapPreviewItem item = response.capPreview().get(0);
+        assertThat(item.contractNo()).isEqualTo("CT-2026-0003");
+        assertThat(item.paymentStage()).isEqualTo(PaymentStage.GA_TO_FC);
+        assertThat(item.limitAmount()).isEqualTo(1200000L);
+        assertThat(item.existingIncludedAmount()).isZero();
+        assertThat(item.candidateAmount()).isEqualTo(500000L);
+        assertThat(item.includedAmount()).isEqualTo(500000L);
+        assertThat(item.remainingAmount()).isEqualTo(700000L);
+        assertThat(item.usagePct()).isEqualTo("41.666667");
+        assertThat(item.resultStatus()).isEqualTo(CapResultStatus.NORMAL);
+        assertThat(item.capCheckId()).isNull();
+        assertPrecheckSavesNothing();
+    }
+
+    // REG-08 — 한도 초과 건은 blockers에 FGC-CAP-001과 사용률이 포함되고, 그래도 아무것도 저장하지 않는다
+    @Test
+    void precheckReportsCapExceededWithoutSaving() {
+        ConfirmationData data = confirmation(
+                201L, 3L, "1300000", "1300000", InclusionDecisionStatus.INCLUDED,
+                ExclusionType.NONE, AttributionMethod.DIRECT, "EVIDENCE"
+        );
+        given(mapper.findConfirmationData(101L)).willReturn(List.of(data));
+        given(mapper.findAttributedContractNumbers(101L))
+                .willReturn(List.of(new AttributedContractNo(3L, "CT-2026-0003")));
+        given(mapper.findCapRuleSnapshot(101L, 201L)).willReturn(capRule("0", null));
+        given(capCalculator.calculate(any())).willReturn(capCalculation(3L));
+
+        TransactionPrecheckResponse response = service.precheck(101L);
+
+        assertThat(response.confirmable()).isFalse();
+        assertThat(response.blockers()).hasSize(1);
+        assertThat(response.blockers().get(0).code()).isEqualTo("FGC-CAP-001");
+        assertThat(response.blockers().get(0).message()).contains("108.333333");
+        assertThat(response.capPreview()).hasSize(1);
+        assertThat(response.capPreview().get(0).resultStatus()).isEqualTo(CapResultStatus.VIOLATION);
+        assertThat(response.capPreview().get(0).usagePct()).isEqualTo("108.333333");
+        assertPrecheckSavesNothing();
+    }
+
+    // 같은 지급 건에 대해 precheck의 판정과 confirm의 차단 판정이 일치해야 한다 (FGC-FUN-033 완료 조건)
+    @Test
+    void precheckVerdictMatchesConfirmRejection() {
+        ConfirmationData data = confirmation(
+                201L, 3L, "1300000", "1300000", InclusionDecisionStatus.INCLUDED,
+                ExclusionType.NONE, AttributionMethod.DIRECT, "EVIDENCE"
+        );
+        given(mapper.findConfirmationData(101L)).willReturn(List.of(data));
+        given(mapper.findConfirmationDataForUpdate(101L)).willReturn(List.of(data));
+        given(mapper.findAttributedContractNumbers(101L))
+                .willReturn(List.of(new AttributedContractNo(3L, "CT-2026-0003")));
+        given(mapper.findCapRuleSnapshot(101L, 201L)).willReturn(capRule("0", null));
+        given(capCalculator.calculate(any())).willReturn(capCalculation(3L));
+        doAnswer(invocation -> {
+            invocation.<CapCheckCommand>getArgument(0).setCapCheckId(56L);
+            return null;
+        }).when(mapper).insertCapCheck(any());
+
+        TransactionPrecheckResponse preview = service.precheck(101L);
+
+        assertThatThrownBy(() -> service.confirm(101L, null))
+                .isInstanceOfSatisfying(FgcBusinessException.class,
+                        exception -> assertThat(exception.getErrorCode().getCode())
+                                .isEqualTo(preview.blockers().get(0).code()));
+
+        ArgumentCaptor<CapCheckCommand> captor = ArgumentCaptor.forClass(CapCheckCommand.class);
+        verify(mapper).insertCapCheck(captor.capture());
+        assertThat(preview.capPreview().get(0).usagePct())
+                .isEqualTo(captor.getValue().getUsagePct().toPlainString());
+    }
+
+    // 제31조 게이트 ② — 귀속행 없는 DRAFT는 FGC-TRAN-002 blocker로 표시된다
+    @Test
+    void precheckReportsMissingAttributionBlocker() {
+        given(mapper.findConfirmationData(101L)).willReturn(List.of(emptyDraftConfirmation()));
+
+        TransactionPrecheckResponse response = service.precheck(101L);
+
+        assertThat(response.confirmable()).isFalse();
+        assertThat(response.blockers())
+                .extracting(TransactionPrecheckResponse.Blocker::code)
+                .containsExactly("FGC-TRAN-002");
+        assertThat(response.capPreview()).isEmpty();
+        verify(capCalculator, never()).calculate(any());
+        assertPrecheckSavesNothing();
+    }
+
+    // 제31조 게이트 ③·④ — 귀속합계 불일치와 REVIEW_REQUIRED 귀속을 한 번에 전부 수집한다 (fail-fast 아님)
+    @Test
+    void precheckCollectsMultipleBlockers() {
+        ConfirmationData data = withPaymentAmount(confirmation(
+                201L, 3L, "400000", "400000", InclusionDecisionStatus.REVIEW_REQUIRED,
+                ExclusionType.NONE, AttributionMethod.MANUAL_REVIEW, "EVIDENCE"
+        ), "500000");
+        given(mapper.findConfirmationData(101L)).willReturn(List.of(data));
+        given(mapper.findAttributedContractNumbers(101L))
+                .willReturn(List.of(new AttributedContractNo(3L, "CT-2026-0003")));
+        given(mapper.findCapRuleSnapshot(101L, 201L)).willReturn(capRule("0", null));
+        given(capCalculator.calculate(any())).willReturn(capCalculation(3L));
+
+        TransactionPrecheckResponse response = service.precheck(101L);
+
+        assertThat(response.confirmable()).isFalse();
+        assertThat(response.blockers())
+                .extracting(TransactionPrecheckResponse.Blocker::code)
+                .contains("FGC-TRAN-003", "FGC-CAP-002");
+        assertPrecheckSavesNothing();
+    }
+
+    // 미해결 CAP_VIOLATION 예외가 남아 있으면 FGC-CAP-003 blocker로 표시된다
+    @Test
+    void precheckReportsUnresolvedViolationBlocker() {
+        ConfirmationData data = confirmation(
+                201L, 3L, "500000", "500000", InclusionDecisionStatus.INCLUDED,
+                ExclusionType.NONE, AttributionMethod.DIRECT, "EVIDENCE"
+        );
+        given(mapper.findConfirmationData(101L)).willReturn(List.of(data));
+        given(capExceptionService.hasUnresolvedViolation(101L)).willReturn(true);
+        given(mapper.findAttributedContractNumbers(101L))
+                .willReturn(List.of(new AttributedContractNo(3L, "CT-2026-0003")));
+        given(mapper.findCapRuleSnapshot(101L, 201L)).willReturn(capRule("0", null));
+        given(capCalculator.calculate(any())).willReturn(capCalculation(3L));
+
+        TransactionPrecheckResponse response = service.precheck(101L);
+
+        assertThat(response.confirmable()).isFalse();
+        assertThat(response.blockers())
+                .extracting(TransactionPrecheckResponse.Blocker::code)
+                .contains("FGC-CAP-003");
+        assertPrecheckSavesNothing();
+    }
+
+    @Test
+    void precheckRejectsNonDraftPayment() {
+        ConfirmationData confirmed = withStatus(confirmation(
+                201L, 3L, "500000", "500000", InclusionDecisionStatus.INCLUDED,
+                ExclusionType.NONE, AttributionMethod.DIRECT, "EVIDENCE"
+        ), CommissionPaymentStatus.CONFIRMED);
+        given(mapper.findConfirmationData(101L)).willReturn(List.of(confirmed));
+
+        assertThatThrownBy(() -> service.precheck(101L))
+                .isInstanceOfSatisfying(FgcBusinessException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(FgcErrorCode.TRAN_005));
+        assertPrecheckSavesNothing();
+    }
+
+    @Test
+    void precheckRejectsUnknownPayment() {
+        given(mapper.findConfirmationData(999L)).willReturn(List.of());
+
+        assertThatThrownBy(() -> service.precheck(999L))
+                .isInstanceOfSatisfying(FgcBusinessException.class,
+                        exception -> assertThat(exception.getErrorCode())
+                                .isEqualTo(FgcErrorCode.COMMON_002));
+    }
+
+    /** precheck의 무저장·무잠금 계약 — 확정 경로 전용 부작용이 하나도 호출되지 않아야 한다. */
+    private void assertPrecheckSavesNothing() {
+        verify(mapper, never()).insertCapCheck(any());
+        verify(mapper, never()).insertCapCheckDetail(any());
+        verify(mapper, never()).insertExceptionCase(any());
+        verify(mapper, never()).confirm(any(), any(), any());
+        verify(mapper, never()).lockAttributedContracts(any());
+        verify(mapper, never()).findConfirmationDataForUpdate(any());
+        verify(capExceptionService, never()).createIfNecessary(any());
+    }
+
+    private ConfirmationData withPaymentAmount(ConfirmationData data, String paymentAmount) {
+        return new ConfirmationData(
+                data.paymentId(),
+                data.status(),
+                new BigDecimal(paymentAmount),
+                data.attributedAmount(),
+                data.totalAttributedAmount(),
+                data.confirmIdempotencyKey(),
+                data.attributionDate(),
+                data.attributionMonth(),
+                data.transactionAttributionId(),
+                data.contractId(),
+                data.agentId(),
+                data.paymentStage(),
+                data.commissionItemId(),
+                data.itemCode(),
+                data.itemName(),
+                data.policyVersionId(),
+                data.inclusionDecisionStatus(),
+                data.exclusionType(),
+                data.inclusionDecisionReason(),
+                data.allocationBasis(),
+                data.evidenceRef(),
+                data.attributionMethod()
         );
     }
 

--- a/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
@@ -1342,6 +1342,13 @@ class CommissionPaymentServiceImplTest {
         assertThat(response.blockers())
                 .extracting(TransactionPrecheckResponse.Blocker::code)
                 .contains("FGC-CAP-003");
+        // 지급 건 단위 판정이라 특정 계약·귀속행을 가리키면 안 된다 (엉뚱한 예외 건 안내 방지)
+        TransactionPrecheckResponse.Blocker violation = response.blockers().stream()
+                .filter(blocker -> "FGC-CAP-003".equals(blocker.code()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(violation.contractId()).isNull();
+        assertThat(violation.transactionAttributionId()).isNull();
         assertPrecheckSavesNothing();
     }
 


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* TRAN-W02 [사전검증] 버튼이 호출하는 미리보기 API(IF-API-24) `POST /api/v1/transactions/{id}/precheck` 구현 (FGC-FUN-033 잔여 범위)
* 저장·상태 변경 없이 확정 게이트를 미리 계산해 `capPreview[]`(계약×지급단계별 1,200% 게이지)와 `blockers[]`(확정 차단 사유)를 반환

## 🔗 2. 관련 이슈

* Closes #133

## 🛠 3. 구현 내용

* **판정 추출 리팩터링 (동작 불변)**: `confirm()`의 제31조 게이트 검사(귀속행 0건 TRAN-002 / 합계 불일치 TRAN-003 / REVIEW_REQUIRED CAP-002 / 1,200% 초과 CAP-001 / 미해결 위반 CAP-003 / 증빙·정책 누락 TRAN-004 등)를 `GateFailure` 반환형 순수 메서드로 추출. confirm은 `failFirst()`로 기존과 동일하게 첫 실패에서 예외 이력 저장 후 차단, precheck는 같은 메서드 결과를 저장 없이 전부 수집 — **미리보기와 확정 판정이 같은 코드에서 나와 항상 일치**
* **precheck 서비스**: `@Transactional(readOnly = true)`, 기존 `CapCalculator`의 REALTIME 경로(`CapCalculationCommand.realtime`, validationRunId 없음) 재사용. `cap_check`·`cap_check_detail`·`exception_case` 미생성, `CapExceptionService.createIfNecessary` 미호출, 행 잠금 없음 (`findConfirmationDataForUpdate`의 SELECT를 `<sql>` 프래그먼트로 공유하는 무잠금 `findConfirmationData` 신설)
* **응답 규약**: 차단 사유가 있어도 200 + `blockers[]` (3장 오류 카탈로그의 CAP-001 등 발생 API는 IF-API-25뿐). blockers 문구는 `FgcMessageResolver` 재사용으로 부록 A 표준 문구·confirm 오류 응답과 동일. 전제 실패만 예외: 지급 건 없음 400(FGC-COMMON-002), 비DRAFT 409(FGC-TRAN-005)
* **capPreview**: SIR-008 표시 형식 — 금액은 원 단위 정수, 사용률은 문자열 6자리, 지급단계·판정은 코드+한글 라벨. 저장하지 않으므로 `capCheckId`는 항상 null
* **범위 제외**: 관리자 강제 통과 경로 없음(COR 하드 제약), TRAN-W02 화면 JS 연동은 기존 주석대로 별도(IF-API-22~25 일괄 연동 시), 2027·2029 분급 룰셋 게이트는 2차(FUN-037·038)
* 관련 결함(#37 #38 #39 #68)은 동일 엔진 공유 설계라 해당 버그 수정 시 미리보기 결과도 자동 교정됨

## 🧪 4. 테스트 방법

1. `./gradlew test` — 전체 통과 (기존 확정 차단 테스트 무수정 유지 = 리팩터링 동작 불변 검증)
2. 서비스 단위: `precheck*` 8건 — 판정 일치(`precheckVerdictMatchesConfirmRejection`: 같은 데이터로 precheck blocker 코드 == confirm 차단 코드, 사용률 값 일치), 무저장(`assertPrecheckSavesNothing`: insertCapCheck·insertExceptionCase·confirm·lockAttributedContracts 등 never), 사유별 blocker(귀속 0건·합계 불일치·REVIEW_REQUIRED·한도 초과·미해결 위반·복수 수집), 비DRAFT 409·미존재 400
3. 컨트롤러: 200 직렬화(금액 숫자·사용률 문자열·capCheckId null), 401 비로그인, CSRF 누락 403, GA_ADMIN·COMPLIANCE 403
4. 통합(PostgreSQL): precheck 전후 `commission_transaction.status`·`updated_at`·`cap_check`·`exception_case` 무변화, 실데이터 precheck↔confirm 사용률 일치

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* `CommissionPaymentServiceImpl`의 게이트 추출이 기존 confirm 동작(예외 저장 순서·오류 코드·메시지 파라미터)과 완전히 동일한지
* precheck 경로에 부작용 호출이 정말 없는지 (`insertCapCheck`/`insertExceptionCase`/`createIfNecessary`/`lockAttributedContracts`/`findConfirmationDataForUpdate` 미호출)

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음 (TRAN-W02 `#btn-precheck` JS 연동은 화면 일괄 연동 시 별도 작업)

## 💬 9. 참고 사항

* 이슈의 미결 결정은 다음으로 확정: `blockers[]` = 제31조 전체 게이트 + confirm이 던지는 모든 차단 사유(CAP-003·TRAN-004·CAP-002 계열 포함), `capPreview` 단위 = 귀속 계약×지급단계, `capCheckId` = null(미저장)
* 목업의 "계산근거 보기(capCheckId 링크)"는 precheck 결과에선 대상이 없으므로 화면 연동 시 비활성 처리 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 지급 확정 전에 한도·정책·귀속 정보를 확인하는 사전검증 API를 추가했습니다.
  - 확정 가능 여부, 한도 미리보기, 모든 차단 사유를 제공합니다.
  - 차단 사유가 있어도 검증 결과를 정상 응답으로 확인할 수 있습니다.
- **개선**
  - 사전검증은 지급 상태나 데이터를 변경하지 않고 수행됩니다.
  - 지급 확정 시 사전검증과 일관된 차단 결과를 적용합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->