### PR TITLE
[Feat] FUN-006 보험회사 기준정보 조회·선택 API 개발

### DIFF
--- a/src/main/java/com/susukkang/fgc/base/code/InsurerType.java
+++ b/src/main/java/com/susukkang/fgc/base/code/InsurerType.java
@@ -1,0 +1,16 @@
+package com.susukkang.fgc.base.code;
+
+/**
+ * 보험회사(원수사) 유형. fgc.insurer.insurer_type CHECK 제약조건의 값과 일치해야 한다.
+ */
+public enum InsurerType {
+    LIFE,
+    NON_LIFE;
+
+    public String label() {
+        return switch (this) {
+            case LIFE -> "생명보험";
+            case NON_LIFE -> "손해보험";
+        };
+    }
+}

--- a/src/main/java/com/susukkang/fgc/base/controller/InsurerController.java
+++ b/src/main/java/com/susukkang/fgc/base/controller/InsurerController.java
@@ -1,0 +1,46 @@
+package com.susukkang.fgc.base.controller;
+
+import com.susukkang.fgc.base.dto.InsurerResponse;
+import com.susukkang.fgc.base.service.InsurerService;
+import com.susukkang.fgc.common.security.Roles;
+import com.susukkang.fgc.common.web.ApiResponse;
+import com.susukkang.fgc.common.web.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "기준정보", description = "FGC 기준정보 조회 API")
+@RestController
+@RequestMapping("/api/v1/base/insurers")
+@RequiredArgsConstructor
+public class InsurerController {
+
+    private final InsurerService insurerService;
+
+    @Operation(
+            summary = "보험회사(원수사) 기준정보 조회·선택",
+            description = "보험회사를 코드 또는 이름으로 검색합니다. "
+                    + "사용중지된 보험회사도 반환되며 activeYn=false인 항목은 신규 입력에서 선택할 수 없습니다."
+    )
+    @GetMapping
+    @PreAuthorize(Roles.ANY_ROLE)
+    public ApiResponse<PageResponse<InsurerResponse>> search(
+            @Parameter(description = "보험회사 코드 또는 보험회사명 검색어")
+            @RequestParam(required = false)
+            String keyword,
+            @Parameter(description = "페이지(1-base)", example = "1")
+            @RequestParam(defaultValue = "1")
+            int page,
+            @Parameter(description = "페이지 크기(최대 100)", example = "20")
+            @RequestParam(defaultValue = "20")
+            int size
+    ) {
+        return ApiResponse.success(insurerService.search(keyword, page, size));
+    }
+}

--- a/src/main/java/com/susukkang/fgc/base/dto/InsurerResponse.java
+++ b/src/main/java/com/susukkang/fgc/base/dto/InsurerResponse.java
@@ -1,0 +1,32 @@
+package com.susukkang.fgc.base.dto;
+
+import com.susukkang.fgc.base.code.InsurerType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "보험회사(원수사) 기준정보")
+public record InsurerResponse(
+        @Schema(description = "보험회사 ID", example = "1")
+        Long insurerId,
+        @Schema(description = "보험회사 코드", example = "FGL01")
+        String insurerCode,
+        @Schema(description = "보험회사명", example = "미래가상생명")
+        String insurerName,
+        @Schema(description = "보험회사 유형 코드", allowableValues = {"LIFE", "NON_LIFE"})
+        String insurerType,
+        @Schema(description = "보험회사 유형 한글명", example = "생명보험")
+        String insurerTypeLabel,
+        @Schema(description = "활성 여부. false인 보험회사는 조회되지만 신규 입력에서 선택할 수 없음", example = "true")
+        boolean activeYn
+) {
+    public static InsurerResponse from(InsurerRow row) {
+        InsurerType type = InsurerType.valueOf(row.insurerType());
+        return new InsurerResponse(
+                row.insurerId(),
+                row.insurerCode(),
+                row.insurerName(),
+                type.name(),
+                type.label(),
+                row.activeYn()
+        );
+    }
+}

--- a/src/main/java/com/susukkang/fgc/base/dto/InsurerRow.java
+++ b/src/main/java/com/susukkang/fgc/base/dto/InsurerRow.java
@@ -1,0 +1,13 @@
+package com.susukkang.fgc.base.dto;
+
+/**
+ * 보험회사 조회 SQL 결과를 서비스 계층으로 전달하는 내부 프로젝션이다.
+ */
+public record InsurerRow(
+        Long insurerId,
+        String insurerCode,
+        String insurerName,
+        String insurerType,
+        boolean activeYn
+) {
+}

--- a/src/main/java/com/susukkang/fgc/base/mapper/InsurerMapper.java
+++ b/src/main/java/com/susukkang/fgc/base/mapper/InsurerMapper.java
@@ -1,0 +1,19 @@
+package com.susukkang.fgc.base.mapper;
+
+import com.susukkang.fgc.base.dto.InsurerRow;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface InsurerMapper {
+
+    List<InsurerRow> selectInsurers(
+            @Param("keyword") String keyword,
+            @Param("offset") int offset,
+            @Param("limit") int limit
+    );
+
+    long countInsurers(@Param("keyword") String keyword);
+}

--- a/src/main/java/com/susukkang/fgc/base/service/InsurerService.java
+++ b/src/main/java/com/susukkang/fgc/base/service/InsurerService.java
@@ -1,0 +1,9 @@
+package com.susukkang.fgc.base.service;
+
+import com.susukkang.fgc.base.dto.InsurerResponse;
+import com.susukkang.fgc.common.web.PageResponse;
+
+public interface InsurerService {
+
+    PageResponse<InsurerResponse> search(String keyword, int page, int size);
+}

--- a/src/main/java/com/susukkang/fgc/base/service/InsurerServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/base/service/InsurerServiceImpl.java
@@ -1,0 +1,73 @@
+package com.susukkang.fgc.base.service;
+
+import com.susukkang.fgc.base.dto.InsurerResponse;
+import com.susukkang.fgc.base.mapper.InsurerMapper;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.web.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class InsurerServiceImpl implements InsurerService {
+
+    private static final int MIN_PAGE = 1;
+    private static final int MIN_SIZE = 1;
+    private static final int MAX_SIZE = 100;
+    private static final String SORT = "insurerCode,asc";
+
+    private final InsurerMapper insurerMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<InsurerResponse> search(String keyword, int page, int size) {
+        validatePaging(page, size);
+
+        String normalizedKeyword = normalizeKeyword(keyword);
+
+        long offsetLong = (long) (page - 1) * size;
+        if (offsetLong > Integer.MAX_VALUE) {
+            throw validationException("page");
+        }
+        int offset = (int) offsetLong;
+
+        List<InsurerResponse> content = insurerMapper
+                .selectInsurers(normalizedKeyword, offset, size)
+                .stream()
+                .map(InsurerResponse::from)
+                .toList();
+        long totalElements = insurerMapper.countInsurers(normalizedKeyword);
+
+        return PageResponse.of(content, page, size, totalElements, SORT);
+    }
+
+    private void validatePaging(int page, int size) {
+        if (page < MIN_PAGE) {
+            throw validationException("page");
+        }
+        if (size < MIN_SIZE || size > MAX_SIZE) {
+            throw validationException("size");
+        }
+    }
+
+    private String normalizeKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+        return keyword.trim();
+    }
+
+    private FgcBusinessException validationException(String field) {
+        return new FgcBusinessException(
+                FgcErrorCode.COMMON_002,
+                field,
+                Map.of("field", field),
+                null
+        );
+    }
+}

--- a/src/main/resources/mapper/base/InsurerMapper.xml
+++ b/src/main/resources/mapper/base/InsurerMapper.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.susukkang.fgc.base.mapper.InsurerMapper">
+
+    <sql id="insurerSearchConditions">
+        1 = 1
+        <if test="keyword != null">
+            AND (
+                LOWER(i.insurer_code) LIKE CONCAT('%', LOWER(#{keyword}), '%')
+                OR LOWER(i.insurer_name) LIKE CONCAT('%', LOWER(#{keyword}), '%')
+            )
+        </if>
+    </sql>
+
+    <select id="selectInsurers"
+            resultType="com.susukkang.fgc.base.dto.InsurerRow">
+        SELECT i.insurer_id AS insurerId,
+               i.insurer_code AS insurerCode,
+               i.insurer_name AS insurerName,
+               i.insurer_type AS insurerType,
+               i.active_yn AS activeYn
+          FROM fgc.insurer i
+         WHERE <include refid="insurerSearchConditions"/>
+         ORDER BY i.insurer_code ASC
+         LIMIT #{limit}
+        OFFSET #{offset}
+    </select>
+
+    <select id="countInsurers" resultType="long">
+        SELECT COUNT(*)
+          FROM fgc.insurer i
+         WHERE <include refid="insurerSearchConditions"/>
+    </select>
+
+</mapper>

--- a/src/test/java/com/susukkang/fgc/base/controller/InsurerControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/base/controller/InsurerControllerTest.java
@@ -1,0 +1,155 @@
+package com.susukkang.fgc.base.controller;
+
+import com.susukkang.fgc.base.dto.InsurerResponse;
+import com.susukkang.fgc.base.service.InsurerService;
+import com.susukkang.fgc.common.config.SecurityConfig;
+import com.susukkang.fgc.common.exception.ConstraintErrorCodeResolver;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.exception.FgcMessageResolver;
+import com.susukkang.fgc.common.exception.GlobalExceptionHandler;
+import com.susukkang.fgc.common.web.PageResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(InsurerController.class)
+@Import({InsurerController.class, GlobalExceptionHandler.class, SecurityConfig.class})
+class InsurerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private InsurerService insurerService;
+
+    @MockitoBean
+    private FgcMessageResolver messageResolver;
+
+    @MockitoBean
+    private ConstraintErrorCodeResolver constraintErrorCodeResolver;
+
+    @Test
+    void returnsPagedInsurersWithDefaultPaging() throws Exception {
+        InsurerResponse insurer = new InsurerResponse(
+                1L,
+                "FGL01",
+                "미래가상생명",
+                "LIFE",
+                "생명보험",
+                true
+        );
+        given(insurerService.search("미래", 1, 20)).willReturn(
+                PageResponse.of(List.of(insurer), 1, 20, 1, "insurerCode,asc")
+        );
+
+        mockMvc.perform(get("/api/v1/base/insurers")
+                        .param("keyword", "미래")
+                        .with(user("settle01").roles("SETTLEMENT")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].insurerId").value(1))
+                .andExpect(jsonPath("$.data.content[0].insurerCode").value("FGL01"))
+                .andExpect(jsonPath("$.data.content[0].insurerName").value("미래가상생명"))
+                .andExpect(jsonPath("$.data.content[0].insurerType").value("LIFE"))
+                .andExpect(jsonPath("$.data.content[0].insurerTypeLabel").value("생명보험"))
+                .andExpect(jsonPath("$.data.content[0].activeYn").value(true))
+                .andExpect(jsonPath("$.data.page").value(1))
+                .andExpect(jsonPath("$.data.size").value(20))
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
+                .andExpect(jsonPath("$.data.sort").value("insurerCode,asc"))
+                .andExpect(jsonPath("$.error").isEmpty())
+                .andExpect(jsonPath("$.requestId", matchesPattern("^\\d{8}-[0-9a-f]{6}$")));
+
+        verify(insurerService).search("미래", 1, 20);
+    }
+
+    @Test
+    void includesInactiveInsurerWithActiveYnFalse() throws Exception {
+        InsurerResponse inactive = new InsurerResponse(
+                7L,
+                "FGN09",
+                "중지가상손해보험",
+                "NON_LIFE",
+                "손해보험",
+                false
+        );
+        given(insurerService.search(null, 1, 20)).willReturn(
+                PageResponse.of(List.of(inactive), 1, 20, 1, "insurerCode,asc")
+        );
+
+        mockMvc.perform(get("/api/v1/base/insurers")
+                        .with(user("settle01").roles("SETTLEMENT")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].insurerCode").value("FGN09"))
+                .andExpect(jsonPath("$.data.content[0].insurerTypeLabel").value("손해보험"))
+                .andExpect(jsonPath("$.data.content[0].activeYn").value(false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"SYSTEM_ADMIN", "GA_ADMIN", "SETTLEMENT", "COMPLIANCE"})
+    void allowsEveryAuthenticatedRole(String role) throws Exception {
+        given(insurerService.search(null, 2, 10)).willReturn(
+                PageResponse.of(List.of(), 2, 10, 0, "insurerCode,asc")
+        );
+
+        mockMvc.perform(get("/api/v1/base/insurers")
+                        .param("page", "2")
+                        .param("size", "10")
+                        .with(user("fgc-user").roles(role)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content").isEmpty());
+    }
+
+    @Test
+    void rejectsAuthenticatedUserWithoutAllowedRole() throws Exception {
+        mockMvc.perform(get("/api/v1/base/insurers")
+                        .with(user("other-user").roles("USER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0, 20, page", "1, 101, size"})
+    void rejectsInvalidPaging(int page, int size, String field) throws Exception {
+        given(insurerService.search(null, page, size)).willThrow(
+                new FgcBusinessException(
+                        FgcErrorCode.COMMON_002,
+                        field,
+                        Map.of("field", field),
+                        null
+                )
+        );
+
+        mockMvc.perform(get("/api/v1/base/insurers")
+                        .param("page", String.valueOf(page))
+                        .param("size", String.valueOf(size))
+                        .with(user("settle01").roles("SETTLEMENT")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("FGC-COMMON-002"))
+                .andExpect(jsonPath("$.error.field").value(field));
+    }
+
+    @Test
+    void requiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/base/insurers"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/susukkang/fgc/base/mapper/InsurerMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/base/mapper/InsurerMapperIntegrationTest.java
@@ -1,0 +1,102 @@
+package com.susukkang.fgc.base.mapper;
+
+import com.susukkang.fgc.base.dto.InsurerRow;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class InsurerMapperIntegrationTest {
+
+    @Autowired
+    private InsurerMapper insurerMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void includesInactiveInsurers() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String prefix = "INS-" + suffix;
+        insertInsurer(prefix + "-A", "테스트활성생명-" + suffix, "LIFE", true);
+        insertInsurer(prefix + "-I", "테스트중지손보-" + suffix, "NON_LIFE", false);
+
+        List<InsurerRow> rows = insurerMapper.selectInsurers(prefix, 0, 20);
+
+        assertThat(rows).extracting(InsurerRow::insurerCode)
+                .containsExactly(prefix + "-A", prefix + "-I");
+        assertThat(rows.get(0).activeYn()).isTrue();
+        assertThat(rows.get(1).activeYn()).isFalse();
+        assertThat(rows.get(1).insurerType()).isEqualTo("NON_LIFE");
+        assertThat(insurerMapper.countInsurers(prefix)).isEqualTo(2);
+    }
+
+    @Test
+    void searchesCodeOrNameCaseInsensitivelyAndAppliesStablePaging() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String prefix = "pg-" + suffix;
+        for (int index = 21; index >= 1; index--) {
+            insertInsurer(
+                    "%s-%02d".formatted(prefix, index),
+                    "보험회사 %02d".formatted(index),
+                    "LIFE",
+                    true
+            );
+        }
+
+        List<InsurerRow> secondPage = insurerMapper.selectInsurers(prefix.toUpperCase(), 20, 20);
+
+        assertThat(insurerMapper.countInsurers(prefix.toUpperCase())).isEqualTo(21);
+        assertThat(secondPage).singleElement()
+                .extracting(InsurerRow::insurerCode)
+                .isEqualTo(prefix + "-21");
+    }
+
+    @Test
+    void searchesByInsurerName() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String uniqueName = "가상테스트생명-" + suffix;
+        String code = "NM-" + suffix;
+        insertInsurer(code, uniqueName, "LIFE", true);
+
+        List<InsurerRow> rows = insurerMapper.selectInsurers("테스트생명-" + suffix, 0, 20);
+
+        assertThat(rows).singleElement()
+                .extracting(InsurerRow::insurerCode)
+                .isEqualTo(code);
+    }
+
+    @Test
+    void returnsEmptyListWhenNoMatch() {
+        String noMatchKeyword = "no-match-" + UUID.randomUUID();
+
+        assertThat(insurerMapper.selectInsurers(noMatchKeyword, 0, 20)).isEmpty();
+        assertThat(insurerMapper.countInsurers(noMatchKeyword)).isZero();
+    }
+
+    private long insertInsurer(String code, String name, String type, boolean activeYn) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.insurer (
+                    insurer_code,
+                    insurer_name,
+                    insurer_type,
+                    active_yn
+                ) VALUES (?, ?, ?, ?)
+                RETURNING insurer_id
+                """,
+                Long.class,
+                code,
+                name,
+                type,
+                activeYn
+        );
+    }
+}

--- a/src/test/java/com/susukkang/fgc/base/service/InsurerServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/base/service/InsurerServiceImplTest.java
@@ -1,0 +1,101 @@
+package com.susukkang.fgc.base.service;
+
+import com.susukkang.fgc.base.dto.InsurerResponse;
+import com.susukkang.fgc.base.dto.InsurerRow;
+import com.susukkang.fgc.base.mapper.InsurerMapper;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.web.PageResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InsurerServiceImplTest {
+
+    @Mock
+    private InsurerMapper insurerMapper;
+
+    private InsurerServiceImpl insurerService;
+
+    @BeforeEach
+    void setUp() {
+        insurerService = new InsurerServiceImpl(insurerMapper);
+    }
+
+    @Test
+    void trimsKeywordMapsLabelsAndBuildsPageResponse() {
+        InsurerRow row = new InsurerRow(1L, "FGL01", "미래가상생명", "LIFE", false);
+
+        when(insurerMapper.selectInsurers(anyString(), eq(20), eq(20)))
+                .thenReturn(List.of(row));
+        when(insurerMapper.countInsurers(anyString())).thenReturn(21L);
+
+        PageResponse<InsurerResponse> result = insurerService.search("  fgl  ", 2, 20);
+
+        verify(insurerMapper).selectInsurers(eq("fgl"), eq(20), eq(20));
+        verify(insurerMapper).countInsurers(eq("fgl"));
+        assertThat(result.page()).isEqualTo(2);
+        assertThat(result.size()).isEqualTo(20);
+        assertThat(result.totalElements()).isEqualTo(21);
+        assertThat(result.totalPages()).isEqualTo(2);
+        assertThat(result.sort()).isEqualTo("insurerCode,asc");
+        assertThat(result.content()).singleElement().satisfies(response -> {
+            assertThat(response.insurerCode()).isEqualTo("FGL01");
+            assertThat(response.insurerType()).isEqualTo("LIFE");
+            assertThat(response.insurerTypeLabel()).isEqualTo("생명보험");
+            assertThat(response.activeYn()).isFalse();
+        });
+    }
+
+    @Test
+    void convertsBlankKeywordToNull() {
+        when(insurerMapper.selectInsurers(isNull(), eq(0), eq(20)))
+                .thenReturn(List.of());
+        when(insurerMapper.countInsurers(isNull())).thenReturn(0L);
+
+        insurerService.search("   ", 1, 20);
+
+        verify(insurerMapper).selectInsurers(isNull(), eq(0), eq(20));
+        verify(insurerMapper).countInsurers(isNull());
+    }
+
+    @Test
+    void rejectsPageBelowOne() {
+        assertThatThrownBy(() -> insurerService.search(null, 0, 20))
+                .isInstanceOf(FgcBusinessException.class)
+                .extracting("field")
+                .isEqualTo("page");
+    }
+
+    @Test
+    void rejectsSizeOutsideOneToOneHundred() {
+        assertThatThrownBy(() -> insurerService.search(null, 1, 0))
+                .isInstanceOf(FgcBusinessException.class)
+                .extracting("field")
+                .isEqualTo("size");
+        assertThatThrownBy(() -> insurerService.search(null, 1, 101))
+                .isInstanceOf(FgcBusinessException.class)
+                .extracting("field")
+                .isEqualTo("size");
+    }
+
+    @Test
+    void rejectsPageWhenOffsetExceedsIntegerRange() {
+        assertThatThrownBy(() -> insurerService.search(null, Integer.MAX_VALUE, 100))
+                .isInstanceOf(FgcBusinessException.class)
+                .extracting("field")
+                .isEqualTo("page");
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* FGC-FUN-006 보험회사(원수사) 기준정보 조회 API(`GET /api/v1/base/insurers`, IF-API-05)를 추가했습니다. 조회 전용이며 등록·수정·삭제는 2차 범위로 구현하지 않았습니다.

## 🔗 2. 관련 이슈

* Closes #132

## 🛠 3. 구현 내용

* FUN-005 조직 조회 API(#91) 구조를 그대로 미러링: Controller → Service → MyBatis Mapper, `ApiResp 투, 공통 20행 서버페이징(page 기본 1, size 기본 20·최대 100).
* `keyword`로 보험사코드  검색합니다. 0건이면 200 + 빈 content를 반환합니다(인터페이스정의서 §2-3).
* 응답: `insurerId`, `in`insurerType`(LIFE/NON_LIFE), `insurerTypeLabel`(생명보험/손해보험 — §2-4
  "한글 라벨은 서버가 만든
* 사용중지 회사도 응답에 포함하되 `activeYn=false`로 구분합니다(인수조건
  "사용중지 회사는 신규 입-005 결정과 동일하게 별도 `selectableYn` 필드는 두지 않고 선택 불가 처리는 화면 몫입니다.
* `@PreAuthorize(Roles.A역할(SYSTEM_ADMIN·GA_ADMIN·SETTLEMENT·COMPLIANCE) 모두 조회 가능, 비로그인은
기존 SecurityConfig `/ap
* 화면정의서 :446 "막아야 할 것"에 따라 1,200% 산입 여부 관련 필드는 노출하지
  않습니다(산입 여부는 `ca
* `insurer` 테이블에는 적용기간 컬럼이 없어 FUN-005의 `asOf` 파라미터는
  없습니다. 검색조건이 `keCriteria record도 만들지않았습니다.
* 이 API는 BASE-W01 보험03 계약 등록, TRAN-W01검색 등) 드롭다운에서 공용으로 재사용합니다(화면정의서 "만들 때 주의").

## 🧪 4. 테스트 방법

1. `./gradlew test` —
   Controller(`InsurerContrerviceImplTest`)·Mapper통합(`InsurerMapperIntegrationTest`) 및 전체 테스트 통과 확인
2. 로컬 기동 후 로그인  urers` → 시드6개사(FGL01~04, FGN01~02) 반환 확인
3. `?keyword=생명` → 생 2건(대소문자 무시) 확인
4. 비로그인 상태에서 호출 → 401 확인, Swagger(`/swagger-ui.html`) "기준정보" 태그에 엔드포인트 노출

## 🗄️ 5. DB / Flyway 변

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* 인터페이스정의서 IF-API-05 응답 핵심에는 없는 `activeYn`을 응답에
  추가했습니다 — 요구사항  인수조건 충족을 위한의도적 추가입니다. 이 판단이 적절한지 확인 부탁드립니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디

## 🖼️ 8. 화면 변경

* 없음

## 💬 9. 참고 사항

* 시드 보험회사 6곳은 전케이스는 Mapper 통합테스트에서 직접 INSERT하여 검증했습니다.
* 페이징은 이슈 결정사항통 20행 서버 페이징을적용했습니다(시드 6건이라 실사용에선 1페이지에 전부 담깁니다).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 보험회사 기준정보를 조회하는 API를 추가했습니다.
  * 보험회사 코드·명칭으로 검색하고, 페이지 번호와 페이지 크기로 결과를 나눠볼 수 있습니다.
  * 보험회사 유형을 생명보험·손해보험으로 표시하며, 활성 상태와 전체 결과 건수를 제공합니다.
* **개선 사항**
  * 검색어의 대소문자를 구분하지 않도록 지원합니다.
  * 잘못된 페이징 요청과 인증·권한별 접근을 적절한 오류 응답으로 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->