### PR TITLE
[Feat] FUN-008 보험설계사 기준정보 조회·선택 API 개발

### DIFF
--- a/src/main/java/com/susukkang/fgc/base/controller/AgentController.java
+++ b/src/main/java/com/susukkang/fgc/base/controller/AgentController.java
@@ -1,0 +1,58 @@
+package com.susukkang.fgc.base.controller;
+
+import com.susukkang.fgc.base.dto.AgentResponse;
+import com.susukkang.fgc.base.dto.AgentSearchCriteria;
+import com.susukkang.fgc.base.service.AgentService;
+import com.susukkang.fgc.common.security.Roles;
+import com.susukkang.fgc.common.web.ApiResponse;
+import com.susukkang.fgc.common.web.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@Tag(name = "기준정보", description = "FGC 기준정보 조회 API")
+@RestController
+@RequestMapping("/api/v1/base/agents")
+@RequiredArgsConstructor
+public class AgentController {
+
+    private final AgentService agentService;
+
+    @Operation(
+            summary = "보험설계사 기준정보 조회·선택 (IF-API-07)",
+            description = "기준일에 위촉 상태가 유효한 설계사를 조직·코드·이름으로 검색합니다. "
+                    + "agentStatus와 activeYn은 신규 입력 선택 가능 여부를 판단할 때 사용합니다."
+    )
+    @GetMapping
+    @PreAuthorize(Roles.ANY_ROLE)
+    public ApiResponse<PageResponse<AgentResponse>> search(
+            @Parameter(description = "소속 조직 ID")
+            @RequestParam(required = false)
+            Long organizationId,
+            @Parameter(description = "설계사 코드 또는 이름 검색어")
+            @RequestParam(required = false)
+            String keyword,
+            @Parameter(description = "위촉 유효성 기준일(yyyy-MM-dd)", example = "2026-08-11", required = true)
+            @RequestParam
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate asOf,
+            @Parameter(description = "페이지(1-base)", example = "1")
+            @RequestParam(defaultValue = "1")
+            int page,
+            @Parameter(description = "페이지 크기(최대 100)", example = "20")
+            @RequestParam(defaultValue = "20")
+            int size
+    ) {
+        AgentSearchCriteria criteria = new AgentSearchCriteria(organizationId, keyword, asOf);
+        return ApiResponse.success(agentService.search(criteria, page, size));
+    }
+}

--- a/src/main/java/com/susukkang/fgc/base/dto/AgentResponse.java
+++ b/src/main/java/com/susukkang/fgc/base/dto/AgentResponse.java
@@ -1,0 +1,93 @@
+package com.susukkang.fgc.base.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+@Schema(description = "보험설계사 기준정보")
+public record AgentResponse(
+        @Schema(description = "설계사 ID", example = "101")
+        Long agentId,
+        @Schema(description = "설계사 코드", example = "FC-SEOUL-001")
+        String agentCode,
+        @Schema(description = "설계사명", example = "김설계")
+        String agentName,
+        @Schema(description = "직급 코드", example = "FC")
+        String rankCode,
+        @Schema(description = "직급 한글명", example = "설계사")
+        String rankLabel,
+        @Schema(description = "소속 조직 ID", example = "11")
+        Long organizationId,
+        @Schema(description = "소속 조직 코드", example = "FGC-BR-SEOUL")
+        String organizationCode,
+        @Schema(description = "소속 조직명", example = "서울지사")
+        String organizationName,
+        @Schema(description = "위촉일", example = "2026-05-01")
+        LocalDate appointmentDate,
+        @Schema(description = "해촉일", nullable = true)
+        LocalDate terminationDate,
+        @Schema(description = "설계사 상태 코드", allowableValues = {"ACTIVE", "INACTIVE", "TERMINATED"})
+        String agentStatus,
+        @Schema(description = "설계사 상태 한글명", example = "활동")
+        String agentStatusLabel,
+        @Schema(description = "최근 등록일", nullable = true)
+        LocalDate latestRegistrationDate,
+        @Schema(description = "최근 등록일 직전 3년 모집경력 여부", nullable = true)
+        Boolean priorThreeYearExperienceYn,
+        @Schema(description = "경력 조회 기준일", nullable = true)
+        LocalDate experienceCheckedOn,
+        @Schema(description = "신인활동지원 대상 여부")
+        boolean newcomerSupportEligibleYn,
+        @Schema(description = "신인활동지원 종료일", nullable = true)
+        LocalDate newcomerSupportEndDate,
+        @Schema(description = "기준정보 활성 여부. false이면 신규 입력에서 선택할 수 없음")
+        boolean activeYn
+) {
+    public static AgentResponse from(AgentRow row) {
+        return new AgentResponse(
+                row.agentId(),
+                row.agentCode(),
+                row.agentName(),
+                row.rankCode(),
+                rankLabel(row.rankCode()),
+                row.organizationId(),
+                row.organizationCode(),
+                row.organizationName(),
+                row.appointmentDate(),
+                row.terminationDate(),
+                row.agentStatus(),
+                statusLabel(row.agentStatus()),
+                row.latestRegistrationDate(),
+                row.priorThreeYearExperienceYn(),
+                row.experienceCheckedOn(),
+                row.newcomerSupportEligibleYn(),
+                row.newcomerSupportEndDate(),
+                row.activeYn()
+        );
+    }
+
+    private static String rankLabel(String rankCode) {
+        if (rankCode == null) {
+            return null;
+        }
+        return switch (rankCode) {
+            case "FC" -> "설계사";
+            case "TEAM_LEADER" -> "팀장";
+            case "BRANCH_MANAGER" -> "지점장";
+            case "DIVISION_HEAD" -> "본부장";
+            default -> rankCode;
+        };
+    }
+
+    private static String statusLabel(String agentStatus) {
+        if (agentStatus == null) {
+            return null;
+        }
+        return switch (agentStatus) {
+            case "ACTIVE" -> "활동";
+            case "INACTIVE" -> "비활동";
+            case "TERMINATED" -> "해촉";
+            default -> agentStatus;
+        };
+    }
+}

--- a/src/main/java/com/susukkang/fgc/base/dto/AgentRow.java
+++ b/src/main/java/com/susukkang/fgc/base/dto/AgentRow.java
@@ -1,0 +1,24 @@
+package com.susukkang.fgc.base.dto;
+
+import java.time.LocalDate;
+
+/** 설계사 조회 SQL 결과를 서비스 계층으로 전달하는 내부 프로젝션이다. */
+public record AgentRow(
+        Long agentId,
+        String agentCode,
+        String agentName,
+        String rankCode,
+        Long organizationId,
+        String organizationCode,
+        String organizationName,
+        LocalDate appointmentDate,
+        LocalDate terminationDate,
+        String agentStatus,
+        LocalDate latestRegistrationDate,
+        Boolean priorThreeYearExperienceYn,
+        LocalDate experienceCheckedOn,
+        boolean newcomerSupportEligibleYn,
+        LocalDate newcomerSupportEndDate,
+        boolean activeYn
+) {
+}

--- a/src/main/java/com/susukkang/fgc/base/dto/AgentSearchCriteria.java
+++ b/src/main/java/com/susukkang/fgc/base/dto/AgentSearchCriteria.java
@@ -1,0 +1,15 @@
+package com.susukkang.fgc.base.dto;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+/** IF-API-07 설계사 기준정보 조회 조건이다. */
+public record AgentSearchCriteria(
+        Long organizationId,
+        String keyword,
+        LocalDate asOf
+) {
+    public AgentSearchCriteria {
+        Objects.requireNonNull(asOf, "asOf는 null일 수 없습니다.");
+    }
+}

--- a/src/main/java/com/susukkang/fgc/base/mapper/AgentMapper.java
+++ b/src/main/java/com/susukkang/fgc/base/mapper/AgentMapper.java
@@ -1,10 +1,13 @@
 package com.susukkang.fgc.base.mapper;
 
+import com.susukkang.fgc.base.dto.AgentRow;
+import com.susukkang.fgc.base.dto.AgentSearchCriteria;
 import com.susukkang.fgc.common.code.AgentRankCode;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.time.LocalDate;
+import java.util.List;
 
 /**
  * 설명 : 설계사 기준정보 조회 Mapper
@@ -15,6 +18,14 @@ import java.time.LocalDate;
  */
 @Mapper
 public interface AgentMapper {
+
+    List<AgentRow> selectAgents(
+            @Param("criteria") AgentSearchCriteria criteria,
+            @Param("offset") int offset,
+            @Param("limit") int limit
+    );
+
+    long countAgents(@Param("criteria") AgentSearchCriteria criteria);
 
     /**
      * 설명 : 계약 소속 조직과 상위 조직에서 직급에 해당하는 활성 설계사 ID를 조회한다.

--- a/src/main/java/com/susukkang/fgc/base/service/AgentService.java
+++ b/src/main/java/com/susukkang/fgc/base/service/AgentService.java
@@ -1,0 +1,10 @@
+package com.susukkang.fgc.base.service;
+
+import com.susukkang.fgc.base.dto.AgentResponse;
+import com.susukkang.fgc.base.dto.AgentSearchCriteria;
+import com.susukkang.fgc.common.web.PageResponse;
+
+public interface AgentService {
+
+    PageResponse<AgentResponse> search(AgentSearchCriteria criteria, int page, int size);
+}

--- a/src/main/java/com/susukkang/fgc/base/service/AgentServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/base/service/AgentServiceImpl.java
@@ -1,0 +1,85 @@
+package com.susukkang.fgc.base.service;
+
+import com.susukkang.fgc.base.dto.AgentResponse;
+import com.susukkang.fgc.base.dto.AgentSearchCriteria;
+import com.susukkang.fgc.base.mapper.AgentMapper;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.web.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AgentServiceImpl implements AgentService {
+
+    private static final int MIN_PAGE = 1;
+    private static final int MIN_SIZE = 1;
+    private static final int MAX_SIZE = 100;
+    private static final String SORT = "agentCode,asc";
+
+    private final AgentMapper agentMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<AgentResponse> search(AgentSearchCriteria criteria, int page, int size) {
+        validateCriteria(criteria);
+        validatePaging(page, size);
+
+        AgentSearchCriteria normalizedCriteria = new AgentSearchCriteria(
+                criteria.organizationId(),
+                normalizeKeyword(criteria.keyword()),
+                criteria.asOf()
+        );
+
+        long offsetLong = (long) (page - 1) * size;
+        if (offsetLong > Integer.MAX_VALUE) {
+            throw validationException("page");
+        }
+        int offset = (int) offsetLong;
+
+        List<AgentResponse> content = agentMapper
+                .selectAgents(normalizedCriteria, offset, size)
+                .stream()
+                .map(AgentResponse::from)
+                .toList();
+        long totalElements = agentMapper.countAgents(normalizedCriteria);
+
+        return PageResponse.of(content, page, size, totalElements, SORT);
+    }
+
+    private void validateCriteria(AgentSearchCriteria criteria) {
+        if (criteria.organizationId() != null && criteria.organizationId() < 1) {
+            throw validationException("organizationId");
+        }
+    }
+
+    private void validatePaging(int page, int size) {
+        if (page < MIN_PAGE) {
+            throw validationException("page");
+        }
+        if (size < MIN_SIZE || size > MAX_SIZE) {
+            throw validationException("size");
+        }
+    }
+
+    private String normalizeKeyword(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+        return keyword.trim();
+    }
+
+    private FgcBusinessException validationException(String field) {
+        return new FgcBusinessException(
+                FgcErrorCode.COMMON_002,
+                field,
+                Map.of("field", field),
+                null
+        );
+    }
+}

--- a/src/main/resources/mapper/base/AgentMapper.xml
+++ b/src/main/resources/mapper/base/AgentMapper.xml
@@ -4,6 +4,53 @@
         "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.susukkang.fgc.base.mapper.AgentMapper">
+    <sql id="agentSearchConditions">
+        a.appointment_date &lt;= #{criteria.asOf}
+        AND (a.termination_date IS NULL OR a.termination_date &gt;= #{criteria.asOf})
+        <if test="criteria.organizationId != null">
+            AND a.organization_id = #{criteria.organizationId}
+        </if>
+        <if test="criteria.keyword != null">
+            AND (
+                LOWER(a.agent_code) LIKE CONCAT('%', LOWER(#{criteria.keyword}), '%')
+                OR LOWER(a.agent_name) LIKE CONCAT('%', LOWER(#{criteria.keyword}), '%')
+            )
+        </if>
+    </sql>
+
+    <select id="selectAgents"
+            resultType="com.susukkang.fgc.base.dto.AgentRow">
+        SELECT a.agent_id AS agentId,
+               a.agent_code AS agentCode,
+               a.agent_name AS agentName,
+               a.rank_code AS rankCode,
+               a.organization_id AS organizationId,
+               o.organization_code AS organizationCode,
+               o.organization_name AS organizationName,
+               a.appointment_date AS appointmentDate,
+               a.termination_date AS terminationDate,
+               a.agent_status AS agentStatus,
+               a.latest_registration_date AS latestRegistrationDate,
+               a.prior_three_year_experience_yn AS priorThreeYearExperienceYn,
+               a.experience_checked_on AS experienceCheckedOn,
+               a.newcomer_support_eligible_yn AS newcomerSupportEligibleYn,
+               a.newcomer_support_end_date AS newcomerSupportEndDate,
+               a.active_yn AS activeYn
+          FROM fgc.agent a
+          JOIN fgc.organization o
+            ON o.organization_id = a.organization_id
+         WHERE <include refid="agentSearchConditions"/>
+         ORDER BY a.agent_code ASC
+         LIMIT #{limit}
+        OFFSET #{offset}
+    </select>
+
+    <select id="countAgents" resultType="long">
+        SELECT COUNT(*)
+          FROM fgc.agent a
+         WHERE <include refid="agentSearchConditions"/>
+    </select>
+
     <!-- 조직 계층 및 직급별 설계사 조회 SQL -->
     <select id="findActiveAgentIdFromOrganizationHierarchy"
             resultType="long">

--- a/src/test/java/com/susukkang/fgc/base/controller/AgentControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/base/controller/AgentControllerTest.java
@@ -1,0 +1,189 @@
+package com.susukkang.fgc.base.controller;
+
+import com.susukkang.fgc.base.dto.AgentResponse;
+import com.susukkang.fgc.base.dto.AgentSearchCriteria;
+import com.susukkang.fgc.base.service.AgentService;
+import com.susukkang.fgc.common.config.SecurityConfig;
+import com.susukkang.fgc.common.exception.ConstraintErrorCodeResolver;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.exception.FgcMessageResolver;
+import com.susukkang.fgc.common.exception.GlobalExceptionHandler;
+import com.susukkang.fgc.common.web.PageResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AgentController.class)
+@Import({AgentController.class, GlobalExceptionHandler.class, SecurityConfig.class})
+class AgentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AgentService agentService;
+
+    @MockitoBean
+    private FgcMessageResolver messageResolver;
+
+    @MockitoBean
+    private ConstraintErrorCodeResolver constraintErrorCodeResolver;
+
+    @Test
+    void returnsPagedAgentsForBaseAndContractScreens() throws Exception {
+        LocalDate asOf = LocalDate.of(2026, 8, 11);
+        AgentSearchCriteria criteria = new AgentSearchCriteria(11L, "김설계", asOf);
+        AgentResponse agent = new AgentResponse(
+                101L,
+                "FC-SEOUL-001",
+                "김설계",
+                "FC",
+                "설계사",
+                11L,
+                "FGC-BR-SEOUL",
+                "서울지사",
+                LocalDate.of(2026, 5, 1),
+                null,
+                "ACTIVE",
+                "활동",
+                LocalDate.of(2026, 5, 1),
+                false,
+                LocalDate.of(2026, 5, 1),
+                true,
+                LocalDate.of(2027, 4, 30),
+                true
+        );
+        given(agentService.search(criteria, 1, 20)).willReturn(
+                PageResponse.of(List.of(agent), 1, 20, 1, "agentCode,asc")
+        );
+
+        mockMvc.perform(get("/api/v1/base/agents")
+                        .param("organizationId", "11")
+                        .param("keyword", "김설계")
+                        .param("asOf", "2026-08-11")
+                        .with(user("settle01").roles("SETTLEMENT")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].agentId").value(101))
+                .andExpect(jsonPath("$.data.content[0].agentCode").value("FC-SEOUL-001"))
+                .andExpect(jsonPath("$.data.content[0].agentName").value("김설계"))
+                .andExpect(jsonPath("$.data.content[0].rankCode").value("FC"))
+                .andExpect(jsonPath("$.data.content[0].rankLabel").value("설계사"))
+                .andExpect(jsonPath("$.data.content[0].organizationId").value(11))
+                .andExpect(jsonPath("$.data.content[0].organizationCode").value("FGC-BR-SEOUL"))
+                .andExpect(jsonPath("$.data.content[0].organizationName").value("서울지사"))
+                .andExpect(jsonPath("$.data.content[0].appointmentDate").value("2026-05-01"))
+                .andExpect(jsonPath("$.data.content[0].terminationDate").isEmpty())
+                .andExpect(jsonPath("$.data.content[0].agentStatus").value("ACTIVE"))
+                .andExpect(jsonPath("$.data.content[0].agentStatusLabel").value("활동"))
+                .andExpect(jsonPath("$.data.content[0].latestRegistrationDate").value("2026-05-01"))
+                .andExpect(jsonPath("$.data.content[0].priorThreeYearExperienceYn").value(false))
+                .andExpect(jsonPath("$.data.content[0].experienceCheckedOn").value("2026-05-01"))
+                .andExpect(jsonPath("$.data.content[0].newcomerSupportEligibleYn").value(true))
+                .andExpect(jsonPath("$.data.content[0].newcomerSupportEndDate").value("2027-04-30"))
+                .andExpect(jsonPath("$.data.content[0].activeYn").value(true))
+                .andExpect(jsonPath("$.data.page").value(1))
+                .andExpect(jsonPath("$.data.size").value(20))
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
+                .andExpect(jsonPath("$.data.sort").value("agentCode,asc"))
+                .andExpect(jsonPath("$.error").isEmpty())
+                .andExpect(jsonPath("$.requestId", matchesPattern("^\\d{8}-[0-9a-f]{6}$")));
+
+        verify(agentService).search(criteria, 1, 20);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"SYSTEM_ADMIN", "GA_ADMIN", "SETTLEMENT", "COMPLIANCE"})
+    void allowsEveryAuthenticatedRole(String role) throws Exception {
+        LocalDate asOf = LocalDate.of(2026, 8, 11);
+        AgentSearchCriteria criteria = new AgentSearchCriteria(null, null, asOf);
+        given(agentService.search(criteria, 2, 10)).willReturn(
+                PageResponse.of(List.of(), 2, 10, 0, "agentCode,asc")
+        );
+
+        mockMvc.perform(get("/api/v1/base/agents")
+                        .param("asOf", "2026-08-11")
+                        .param("page", "2")
+                        .param("size", "10")
+                        .with(user("fgc-user").roles(role)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isEmpty());
+    }
+
+    @Test
+    void rejectsAuthenticatedUserWithoutAllowedRole() throws Exception {
+        mockMvc.perform(get("/api/v1/base/agents")
+                        .param("asOf", "2026-08-11")
+                        .with(user("other-user").roles("USER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void rejectsInvalidAsOfFormat() throws Exception {
+        mockMvc.perform(get("/api/v1/base/agents")
+                        .param("asOf", "2026/08/11")
+                        .with(user("settle01").roles("SETTLEMENT")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("FGC-COMMON-002"))
+                .andExpect(jsonPath("$.error.field").value("asOf"));
+    }
+
+    @Test
+    void rejectsMissingAsOf() throws Exception {
+        mockMvc.perform(get("/api/v1/base/agents")
+                        .with(user("settle01").roles("SETTLEMENT")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("FGC-COMMON-002"))
+                .andExpect(jsonPath("$.error.field").value("asOf"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0, 20, page", "1, 101, size", "1, 20, organizationId"})
+    void rejectsInvalidSearchValues(int page, int size, String field) throws Exception {
+        LocalDate asOf = LocalDate.of(2026, 8, 11);
+        Long organizationId = "organizationId".equals(field) ? 0L : null;
+        AgentSearchCriteria criteria = new AgentSearchCriteria(organizationId, null, asOf);
+        given(agentService.search(criteria, page, size)).willThrow(
+                new FgcBusinessException(FgcErrorCode.COMMON_002, field, Map.of("field", field), null)
+        );
+
+        var request = get("/api/v1/base/agents")
+                .param("asOf", "2026-08-11")
+                .param("page", String.valueOf(page))
+                .param("size", String.valueOf(size))
+                .with(user("settle01").roles("SETTLEMENT"));
+        if (organizationId != null) {
+            request.param("organizationId", String.valueOf(organizationId));
+        }
+
+        mockMvc.perform(request)
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("FGC-COMMON-002"))
+                .andExpect(jsonPath("$.error.field").value(field));
+    }
+
+    @Test
+    void requiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/base/agents").param("asOf", "2026-08-11"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/com/susukkang/fgc/base/mapper/AgentMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/base/mapper/AgentMapperIntegrationTest.java
@@ -1,0 +1,160 @@
+package com.susukkang.fgc.base.mapper;
+
+import com.susukkang.fgc.base.dto.AgentRow;
+import com.susukkang.fgc.base.dto.AgentSearchCriteria;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class AgentMapperIntegrationTest {
+
+    @Autowired
+    private AgentMapper agentMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void filtersByOrganizationAndAppointmentPeriodButIncludesInactiveRows() {
+        LocalDate asOf = LocalDate.of(2026, 8, 11);
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        long organizationId = insertOrganization("AGENT-ORG-" + suffix, "설계사 테스트 조직");
+        long otherOrganizationId = insertOrganization("OTHER-ORG-" + suffix, "다른 조직");
+        String prefix = "AGENT-" + suffix;
+
+        insertAgent(prefix + "-ACTIVE", "유효 활동", organizationId,
+                LocalDate.of(2026, 1, 1), null, "ACTIVE", true);
+        insertAgent(prefix + "-INACTIVE", "유효 비활동", organizationId,
+                LocalDate.of(2026, 1, 1), LocalDate.of(2026, 8, 11), "INACTIVE", false);
+        insertAgent(prefix + "-FUTURE", "미래 위촉", organizationId,
+                LocalDate.of(2026, 8, 12), null, "ACTIVE", true);
+        insertAgent(prefix + "-EXPIRED", "과거 해촉", organizationId,
+                LocalDate.of(2026, 1, 1), LocalDate.of(2026, 8, 10), "TERMINATED", false);
+        insertAgent(prefix + "-OTHER", "다른 조직 설계사", otherOrganizationId,
+                LocalDate.of(2026, 1, 1), null, "ACTIVE", true);
+
+        AgentSearchCriteria criteria = new AgentSearchCriteria(organizationId, prefix, asOf);
+        List<AgentRow> rows = agentMapper.selectAgents(criteria, 0, 20);
+
+        assertThat(rows).extracting(AgentRow::agentCode)
+                .containsExactly(prefix + "-ACTIVE", prefix + "-INACTIVE");
+        assertThat(rows).allSatisfy(row -> {
+            assertThat(row.organizationId()).isEqualTo(organizationId);
+            assertThat(row.organizationCode()).isEqualTo("AGENT-ORG-" + suffix);
+            assertThat(row.organizationName()).isEqualTo("설계사 테스트 조직");
+        });
+        assertThat(rows.get(1).activeYn()).isFalse();
+        assertThat(agentMapper.countAgents(criteria)).isEqualTo(2);
+    }
+
+    @Test
+    void searchesCodeOrNameCaseInsensitivelyAndAppliesStablePaging() {
+        LocalDate asOf = LocalDate.of(2026, 8, 11);
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        long organizationId = insertOrganization("PAGE-ORG-" + suffix, "페이징 조직");
+        String prefix = "page-agent-" + suffix;
+        for (int index = 21; index >= 1; index--) {
+            insertAgent(
+                    "%s-%02d".formatted(prefix, index),
+                    "설계사 %02d".formatted(index),
+                    organizationId,
+                    LocalDate.of(2026, 1, 1),
+                    null,
+                    "ACTIVE",
+                    true
+            );
+        }
+
+        AgentSearchCriteria criteria = new AgentSearchCriteria(null, prefix.toUpperCase(), asOf);
+        List<AgentRow> secondPage = agentMapper.selectAgents(criteria, 20, 20);
+
+        assertThat(agentMapper.countAgents(criteria)).isEqualTo(21);
+        assertThat(secondPage).singleElement()
+                .extracting(AgentRow::agentCode)
+                .isEqualTo(prefix + "-21");
+    }
+
+    @Test
+    void searchesByAgentNameAndMapsNewcomerFields() {
+        LocalDate asOf = LocalDate.of(2026, 8, 11);
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        long organizationId = insertOrganization("NAME-ORG-" + suffix, "이름 검색 조직");
+        String code = "NAME-AGENT-" + suffix;
+        insertAgent(code, "이름검색설계사-" + suffix, organizationId,
+                LocalDate.of(2026, 5, 1), null, "ACTIVE", true);
+
+        List<AgentRow> rows = agentMapper.selectAgents(
+                new AgentSearchCriteria(null, "검색설계사-" + suffix, asOf), 0, 20
+        );
+
+        assertThat(rows).singleElement().satisfies(row -> {
+            assertThat(row.agentCode()).isEqualTo(code);
+            assertThat(row.rankCode()).isEqualTo("FC");
+            assertThat(row.latestRegistrationDate()).isEqualTo(LocalDate.of(2026, 5, 1));
+            assertThat(row.priorThreeYearExperienceYn()).isFalse();
+            assertThat(row.experienceCheckedOn()).isEqualTo(LocalDate.of(2026, 5, 1));
+            assertThat(row.newcomerSupportEligibleYn()).isTrue();
+            assertThat(row.newcomerSupportEndDate()).isEqualTo(LocalDate.of(2027, 4, 30));
+        });
+    }
+
+    private long insertOrganization(String code, String name) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.organization (
+                    organization_code,
+                    organization_name,
+                    organization_type,
+                    effective_from,
+                    active_yn
+                ) VALUES (?, ?, 'BRANCH', DATE '2026-01-01', TRUE)
+                RETURNING organization_id
+                """, Long.class, code, name);
+    }
+
+    private void insertAgent(
+            String code,
+            String name,
+            long organizationId,
+            LocalDate appointmentDate,
+            LocalDate terminationDate,
+            String status,
+            boolean activeYn
+    ) {
+        jdbcTemplate.update("""
+                INSERT INTO fgc.agent (
+                    organization_id,
+                    agent_code,
+                    agent_name,
+                    rank_code,
+                    appointment_date,
+                    termination_date,
+                    agent_status,
+                    latest_registration_date,
+                    prior_three_year_experience_yn,
+                    experience_checked_on,
+                    newcomer_support_eligible_yn,
+                    newcomer_support_end_date,
+                    active_yn
+                ) VALUES (?, ?, ?, 'FC', ?, ?, ?, DATE '2026-05-01', FALSE,
+                          DATE '2026-05-01', TRUE, DATE '2027-04-30', ?)
+                """,
+                organizationId,
+                code,
+                name,
+                appointmentDate,
+                terminationDate,
+                status,
+                activeYn
+        );
+    }
+}

--- a/src/test/java/com/susukkang/fgc/base/service/AgentServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/base/service/AgentServiceImplTest.java
@@ -1,0 +1,130 @@
+package com.susukkang.fgc.base.service;
+
+import com.susukkang.fgc.base.dto.AgentResponse;
+import com.susukkang.fgc.base.dto.AgentRow;
+import com.susukkang.fgc.base.dto.AgentSearchCriteria;
+import com.susukkang.fgc.base.mapper.AgentMapper;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.web.PageResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentServiceImplTest {
+
+    @Mock
+    private AgentMapper agentMapper;
+
+    private AgentServiceImpl agentService;
+
+    @BeforeEach
+    void setUp() {
+        agentService = new AgentServiceImpl(agentMapper);
+    }
+
+    @Test
+    void normalizesCriteriaMapsLabelsAndBuildsPageResponse() {
+        LocalDate asOf = LocalDate.of(2026, 8, 11);
+        AgentSearchCriteria input = new AgentSearchCriteria(11L, "  kim  ", asOf);
+        AgentRow row = row("FC", "INACTIVE", false);
+        ArgumentCaptor<AgentSearchCriteria> criteriaCaptor =
+                ArgumentCaptor.forClass(AgentSearchCriteria.class);
+
+        when(agentMapper.selectAgents(any(AgentSearchCriteria.class), eq(20), eq(20)))
+                .thenReturn(List.of(row));
+        when(agentMapper.countAgents(any(AgentSearchCriteria.class))).thenReturn(21L);
+
+        PageResponse<AgentResponse> result = agentService.search(input, 2, 20);
+
+        verify(agentMapper).selectAgents(criteriaCaptor.capture(), eq(20), eq(20));
+        assertThat(criteriaCaptor.getValue()).isEqualTo(new AgentSearchCriteria(11L, "kim", asOf));
+        assertThat(result.page()).isEqualTo(2);
+        assertThat(result.totalPages()).isEqualTo(2);
+        assertThat(result.sort()).isEqualTo("agentCode,asc");
+        assertThat(result.content()).singleElement().satisfies(response -> {
+            assertThat(response.rankLabel()).isEqualTo("설계사");
+            assertThat(response.agentStatusLabel()).isEqualTo("비활동");
+            assertThat(response.organizationId()).isEqualTo(11L);
+            assertThat(response.activeYn()).isFalse();
+        });
+    }
+
+    @Test
+    void convertsBlankKeywordToNull() {
+        LocalDate asOf = LocalDate.of(2026, 8, 11);
+        ArgumentCaptor<AgentSearchCriteria> criteriaCaptor =
+                ArgumentCaptor.forClass(AgentSearchCriteria.class);
+        when(agentMapper.selectAgents(any(AgentSearchCriteria.class), eq(0), eq(20)))
+                .thenReturn(List.of());
+        when(agentMapper.countAgents(any(AgentSearchCriteria.class))).thenReturn(0L);
+
+        agentService.search(new AgentSearchCriteria(null, "   ", asOf), 1, 20);
+
+        verify(agentMapper).selectAgents(criteriaCaptor.capture(), eq(0), eq(20));
+        assertThat(criteriaCaptor.getValue().keyword()).isNull();
+    }
+
+    @Test
+    void rejectsInvalidOrganizationId() {
+        assertThatThrownBy(() -> agentService.search(
+                new AgentSearchCriteria(0L, null, LocalDate.of(2026, 8, 11)), 1, 20))
+                .isInstanceOf(FgcBusinessException.class)
+                .extracting("field")
+                .isEqualTo("organizationId");
+    }
+
+    @Test
+    void rejectsInvalidPagingAndOverflow() {
+        assertThatThrownBy(() -> agentService.search(criteria(), 0, 20))
+                .isInstanceOf(FgcBusinessException.class)
+                .extracting("field")
+                .isEqualTo("page");
+        assertThatThrownBy(() -> agentService.search(criteria(), 1, 101))
+                .isInstanceOf(FgcBusinessException.class)
+                .extracting("field")
+                .isEqualTo("size");
+        assertThatThrownBy(() -> agentService.search(criteria(), Integer.MAX_VALUE, 100))
+                .isInstanceOf(FgcBusinessException.class)
+                .extracting("field")
+                .isEqualTo("page");
+    }
+
+    private AgentSearchCriteria criteria() {
+        return new AgentSearchCriteria(null, null, LocalDate.of(2026, 8, 11));
+    }
+
+    private AgentRow row(String rankCode, String status, boolean activeYn) {
+        return new AgentRow(
+                101L,
+                "FC-SEOUL-001",
+                "김설계",
+                rankCode,
+                11L,
+                "FGC-BR-SEOUL",
+                "서울지사",
+                LocalDate.of(2026, 5, 1),
+                null,
+                status,
+                LocalDate.of(2026, 5, 1),
+                false,
+                LocalDate.of(2026, 5, 1),
+                true,
+                LocalDate.of(2027, 4, 30),
+                activeYn
+        );
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- FGC-FUN-008 보험설계사 기준정보 조회·선택 API를 구현했습니다.
- BASE-W01 설계사 탭과 CONT-W03 모집 설계사 선택에서 재사용할 수 있도록 프론트 요구 필드를 포함했습니다.

## 🔗 2. 관련 이슈

- Closes #182

## 🛠 3. 구현 내용

- `GET /api/v1/base/agents`에 조직, 검색어, 기준일 및 1-base 페이징 조건을 적용했습니다.
- `agent`와 `organization`을 조회하여 설계사 식별자, 직급·상태 라벨, 소속 조직, 위촉·해촉 및 신인·경력 정보를 반환합니다.
- 기준일의 위촉 유효기간을 적용하면서 비활성 기준정보도 `agentStatus`와 `activeYn`으로 구분해 반환합니다.
- 네 가지 역할의 조회 권한과 공통 `ApiResponse<PageResponse<...>>` 응답을 적용했습니다.
- 기존 스케줄 계산용 `AgentMapper.findActiveAgentIdFromOrganizationHierarchy`는 그대로 보존했습니다.

## 🧪 4. 테스트 방법

1. 다음 FUN-008 대상 테스트를 실행합니다.

   ```bash
   ./gradlew test \
     --tests 'com.susukkang.fgc.base.controller.AgentControllerTest' \
     --tests 'com.susukkang.fgc.base.service.AgentServiceImplTest' \
     --tests 'com.susukkang.fgc.base.mapper.AgentMapperIntegrationTest'
   ```

2. `GET /api/v1/base/agents?asOf=2026-08-11&organizationId=11&keyword=설계사&page=1&size=20` 응답의 검색·페이징 및 화면 매핑 필드를 확인합니다.
3. 비활성 설계사가 응답에 포함되되 `agentStatus`와 `activeYn`으로 선택 불가 여부를 구분할 수 있는지 확인합니다.

검증 결과:
- FUN-008 대상 테스트 19건 통과
- `git diff --check` 통과
- 전체 테스트 803건 중 800건 통과
- 기존 로컬 `cap_check` 잔존 데이터 기준선 문제 3건은 동일하게 재현
  - `CapCalculatorIntegrationTest` 1건
  - `DashboardServiceIntegrationTest` 2건

## 🗄️ 5. DB / Flyway 변경

- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

- 없음

## 📋 6. 리뷰 요구사항

- IF-API-07 요약 필드보다 `asOf`, `agentId`, 조직·위촉·신인 정보를 확장한 범위가 BASE-W01·CONT-W03 재사용에 적절한지 확인 부탁드립니다.
- 비활성 설계사를 조회에는 포함하되 신규 계약 선택은 `agentStatus=ACTIVE` 및 `activeYn=true`로 제한하는 계약을 확인 부탁드립니다.
- `organizationId`가 현재 소속 조직의 정확 일치 조건인 점을 확인 부탁드립니다.

## ✅ 7. 체크리스트

- [x] `develop` 최신 내용을 반영했습니다.
- [x] 로컬 빌드에 성공했습니다.
- [ ] 애플리케이션 실행을 확인했습니다.
- [x] 관련 기능을 직접 테스트했습니다.
- [x] 테스트 코드를 작성했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

- 없음
- 최신 BASE-W01·CONT-W03 목업은 API 응답 필드 결정에만 사용했습니다.

## 💬 9. 참고 사항

- 인터페이스 정의서와 프로젝트 화면 파일은 수정하지 않았습니다.
- BASE-W01 설계사 탭 API 연결은 이 API 병합 후 별도 프론트 작업으로 진행합니다.
- CONT-W03 화면 연결은 이슈 #170과 동일 파일 충돌을 피하기 위해 #170 병합 후 진행합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 설계사 목록 조회 API를 추가했습니다.
  * 조직, 검색어, 기준일로 설계사를 검색할 수 있습니다.
  * 페이지 단위 조회와 전체 결과 건수를 제공합니다.
  * 소속, 직급, 상태, 위촉·해촉일, 경력 및 지원 자격 정보를 확인할 수 있습니다.
  * 인증 및 역할별 접근 권한을 적용했습니다.

* **검증**
  * 검색 조건, 날짜 형식, 페이지 입력값 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->