### PR TITLE
[Feat] FUN-061 핵심 업무 감사로그 기록·조회 개발

### DIFF
--- a/src/main/java/com/susukkang/fgc/arbitrage/service/ArbitrageService.java
+++ b/src/main/java/com/susukkang/fgc/arbitrage/service/ArbitrageService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.susukkang.fgc.arbitrage.dto.*;
 import com.susukkang.fgc.arbitrage.mapper.ArbitrageMapper;
+import com.susukkang.fgc.audit.service.AuditLogService;
 import com.susukkang.fgc.common.code.ArbitrageCheckStatus;
 import com.susukkang.fgc.common.code.ExceptionType;
 import com.susukkang.fgc.common.code.PaymentStage;
@@ -45,11 +46,17 @@ public class ArbitrageService {
     // 현재 값은 REG-12의 계약 체결 후 3년(36개월) 기준을 따른다.
     private static final int REFUND_ADDITION_LAST_MONTH = 36;
 
+    // FUN-061 — 수동 재검증은 사용자가 촉발하는 상태 변경이라 같은 트랜잭션에서 감사행을 남긴다.
+    // 월 통합검증 경유(checkInExistingRun)는 배치의 VALIDATION_RUN_* 감사가 이미 커버하므로 제외.
+    private static final String AUDIT_ENTITY_TYPE = "ARBITRAGE_CHECK";
+    private static final String AUDIT_ARBITRAGE_RECHECKED = "ARBITRAGE_RECHECKED";
+
     private final ArbitrageMapper arbitrageMapper;
     private final ValidationRunCreateService validationRunCreateService;
     private final ValidationRunMapper validationRunMapper;
     private final ExceptionCaseMapper exceptionCaseMapper;
     private final ObjectMapper objectMapper;
+    private final AuditLogService auditLogService;
 
     /**
      * 설명 : 검색 조건에 해당하는 차익거래 검증 결과 요약과 페이징 목록을 조회한다.
@@ -150,6 +157,22 @@ public class ArbitrageService {
         // 수동 검증 실행 완료 처리
         if (validationRunMapper.transitionToCompleted(run.getValidationRunId()) != 1)
             throw new FgcBusinessException(FgcErrorCode.VRUN_005, Map.of());
+
+        Map<String, Object> auditValue = new LinkedHashMap<>();
+        auditValue.put("validationRunId", run.getValidationRunId());
+        auditValue.put("contractId", contractId);
+        auditValue.put("paymentStage", REGULATORY_PAYMENT_STAGE);
+        auditValue.put("asOfDate", request.getAsOfDate());
+        auditValue.put("resultStatus", row.getResultStatus());
+        auditValue.put("netDifferenceAmount", row.getNetDifferenceAmount());
+        auditLogService.record(AuditLogService.AuditEvent.builder()
+                .actionCode(AUDIT_ARBITRAGE_RECHECKED)
+                .entityType(AUDIT_ENTITY_TYPE)
+                .entityId(String.valueOf(row.getArbitrageCheckId()))
+                .userId(triggeredBy)
+                .after(auditValue)
+                .reason(request.getReason())
+                .build());
 
         // 생성된 검증 결과 ID와 판정 및 실행 ID 반환
         return ReArbitrageCheckResponse.builder()

--- a/src/main/java/com/susukkang/fgc/audit/controller/AuditLogController.java
+++ b/src/main/java/com/susukkang/fgc/audit/controller/AuditLogController.java
@@ -1,0 +1,72 @@
+package com.susukkang.fgc.audit.controller;
+
+import com.susukkang.fgc.audit.dto.AuditLogResponse;
+import com.susukkang.fgc.audit.service.AuditLogQueryService;
+import com.susukkang.fgc.common.security.Roles;
+import com.susukkang.fgc.common.web.ApiResponse;
+import com.susukkang.fgc.common.web.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+/**
+ * FUN-061 IF-API-52 감사로그 조회 API.
+ * audit_log 는 append-only 라 이 컨트롤러는 조회 외 어떤 쓰기 엔드포인트도 제공하지 않는다.
+ */
+@Tag(name = "감사로그", description = "FUN-061 핵심 업무 감사로그 조회 API")
+@RestController
+@RequestMapping("/api/v1/audit-logs")
+@RequiredArgsConstructor
+public class AuditLogController {
+
+    private final AuditLogQueryService auditLogQueryService;
+
+    @Operation(
+            summary = "감사로그 조회",
+            description = "누가 언제 무엇을 바꿨는지 검색합니다. "
+                    + "userLoginId 가 null 인 행은 배치 발 감사행(화면 표기 BATCH)입니다."
+    )
+    @GetMapping
+    // SecurityConfig 의 URL 규칙과 이중화 — 컨트롤러를 우회하는 경로가 생겨도 조회 권한을 지킨다 (FUN-002)
+    @PreAuthorize(Roles.CAN_VIEW_AUDIT_LOG)
+    public ApiResponse<PageResponse<AuditLogResponse>> search(
+            @Parameter(description = "대상 종류", example = "COMMISSION_PAYMENT")
+            @RequestParam(required = false)
+            String entityType,
+            @Parameter(description = "대상 ID", example = "42")
+            @RequestParam(required = false)
+            String entityId,
+            @Parameter(description = "행위자 사용자 ID", example = "12")
+            @RequestParam(required = false)
+            Long userId,
+            @Parameter(description = "행위 종류", example = "PAYMENT_CONFIRMED")
+            @RequestParam(required = false)
+            String action,
+            @Parameter(description = "조회 시작일(포함)", example = "2026-08-01")
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate from,
+            @Parameter(description = "조회 종료일(포함)", example = "2026-08-16")
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+            LocalDate to,
+            @Parameter(description = "페이지(1-base)", example = "1")
+            @RequestParam(defaultValue = "1")
+            int page,
+            @Parameter(description = "페이지 크기(최대 100)", example = "20")
+            @RequestParam(defaultValue = "20")
+            int size
+    ) {
+        return ApiResponse.success(
+                auditLogQueryService.search(entityType, entityId, userId, action, from, to, page, size));
+    }
+}

--- a/src/main/java/com/susukkang/fgc/audit/controller/AuditLogViewController.java
+++ b/src/main/java/com/susukkang/fgc/audit/controller/AuditLogViewController.java
@@ -55,6 +55,17 @@ public class AuditLogViewController {
             @RequestParam(required = false) Long selected,
             Model model
     ) {
+        // MPA @Controller 는 GlobalExceptionHandler(@RestController 한정) 밖이라 업무 예외가
+        // 그대로 일반 500 화면이 된다. 사용자가 폼·URL 로 만들 수 있는 잘못된 값은
+        // ExceptionCaseViewController 의 status 처럼 조용히 정상값으로 되돌려, "MPA 는 업무
+        // 예외를 던지지 않는다"는 GlobalExceptionHandler 의 전제를 지킨다.
+        if (from != null && to != null && from.isAfter(to)) {
+            LocalDate swap = from;
+            from = to;
+            to = swap;
+        }
+        page = Math.max(1, Math.min(page, Integer.MAX_VALUE / PAGE_SIZE));
+
         PageResponse<AuditLogResponse> logs =
                 auditLogQueryService.search(entityType, entityId, userId, action, from, to, page, PAGE_SIZE);
 

--- a/src/main/java/com/susukkang/fgc/audit/controller/AuditLogViewController.java
+++ b/src/main/java/com/susukkang/fgc/audit/controller/AuditLogViewController.java
@@ -91,7 +91,9 @@ public class AuditLogViewController {
     }
 
     /**
-     * before/after JSON 을 최상위 키 기준으로 나란히 비교한다.
+     * before/after JSON 을 리프 경로("payment.amount", "attributions[0].contractId") 단위로
+     * 펴서 나란히 비교한다 — 최상위 키만 비교하면 중첩 객체가 통째로 한 칸이 되어
+     * "바뀐 칸만 노랗게"(화면정의서 :1537)가 필드 단위로 동작하지 않는다.
      * 값이 있는 쪽이 하나라도 JSON 객체가 아니면(스칼라·배열·파싱 실패) 필드 비교 대신
      * 원문 한 줄 비교로 되돌린다 — 파싱 실패를 "값 없음"으로 취급하면 그쪽 원문이 diff 에서
      * 사라진다. 감사행은 이미 저장된 증거라 여기서 예외를 던져 화면을 깨뜨리지 않는다.
@@ -109,26 +111,48 @@ public class AuditLogViewController {
                     !Objects.equals(beforeJson, afterJson)));
         }
 
-        Set<String> fields = new LinkedHashSet<>();
+        Map<String, Object> beforeLeaves = new LinkedHashMap<>();
+        Map<String, Object> afterLeaves = new LinkedHashMap<>();
         if (before != null) {
-            fields.addAll(before.keySet());
+            flatten("", before, beforeLeaves);
         }
         if (after != null) {
-            fields.addAll(after.keySet());
+            flatten("", after, afterLeaves);
         }
+
+        Set<String> fields = new LinkedHashSet<>(beforeLeaves.keySet());
+        fields.addAll(afterLeaves.keySet());
 
         List<DiffEntry> entries = new ArrayList<>(fields.size());
         for (String field : fields) {
-            Object beforeValue = before == null ? null : before.get(field);
-            Object afterValue = after == null ? null : after.get(field);
+            Object beforeValue = beforeLeaves.get(field);
+            Object afterValue = afterLeaves.get(field);
             entries.add(new DiffEntry(
-                    field,
+                    field.isEmpty() ? "value" : field,
                     displayValue(beforeValue),
                     displayValue(afterValue),
                     !Objects.equals(beforeValue, afterValue)
             ));
         }
         return entries;
+    }
+
+    /** 중첩 객체·배열을 리프 경로 맵으로 편다. 빈 컨테이너는 그 자체를 리프로 남긴다. */
+    private static void flatten(String prefix, Object value, Map<String, Object> out) {
+        if (value instanceof Map<?, ?> map && !map.isEmpty()) {
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                String key = String.valueOf(entry.getKey());
+                flatten(prefix.isEmpty() ? key : prefix + "." + key, entry.getValue(), out);
+            }
+            return;
+        }
+        if (value instanceof List<?> list && !list.isEmpty()) {
+            for (int index = 0; index < list.size(); index++) {
+                flatten(prefix + "[" + index + "]", list.get(index), out);
+            }
+            return;
+        }
+        out.put(prefix, value);
     }
 
     private Map<String, Object> parseObject(String json) {

--- a/src/main/java/com/susukkang/fgc/audit/controller/AuditLogViewController.java
+++ b/src/main/java/com/susukkang/fgc/audit/controller/AuditLogViewController.java
@@ -92,16 +92,19 @@ public class AuditLogViewController {
 
     /**
      * before/after JSON 을 최상위 키 기준으로 나란히 비교한다.
-     * JSON 객체가 아니면(스칼라·배열·파싱 실패) 원문 한 줄로 비교한다 — 감사행은 이미 저장된
-     * 증거라 여기서 예외를 던져 화면을 깨뜨리지 않는다.
+     * 값이 있는 쪽이 하나라도 JSON 객체가 아니면(스칼라·배열·파싱 실패) 필드 비교 대신
+     * 원문 한 줄 비교로 되돌린다 — 파싱 실패를 "값 없음"으로 취급하면 그쪽 원문이 diff 에서
+     * 사라진다. 감사행은 이미 저장된 증거라 여기서 예외를 던져 화면을 깨뜨리지 않는다.
      */
     private List<DiffEntry> diff(String beforeJson, String afterJson) {
-        Map<String, Object> before = parseObject(beforeJson);
-        Map<String, Object> after = parseObject(afterJson);
-        if (before == null && after == null) {
-            if (beforeJson == null && afterJson == null) {
-                return List.of();
-            }
+        boolean beforePresent = beforeJson != null && !beforeJson.isBlank();
+        boolean afterPresent = afterJson != null && !afterJson.isBlank();
+        if (!beforePresent && !afterPresent) {
+            return List.of();
+        }
+        Map<String, Object> before = beforePresent ? parseObject(beforeJson) : null;
+        Map<String, Object> after = afterPresent ? parseObject(afterJson) : null;
+        if ((beforePresent && before == null) || (afterPresent && after == null)) {
             return List.of(new DiffEntry("value", beforeJson, afterJson,
                     !Objects.equals(beforeJson, afterJson)));
         }

--- a/src/main/java/com/susukkang/fgc/audit/controller/AuditLogViewController.java
+++ b/src/main/java/com/susukkang/fgc/audit/controller/AuditLogViewController.java
@@ -1,0 +1,156 @@
+package com.susukkang.fgc.audit.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.susukkang.fgc.audit.dto.AuditLogResponse;
+import com.susukkang.fgc.audit.service.AuditLogQueryService;
+import com.susukkang.fgc.common.security.Roles;
+import com.susukkang.fgc.common.web.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * FGC-UI-AUDT-W01 감사로그 조회 화면 (FUN-061).
+ * 인터페이스정의서 5-2 라우팅표: GET /audit-logs → audit/list.html, Ajax 없음 —
+ * 목록·필터 선택지·변경 내용 비교(diff)까지 전부 서버 렌더링한다.
+ * 행 선택은 selected 파라미터로 같은 검색조건을 유지한 채 재요청한다(화면정의서 §4-1 공통 규칙 7).
+ *
+ * AUDT-W01 은 다른 1차 화면과 달리 "전체 조회"가 아니다 — 화면정의서 :1530 권한
+ * COMPLIANCE·SYSTEM_ADMIN. FUN-002 인수조건: 직접 URL 호출도 403 으로 차단된다.
+ */
+@Controller
+@RequiredArgsConstructor
+public class AuditLogViewController {
+
+    /** 화면정의서 §4-1 공통 규칙 7 — 목록은 서버에서 20행씩. */
+    private static final int PAGE_SIZE = 20;
+
+    private final AuditLogQueryService auditLogQueryService;
+    private final ObjectMapper objectMapper;
+
+    @PreAuthorize(Roles.CAN_VIEW_AUDIT_LOG)
+    @GetMapping("/audit-logs")
+    public String list(
+            @RequestParam(required = false) String entityType,
+            @RequestParam(required = false) String entityId,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) String action,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(required = false) Long selected,
+            Model model
+    ) {
+        PageResponse<AuditLogResponse> logs =
+                auditLogQueryService.search(entityType, entityId, userId, action, from, to, page, PAGE_SIZE);
+
+        model.addAttribute("logs", logs);
+        model.addAttribute("form", new SearchForm(entityType, entityId, userId, action, from, to));
+        model.addAttribute("actionCodes", auditLogQueryService.actionCodes());
+        model.addAttribute("entityTypes", auditLogQueryService.entityTypes());
+        model.addAttribute("auditUsers", auditLogQueryService.auditUsers());
+
+        AuditLogResponse selectedLog = logs.content().stream()
+                .filter(log -> log.auditLogId().equals(selected))
+                .findFirst()
+                .orElse(null);
+        model.addAttribute("selectedLog", selectedLog);
+        model.addAttribute("diffEntries", selectedLog == null
+                ? List.<DiffEntry>of()
+                : diff(selectedLog.beforeValue(), selectedLog.afterValue()));
+        return "audit/list";
+    }
+
+    /** 검색조건을 폼·행 링크·페이징 링크에 그대로 되돌리기 위한 뷰 전용 값. */
+    public record SearchForm(
+            String entityType,
+            String entityId,
+            Long userId,
+            String action,
+            LocalDate from,
+            LocalDate to
+    ) {
+    }
+
+    /** 변경 내용 비교 패널의 한 행. changed 인 칸만 노랗게 칠한다. */
+    public record DiffEntry(String field, String before, String after, boolean changed) {
+    }
+
+    /**
+     * before/after JSON 을 최상위 키 기준으로 나란히 비교한다.
+     * JSON 객체가 아니면(스칼라·배열·파싱 실패) 원문 한 줄로 비교한다 — 감사행은 이미 저장된
+     * 증거라 여기서 예외를 던져 화면을 깨뜨리지 않는다.
+     */
+    private List<DiffEntry> diff(String beforeJson, String afterJson) {
+        Map<String, Object> before = parseObject(beforeJson);
+        Map<String, Object> after = parseObject(afterJson);
+        if (before == null && after == null) {
+            if (beforeJson == null && afterJson == null) {
+                return List.of();
+            }
+            return List.of(new DiffEntry("value", beforeJson, afterJson,
+                    !Objects.equals(beforeJson, afterJson)));
+        }
+
+        Set<String> fields = new LinkedHashSet<>();
+        if (before != null) {
+            fields.addAll(before.keySet());
+        }
+        if (after != null) {
+            fields.addAll(after.keySet());
+        }
+
+        List<DiffEntry> entries = new ArrayList<>(fields.size());
+        for (String field : fields) {
+            Object beforeValue = before == null ? null : before.get(field);
+            Object afterValue = after == null ? null : after.get(field);
+            entries.add(new DiffEntry(
+                    field,
+                    displayValue(beforeValue),
+                    displayValue(afterValue),
+                    !Objects.equals(beforeValue, afterValue)
+            ));
+        }
+        return entries;
+    }
+
+    private Map<String, Object> parseObject(String json) {
+        if (json == null || json.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(json,
+                    objectMapper.getTypeFactory().constructMapType(LinkedHashMap.class, String.class, Object.class));
+        } catch (JsonProcessingException ex) {
+            return null;
+        }
+    }
+
+    private String displayValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String text) {
+            return text;
+        }
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            return String.valueOf(value);
+        }
+    }
+}

--- a/src/main/java/com/susukkang/fgc/audit/dto/AuditLogInsertRow.java
+++ b/src/main/java/com/susukkang/fgc/audit/dto/AuditLogInsertRow.java
@@ -23,4 +23,5 @@ public class AuditLogInsertRow {
     private final String reason;
     private final String requestId;
     private final String clientIp;
+    private final Long policyVersionId;
 }

--- a/src/main/java/com/susukkang/fgc/audit/dto/AuditLogResponse.java
+++ b/src/main/java/com/susukkang/fgc/audit/dto/AuditLogResponse.java
@@ -1,0 +1,56 @@
+package com.susukkang.fgc.audit.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+
+/**
+ * FUN-061 IF-API-52 감사로그 조회 응답.
+ * 인터페이스정의서 응답 필드에 화면(AUDT-W01) 목록 컬럼인 entityId·policyVersionId 를 더한다.
+ * userLoginId 가 null 이면 배치 발 감사행이며 "BATCH" 표기는 화면 책임이다.
+ */
+@Schema(description = "감사로그 조회 응답")
+public record AuditLogResponse(
+        @Schema(description = "감사로그 ID", example = "1")
+        Long auditLogId,
+        @Schema(description = "발생시각")
+        OffsetDateTime occurredAt,
+        @Schema(description = "행위자 사용자 ID (배치는 null)", example = "12")
+        Long userId,
+        @Schema(description = "행위자 로그인 ID (배치는 null)", example = "settle01")
+        String userLoginId,
+        @Schema(description = "행위 종류", example = "PAYMENT_CONFIRMED")
+        String actionCode,
+        @Schema(description = "대상 종류", example = "COMMISSION_PAYMENT")
+        String entityType,
+        @Schema(description = "대상 ID", example = "42")
+        String entityId,
+        @Schema(description = "변경 전 값(JSON)")
+        String beforeValue,
+        @Schema(description = "변경 후 값(JSON)")
+        String afterValue,
+        @Schema(description = "사유")
+        String reason,
+        @Schema(description = "요청추적 ID", example = "20260816-1a2b3c")
+        String requestId,
+        @Schema(description = "정책버전 ID", example = "3")
+        Long policyVersionId
+) {
+
+    public static AuditLogResponse from(AuditLogRow row) {
+        return new AuditLogResponse(
+                row.auditLogId(),
+                row.occurredAt(),
+                row.userId(),
+                row.userLoginId(),
+                row.actionCode(),
+                row.entityType(),
+                row.entityId(),
+                row.beforeValue(),
+                row.afterValue(),
+                row.reason(),
+                row.requestId(),
+                row.policyVersionId()
+        );
+    }
+}

--- a/src/main/java/com/susukkang/fgc/audit/dto/AuditLogRow.java
+++ b/src/main/java/com/susukkang/fgc/audit/dto/AuditLogRow.java
@@ -1,0 +1,23 @@
+package com.susukkang.fgc.audit.dto;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 감사로그 SQL 결과를 서비스 계층으로 전달하는 내부 프로젝션.
+ * userLoginId 는 app_user LEFT JOIN 결과라 배치 발 감사행(user_id NULL)에서는 null 이다.
+ */
+public record AuditLogRow(
+        Long auditLogId,
+        OffsetDateTime occurredAt,
+        Long userId,
+        String userLoginId,
+        String actionCode,
+        String entityType,
+        String entityId,
+        String beforeValue,
+        String afterValue,
+        String reason,
+        String requestId,
+        Long policyVersionId
+) {
+}

--- a/src/main/java/com/susukkang/fgc/audit/dto/AuditLogSearchCriteria.java
+++ b/src/main/java/com/susukkang/fgc/audit/dto/AuditLogSearchCriteria.java
@@ -1,0 +1,16 @@
+package com.susukkang.fgc.audit.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * FUN-061 IF-API-52 감사로그 검색조건. 서비스가 정규화(blank→null, to→exclusive 상한)한 값만 담는다.
+ */
+public record AuditLogSearchCriteria(
+        String entityType,
+        String entityId,
+        Long userId,
+        String action,
+        LocalDateTime from,
+        LocalDateTime toExclusive
+) {
+}

--- a/src/main/java/com/susukkang/fgc/audit/dto/AuditUserRow.java
+++ b/src/main/java/com/susukkang/fgc/audit/dto/AuditUserRow.java
@@ -1,0 +1,8 @@
+package com.susukkang.fgc.audit.dto;
+
+/** 감사로그 화면 행위자 필터 선택지 — 감사행을 남긴 사용자만 나열한다. */
+public record AuditUserRow(
+        Long userId,
+        String loginId
+) {
+}

--- a/src/main/java/com/susukkang/fgc/audit/mapper/AuditLogQueryMapper.java
+++ b/src/main/java/com/susukkang/fgc/audit/mapper/AuditLogQueryMapper.java
@@ -1,0 +1,34 @@
+package com.susukkang.fgc.audit.mapper;
+
+import com.susukkang.fgc.audit.dto.AuditLogRow;
+import com.susukkang.fgc.audit.dto.AuditLogSearchCriteria;
+import com.susukkang.fgc.audit.dto.AuditUserRow;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * FUN-061 감사로그 조회 전용 매퍼.
+ * INSERT 전용 {@link AuditLogMapper} 와 분리해 append-only 계약을 매퍼 단위로 유지한다.
+ */
+@Mapper
+public interface AuditLogQueryMapper {
+
+    List<AuditLogRow> selectAuditLogs(
+            @Param("c") AuditLogSearchCriteria criteria,
+            @Param("offset") int offset,
+            @Param("limit") int limit
+    );
+
+    long countAuditLogs(@Param("c") AuditLogSearchCriteria criteria);
+
+    /** AUDT-W01 행위 종류 필터 선택지. */
+    List<String> selectDistinctActionCodes();
+
+    /** AUDT-W01 대상 종류 필터 선택지. */
+    List<String> selectDistinctEntityTypes();
+
+    /** AUDT-W01 행위자 필터 선택지 — 감사행을 남긴 사용자만. */
+    List<AuditUserRow> selectAuditUsers();
+}

--- a/src/main/java/com/susukkang/fgc/audit/service/AuditLogQueryService.java
+++ b/src/main/java/com/susukkang/fgc/audit/service/AuditLogQueryService.java
@@ -1,0 +1,31 @@
+package com.susukkang.fgc.audit.service;
+
+import com.susukkang.fgc.audit.dto.AuditLogResponse;
+import com.susukkang.fgc.audit.dto.AuditUserRow;
+import com.susukkang.fgc.common.web.PageResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface AuditLogQueryService {
+
+    PageResponse<AuditLogResponse> search(
+            String entityType,
+            String entityId,
+            Long userId,
+            String action,
+            LocalDate from,
+            LocalDate to,
+            int page,
+            int size
+    );
+
+    /** AUDT-W01 행위 종류 필터 선택지. */
+    List<String> actionCodes();
+
+    /** AUDT-W01 대상 종류 필터 선택지. */
+    List<String> entityTypes();
+
+    /** AUDT-W01 행위자 필터 선택지. */
+    List<AuditUserRow> auditUsers();
+}

--- a/src/main/java/com/susukkang/fgc/audit/service/AuditLogQueryServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/audit/service/AuditLogQueryServiceImpl.java
@@ -1,0 +1,117 @@
+package com.susukkang.fgc.audit.service;
+
+import com.susukkang.fgc.audit.dto.AuditLogResponse;
+import com.susukkang.fgc.audit.dto.AuditLogSearchCriteria;
+import com.susukkang.fgc.audit.dto.AuditUserRow;
+import com.susukkang.fgc.audit.mapper.AuditLogQueryMapper;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.web.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * FUN-061 IF-API-52 감사로그 조회 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class AuditLogQueryServiceImpl implements AuditLogQueryService {
+
+    private static final int MIN_PAGE = 1;
+    private static final int MIN_SIZE = 1;
+    private static final int MAX_SIZE = 100;
+    private static final String SORT = "occurredAt,desc";
+
+    private final AuditLogQueryMapper auditLogQueryMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponse<AuditLogResponse> search(
+            String entityType,
+            String entityId,
+            Long userId,
+            String action,
+            LocalDate from,
+            LocalDate to,
+            int page,
+            int size
+    ) {
+        validatePaging(page, size);
+        if (from != null && to != null && from.isAfter(to)) {
+            throw validationException("from", "조회 시작일은 종료일보다 늦을 수 없습니다.");
+        }
+
+        // to 는 화면의 "종료일 포함" 의미라 다음 날 0시를 exclusive 상한으로 쓴다.
+        AuditLogSearchCriteria criteria = new AuditLogSearchCriteria(
+                normalize(entityType),
+                normalize(entityId),
+                userId,
+                normalize(action),
+                from == null ? null : from.atStartOfDay(),
+                to == null ? null : to.plusDays(1).atStartOfDay()
+        );
+
+        long offsetLong = (long) (page - 1) * size;
+        if (offsetLong > Integer.MAX_VALUE) {
+            throw validationException("page", "요청할 수 있는 페이지 범위를 초과했습니다.");
+        }
+        int offset = (int) offsetLong;
+
+        List<AuditLogResponse> content = auditLogQueryMapper
+                .selectAuditLogs(criteria, offset, size)
+                .stream()
+                .map(AuditLogResponse::from)
+                .toList();
+        long totalElements = auditLogQueryMapper.countAuditLogs(criteria);
+
+        return PageResponse.of(content, page, size, totalElements, SORT);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<String> actionCodes() {
+        return auditLogQueryMapper.selectDistinctActionCodes();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<String> entityTypes() {
+        return auditLogQueryMapper.selectDistinctEntityTypes();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AuditUserRow> auditUsers() {
+        return auditLogQueryMapper.selectAuditUsers();
+    }
+
+    private void validatePaging(int page, int size) {
+        if (page < MIN_PAGE) {
+            throw validationException("page", "page는 1 이상이어야 합니다.");
+        }
+        if (size < MIN_SIZE || size > MAX_SIZE) {
+            throw validationException("size", "size는 1 이상 100 이하여야 합니다.");
+        }
+    }
+
+    private String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    private FgcBusinessException validationException(String field, String detail) {
+        return new FgcBusinessException(
+                FgcErrorCode.COMMON_002,
+                field,
+                Map.of("field", field),
+                detail
+        );
+    }
+}

--- a/src/main/java/com/susukkang/fgc/audit/service/AuditLogService.java
+++ b/src/main/java/com/susukkang/fgc/audit/service/AuditLogService.java
@@ -1,0 +1,119 @@
+package com.susukkang.fgc.audit.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.susukkang.fgc.audit.dto.AuditLogInsertRow;
+import com.susukkang.fgc.audit.mapper.AuditLogMapper;
+import com.susukkang.fgc.auth.dto.FgcUserDetails;
+import com.susukkang.fgc.common.web.RequestIdContext;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * FUN-061 핵심 업무 감사로그 공통 기록 서비스.
+ *
+ * 운영정책서 제51조: audit_log 는 범용 감사 트리거가 아니므로 정책·지급·예외·권한을 변경하는
+ * 서비스가 같은 트랜잭션에서 감사행을 명시적으로 생성해야 한다. 이 컴포넌트는 그 신규 기록
+ * 지점들이 공유하는 관심사(사용자 해석, JSON 직렬화, 컬럼 길이 clamp, 실패 전파)를 모은다.
+ *
+ * 실패 정책: 기록 실패는 예외로 전파되어 호출자의 업무 트랜잭션을 함께 롤백한다(기록률 100%
+ * 인수조건). AuthAuditListener 의 실패-삼킴(로그인 불능 방지)과는 반대의 의도적 정책이므로
+ * 로그인 감사를 이 서비스로 옮기지 말 것.
+ */
+@Component
+@RequiredArgsConstructor
+public class AuditLogService {
+
+    /** audit_log.entity_id varchar(100) */
+    private static final int ENTITY_ID_MAX_LENGTH = 100;
+    /** audit_log.reason varchar(1000) */
+    private static final int REASON_MAX_LENGTH = 1000;
+    /** audit_log.request_id varchar(80) */
+    private static final int REQUEST_ID_MAX_LENGTH = 80;
+
+    private final AuditLogMapper auditLogMapper;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 호출자 트랜잭션에 참여해 감사행 1건을 INSERT 한다.
+     * userId 를 지정하지 않으면 SecurityContext 의 로그인 사용자로 해석하고,
+     * 그래도 없으면 null(화면 표기 "BATCH")로 남긴다.
+     */
+    public void record(AuditEvent event) {
+        int affected = auditLogMapper.insert(AuditLogInsertRow.builder()
+                .userId(event.userId() != null ? event.userId() : currentUserId())
+                .actionCode(event.actionCode())
+                .entityType(event.entityType())
+                .entityId(clamp(event.entityId(), ENTITY_ID_MAX_LENGTH))
+                .beforeValue(toJson(event.before()))
+                .afterValue(toJson(event.after()))
+                .reason(clamp(event.reason(), REASON_MAX_LENGTH))
+                .requestId(clamp(RequestIdContext.current(), REQUEST_ID_MAX_LENGTH))
+                .clientIp(clientIp())
+                .policyVersionId(event.policyVersionId())
+                .build());
+        if (affected != 1) {
+            throw new IllegalStateException(
+                    "감사로그 기록 실패 actionCode=" + event.actionCode()
+                            + " entityId=" + event.entityId());
+        }
+    }
+
+    /**
+     * 감사 사건 1건. actionCode(varchar 50)·entityType(varchar 60)은 코드가 정하는 상수라
+     * clamp 하지 않는다 — 길이 초과는 버그이므로 INSERT 실패로 드러나 트랜잭션이 롤백된다.
+     * before/after 는 임의 객체를 받아 JSON 으로 직렬화한다(null 허용).
+     */
+    @Builder
+    public record AuditEvent(
+            String actionCode,
+            String entityType,
+            String entityId,
+            Long userId,
+            Object before,
+            Object after,
+            String reason,
+            Long policyVersionId) {
+    }
+
+    private String toJson(Object value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("감사로그 값 직렬화 실패", ex);
+        }
+    }
+
+    private static Long currentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof FgcUserDetails details) {
+            return details.getUserId();
+        }
+        return null;
+    }
+
+    /** 배치 스레드처럼 요청 컨텍스트가 없으면 null. */
+    private static String clientIp() {
+        RequestAttributes attributes = RequestContextHolder.getRequestAttributes();
+        if (attributes instanceof ServletRequestAttributes servletAttributes) {
+            return servletAttributes.getRequest().getRemoteAddr();
+        }
+        return null;
+    }
+
+    private static String clamp(String value, int maxLength) {
+        if (value == null) {
+            return null;
+        }
+        return value.length() > maxLength ? value.substring(0, maxLength) : value;
+    }
+}

--- a/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
+++ b/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
@@ -92,13 +92,5 @@ public class ScreenViewController {
         return "vrun/detail";
     }
 
-    /**
-     * AUDT-W01 은 다른 1차 화면과 달리 "전체 조회"가 아니다 — 화면정의서 :1530 권한
-     * COMPLIANCE·SYSTEM_ADMIN. FUN-002 인수조건: 직접 URL 호출도 403 으로 차단된다.
-     */
-    @PreAuthorize(Roles.CAN_VIEW_AUDIT_LOG)
-    @GetMapping("/audit-logs")
-    public String auditLogList() {
-        return "audit/list";
-    }
+    // AUDT-W01(/audit-logs)은 데이터 바인딩과 함께 audit.controller.AuditLogViewController 로 이관했다.
 }

--- a/src/main/java/com/susukkang/fgc/contract/service/ContractService.java
+++ b/src/main/java/com/susukkang/fgc/contract/service/ContractService.java
@@ -1,5 +1,6 @@
 package com.susukkang.fgc.contract.service;
 
+import com.susukkang.fgc.audit.service.AuditLogService;
 import com.susukkang.fgc.cap.service.CapCheckService;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.common.exception.FgcErrorCode;
@@ -38,10 +39,16 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class ContractService {
 
+    // FUN-061·운영정책서 제51조 "계약·상태 사건" — 등록·수정과 같은 트랜잭션에서 감사행을 남긴다.
+    private static final String AUDIT_ENTITY_TYPE = "CONTRACT";
+    private static final String AUDIT_CONTRACT_CREATED = "CONTRACT_CREATED";
+    private static final String AUDIT_CONTRACT_UPDATED = "CONTRACT_UPDATED";
+
     private final ContractMapper contractMapper;
     private final ContractStatusEventMapper contractStatusEventMapper;
     private final CapCheckService capCheckService;
     private final ScheduleService scheduleService;
+    private final AuditLogService auditLogService;
     /**
      * 설명 : 검색 조건에 따라 계약을 조회한다.
      * 검색 조건과 현재 페이지 , 최대 계약수를 받아
@@ -160,6 +167,12 @@ public class ContractService {
 
         // TODO(FUN-026, 2차): 계약 생성 상태 사건 이력을 등록한다.
 
+        auditLogService.record(AuditLogService.AuditEvent.builder()
+                .actionCode(AUDIT_CONTRACT_CREATED)
+                .entityType(AUDIT_ENTITY_TYPE)
+                .entityId(String.valueOf(insuranceContract.getContractId()))
+                .after(insuranceContract)
+                .build());
 
         return ContractResponse.builder()
                 .contractId(insuranceContract.getContractId())
@@ -487,6 +500,14 @@ public class ContractService {
          * request.getContractStatus()가 다른 경우
          * 계약상태 사건 이력을 등록한다.
          */
+
+        auditLogService.record(AuditLogService.AuditEvent.builder()
+                .actionCode(AUDIT_CONTRACT_UPDATED)
+                .entityType(AUDIT_ENTITY_TYPE)
+                .entityId(String.valueOf(id))
+                .before(currentContract)
+                .after(updatedContract)
+                .build());
 
         return ContractResponse.builder()
                 .contractId(id)

--- a/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
@@ -112,12 +112,13 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
         mapper.detachPreConfirmDetails(paymentId);
         mapper.deleteAttributions(paymentId);
         persistAttributions(paymentId, prepared.attributions());
-        // before 는 수정 전 잠금 조회(current)를 그대로 사용한다 — 추가 쿼리 없음
+        // before 는 수정 전 잠금 조회(current)를 after 와 같은 payment/attributions 구조로
+        // 재구성해 diff 화면에서 필드끼리 나란히 비교되게 한다 — 추가 쿼리 없음
         auditLogService.record(AuditLogService.AuditEvent.builder()
                 .actionCode(AUDIT_PAYMENT_UPDATED)
                 .entityType(AUDIT_ENTITY_TYPE)
                 .entityId(String.valueOf(paymentId))
-                .before(Map.of("confirmationData", current))
+                .before(confirmationAuditValue(current))
                 .after(paymentAuditValue(prepared))
                 .policyVersionId(prepared.payment().getPolicyVersionId())
                 .build());
@@ -391,6 +392,43 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
         Map<String, Object> value = new LinkedHashMap<>();
         value.put("payment", prepared.payment());
         value.put("attributions", prepared.attributions());
+        return value;
+    }
+
+    /** 수정 감사행의 before 값 — 수정 전 잠금 조회 행을 after 와 같은 payment/attributions 구조로 편다. */
+    private Map<String, Object> confirmationAuditValue(List<ConfirmationData> rows) {
+        ConfirmationData first = rows.get(0);
+        Map<String, Object> payment = new LinkedHashMap<>();
+        payment.put("status", first.status());
+        payment.put("amount", first.amount());
+        payment.put("paymentStage", first.paymentStage());
+        payment.put("commissionItemId", first.commissionItemId());
+        payment.put("itemCode", first.itemCode());
+        payment.put("policyVersionId", first.policyVersionId());
+
+        List<Map<String, Object>> attributions = new ArrayList<>();
+        for (ConfirmationData row : rows) {
+            if (row.transactionAttributionId() == null) {
+                continue; // 귀속 전 DRAFT — 본문만 저장된 상태
+            }
+            Map<String, Object> attribution = new LinkedHashMap<>();
+            attribution.put("transactionAttributionId", row.transactionAttributionId());
+            attribution.put("contractId", row.contractId());
+            attribution.put("amount", row.attributedAmount());
+            attribution.put("attributionDate", row.attributionDate());
+            attribution.put("attributionMonth", row.attributionMonth());
+            attribution.put("attributionMethod", row.attributionMethod());
+            attribution.put("inclusionDecisionStatus", row.inclusionDecisionStatus());
+            attribution.put("exclusionType", row.exclusionType());
+            attribution.put("inclusionDecisionReason", row.inclusionDecisionReason());
+            attribution.put("allocationBasis", row.allocationBasis());
+            attribution.put("evidenceRef", row.evidenceRef());
+            attributions.add(attribution);
+        }
+
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("payment", payment);
+        value.put("attributions", attributions);
         return value;
     }
 

--- a/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
@@ -28,6 +28,7 @@ import com.susukkang.fgc.transaction.domain.CapCheckCommand;
 import com.susukkang.fgc.transaction.domain.CapRuleSnapshot;
 import com.susukkang.fgc.transaction.domain.CommissionItemReference;
 import com.susukkang.fgc.transaction.domain.CommissionPaymentAttributionCommand;
+import com.susukkang.fgc.transaction.domain.CommissionPaymentAttributionRow;
 import com.susukkang.fgc.transaction.domain.CommissionPaymentCommand;
 import com.susukkang.fgc.transaction.domain.CommissionPaymentRow;
 import com.susukkang.fgc.transaction.domain.ConfirmationData;
@@ -85,15 +86,18 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
     public CommissionPaymentResponse create(CommissionPaymentCreateRequest request) {
         PreparedPayment prepared = commandFrom(request);
         mapper.insertTransaction(prepared.payment());
-        persistAttributions(prepared.payment().getPaymentId(), prepared.attributions());
+        Long paymentId = prepared.payment().getPaymentId();
+        persistAttributions(paymentId, prepared.attributions());
+        CommissionPaymentRow afterRow = requireRow(paymentId);
+        List<CommissionPaymentAttributionRow> afterAttributions = mapper.findAttributions(paymentId);
         auditLogService.record(AuditLogService.AuditEvent.builder()
                 .actionCode(AUDIT_PAYMENT_CREATED)
                 .entityType(AUDIT_ENTITY_TYPE)
-                .entityId(String.valueOf(prepared.payment().getPaymentId()))
-                .after(paymentAuditValue(prepared))
+                .entityId(String.valueOf(paymentId))
+                .after(paymentAuditValue(afterRow, afterAttributions))
                 .policyVersionId(prepared.payment().getPolicyVersionId())
                 .build());
-        return requirePayment(prepared.payment().getPaymentId());
+        return afterRow.toResponse(afterAttributions, List.of());
     }
 
     @Override
@@ -104,6 +108,10 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
     ) {
         List<ConfirmationData> current = requireConfirmationData(paymentId);
         requireDraft(current.get(0));
+        // before 스냅샷 — FOR UPDATE 잠금 이후, 수정 전 본문·귀속행을 after 와 같은 조회
+        // DTO(Row)로 확보한다. 두 스냅샷이 같은 스키마여야 diff 화면이 필드 단위로 비교된다.
+        CommissionPaymentRow beforeRow = requireRow(paymentId);
+        List<CommissionPaymentAttributionRow> beforeAttributions = mapper.findAttributions(paymentId);
 
         PreparedPayment prepared = commandFrom(paymentId, request);
         if (mapper.updateTransaction(prepared.payment()) != 1) {
@@ -112,17 +120,17 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
         mapper.detachPreConfirmDetails(paymentId);
         mapper.deleteAttributions(paymentId);
         persistAttributions(paymentId, prepared.attributions());
-        // before 는 수정 전 잠금 조회(current)를 after 와 같은 payment/attributions 구조로
-        // 재구성해 diff 화면에서 필드끼리 나란히 비교되게 한다 — 추가 쿼리 없음
+        CommissionPaymentRow afterRow = requireRow(paymentId);
+        List<CommissionPaymentAttributionRow> afterAttributions = mapper.findAttributions(paymentId);
         auditLogService.record(AuditLogService.AuditEvent.builder()
                 .actionCode(AUDIT_PAYMENT_UPDATED)
                 .entityType(AUDIT_ENTITY_TYPE)
                 .entityId(String.valueOf(paymentId))
-                .before(confirmationAuditValue(current))
-                .after(paymentAuditValue(prepared))
+                .before(paymentAuditValue(beforeRow, beforeAttributions))
+                .after(paymentAuditValue(afterRow, afterAttributions))
                 .policyVersionId(prepared.payment().getPolicyVersionId())
                 .build());
-        return requirePayment(paymentId);
+        return afterRow.toResponse(afterAttributions, List.of());
     }
 
     @Override
@@ -387,45 +395,15 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                 .build();
     }
 
-    /** 등록·수정 감사행의 after 값 — 지급 본문과 귀속행(포함/제외 판단·귀속방식·배부정책·증빙) 전체 스냅샷. */
-    private Map<String, Object> paymentAuditValue(PreparedPayment prepared) {
-        Map<String, Object> value = new LinkedHashMap<>();
-        value.put("payment", prepared.payment());
-        value.put("attributions", prepared.attributions());
-        return value;
-    }
-
-    /** 수정 감사행의 before 값 — 수정 전 잠금 조회 행을 after 와 같은 payment/attributions 구조로 편다. */
-    private Map<String, Object> confirmationAuditValue(List<ConfirmationData> rows) {
-        ConfirmationData first = rows.get(0);
-        Map<String, Object> payment = new LinkedHashMap<>();
-        payment.put("status", first.status());
-        payment.put("amount", first.amount());
-        payment.put("paymentStage", first.paymentStage());
-        payment.put("commissionItemId", first.commissionItemId());
-        payment.put("itemCode", first.itemCode());
-        payment.put("policyVersionId", first.policyVersionId());
-
-        List<Map<String, Object>> attributions = new ArrayList<>();
-        for (ConfirmationData row : rows) {
-            if (row.transactionAttributionId() == null) {
-                continue; // 귀속 전 DRAFT — 본문만 저장된 상태
-            }
-            Map<String, Object> attribution = new LinkedHashMap<>();
-            attribution.put("transactionAttributionId", row.transactionAttributionId());
-            attribution.put("contractId", row.contractId());
-            attribution.put("amount", row.attributedAmount());
-            attribution.put("attributionDate", row.attributionDate());
-            attribution.put("attributionMonth", row.attributionMonth());
-            attribution.put("attributionMethod", row.attributionMethod());
-            attribution.put("inclusionDecisionStatus", row.inclusionDecisionStatus());
-            attribution.put("exclusionType", row.exclusionType());
-            attribution.put("inclusionDecisionReason", row.inclusionDecisionReason());
-            attribution.put("allocationBasis", row.allocationBasis());
-            attribution.put("evidenceRef", row.evidenceRef());
-            attributions.add(attribution);
-        }
-
+    /**
+     * 등록·수정 감사행의 before/after 값 — 지급 본문과 귀속행(포함/제외 판단·귀속방식·배부정책·
+     * 증빙) 전체 스냅샷. 두 스냅샷 모두 같은 조회 DTO(Row)를 직렬화하므로 필드 스키마가 항상
+     * 일치한다 — 스키마가 다르면 diff 화면이 전 필드를 변경으로 오인한다(화면정의서 :1537).
+     */
+    private Map<String, Object> paymentAuditValue(
+            CommissionPaymentRow payment,
+            List<CommissionPaymentAttributionRow> attributions
+    ) {
         Map<String, Object> value = new LinkedHashMap<>();
         value.put("payment", payment);
         value.put("attributions", attributions);
@@ -1168,11 +1146,15 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
     }
 
     private CommissionPaymentResponse requirePayment(Long paymentId, List<Long> capCheckIds) {
+        return requireRow(paymentId).toResponse(mapper.findAttributions(paymentId), capCheckIds);
+    }
+
+    private CommissionPaymentRow requireRow(Long paymentId) {
         CommissionPaymentRow payment = mapper.findById(paymentId);
         if (payment == null) {
             invalid("paymentId", "지급 건을 찾을 수 없습니다.");
         }
-        return payment.toResponse(mapper.findAttributions(paymentId), capCheckIds);
+        return payment;
     }
 
     private void requireAgent(Long agentId) {

--- a/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImpl.java
@@ -2,6 +2,7 @@ package com.susukkang.fgc.transaction.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.susukkang.fgc.audit.service.AuditLogService;
 import com.susukkang.fgc.cap.dto.CapCalculationCommand;
 import com.susukkang.fgc.cap.dto.CapCalculationResult;
 import com.susukkang.fgc.cap.dto.CapExceptionCreateCommand;
@@ -64,12 +65,20 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CommissionPaymentServiceImpl implements CommissionPaymentService {
 
+    // FUN-061·운영정책서 제51조 "지급 건과 계약귀속" — 등록·수정·확정과 같은 트랜잭션에서 감사행을 남긴다.
+    // after JSON 에 지급단계·포함/제외 판단·정착지원금 귀속·배부정책·증빙(REG-20·22)을 함께 담는다.
+    private static final String AUDIT_ENTITY_TYPE = "COMMISSION_PAYMENT";
+    private static final String AUDIT_PAYMENT_CREATED = "PAYMENT_CREATED";
+    private static final String AUDIT_PAYMENT_UPDATED = "PAYMENT_UPDATED";
+    private static final String AUDIT_PAYMENT_CONFIRMED = "PAYMENT_CONFIRMED";
+
     private final CommissionPaymentMapper mapper;
     private final ObjectMapper objectMapper;
     private final CapValidator capValidator;
     private final CapCalculator capCalculator;
     private final CapExceptionService capExceptionService;
     private final FgcMessageResolver messageResolver;
+    private final AuditLogService auditLogService;
 
     @Override
     @Transactional
@@ -77,6 +86,13 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
         PreparedPayment prepared = commandFrom(request);
         mapper.insertTransaction(prepared.payment());
         persistAttributions(prepared.payment().getPaymentId(), prepared.attributions());
+        auditLogService.record(AuditLogService.AuditEvent.builder()
+                .actionCode(AUDIT_PAYMENT_CREATED)
+                .entityType(AUDIT_ENTITY_TYPE)
+                .entityId(String.valueOf(prepared.payment().getPaymentId()))
+                .after(paymentAuditValue(prepared))
+                .policyVersionId(prepared.payment().getPolicyVersionId())
+                .build());
         return requirePayment(prepared.payment().getPaymentId());
     }
 
@@ -96,6 +112,15 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
         mapper.detachPreConfirmDetails(paymentId);
         mapper.deleteAttributions(paymentId);
         persistAttributions(paymentId, prepared.attributions());
+        // before 는 수정 전 잠금 조회(current)를 그대로 사용한다 — 추가 쿼리 없음
+        auditLogService.record(AuditLogService.AuditEvent.builder()
+                .actionCode(AUDIT_PAYMENT_UPDATED)
+                .entityType(AUDIT_ENTITY_TYPE)
+                .entityId(String.valueOf(paymentId))
+                .before(Map.of("confirmationData", current))
+                .after(paymentAuditValue(prepared))
+                .policyVersionId(prepared.payment().getPolicyVersionId())
+                .build());
         return requirePayment(paymentId);
     }
 
@@ -142,6 +167,7 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
         failFirst(requiredValueFailures(attributions));
 
         List<Long> capCheckIds = new ArrayList<>();
+        List<CapCheckCommand> capChecks = new ArrayList<>();
 
         // 2026-08-10 yslee - 지급 건의 모든 계약별 귀속행을 독립 검증
         // 기존 코드: attribution_seq=1인 단일 귀속행만 FUN-033 검증
@@ -178,6 +204,7 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
             mapper.insertCapCheck(check);
             mapper.insertCapCheckDetail(check);
             capCheckIds.add(check.getCapCheckId());
+            capChecks.add(check);
 
             /**
              * @author hjKang
@@ -199,6 +226,20 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
         if (mapper.confirm(paymentId, normalizedIdempotencyKey, capCheckIdsCsv) != 1) {
             throw new FgcBusinessException(FgcErrorCode.TRAN_005);
         }
+        // 확정 거절(CommissionPaymentConfirmationRejectedException)은 여기 도달 전에 던져지므로
+        // 감사행이 남지 않는 게 의도다 — 거절 근거는 exception_case 가 보존한다.
+        Map<String, Object> confirmedValue = new LinkedHashMap<>();
+        confirmedValue.put("status", CommissionPaymentStatus.CONFIRMED);
+        confirmedValue.put("idempotencyKey", normalizedIdempotencyKey);
+        confirmedValue.put("capChecks", capChecks.stream().map(this::capCheckAuditSummary).toList());
+        auditLogService.record(AuditLogService.AuditEvent.builder()
+                .actionCode(AUDIT_PAYMENT_CONFIRMED)
+                .entityType(AUDIT_ENTITY_TYPE)
+                .entityId(String.valueOf(paymentId))
+                .before(Map.of("status", CommissionPaymentStatus.DRAFT))
+                .after(confirmedValue)
+                .policyVersionId(first.policyVersionId())
+                .build());
         return requirePayment(paymentId, capCheckIds);
     }
 
@@ -343,6 +384,27 @@ public class CommissionPaymentServiceImpl implements CommissionPaymentService {
                 .title(title)
                 .description(description)
                 .build();
+    }
+
+    /** 등록·수정 감사행의 after 값 — 지급 본문과 귀속행(포함/제외 판단·귀속방식·배부정책·증빙) 전체 스냅샷. */
+    private Map<String, Object> paymentAuditValue(PreparedPayment prepared) {
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("payment", prepared.payment());
+        value.put("attributions", prepared.attributions());
+        return value;
+    }
+
+    /** 확정 감사행의 1,200% 판정 요약 — 계산 상세는 cap_check.calculation_snapshot 이 보존한다. */
+    private Map<String, Object> capCheckAuditSummary(CapCheckCommand check) {
+        Map<String, Object> summary = new LinkedHashMap<>();
+        summary.put("capCheckId", check.getCapCheckId());
+        summary.put("contractId", check.getContractId());
+        summary.put("paymentStage", check.getPaymentStage());
+        summary.put("resultStatus", check.getResultStatus());
+        summary.put("usagePct", check.getUsagePct());
+        summary.put("limitAmount", check.getLimitAmount());
+        summary.put("includedAmount", check.getIncludedAmount());
+        return summary;
     }
 
     /*

--- a/src/main/resources/db/migration/V20__audit_log_indexes.sql
+++ b/src/main/resources/db/migration/V20__audit_log_indexes.sql
@@ -1,0 +1,9 @@
+-- 2026-08-16 yslee - FUN-061 감사로그 조회(IF-API-52) 인덱스 추가
+-- 기존 코드: audit_log 는 INSERT 전용 기록만 있고 인덱스가 PK 뿐
+-- 문제: AUDT-W01 조회 API 의 기간·대상·행위자 필터와 occurred_at DESC 정렬이 전부 풀스캔
+-- 개선: 조회 패턴(무필터 최신순 / 대상종류+ID / 행위자)별 복합 인덱스 3개 추가.
+--       action_code 는 카디널리티가 낮고 항상 기간 필터와 결합되므로 단독 인덱스를 만들지 않는다.
+
+CREATE INDEX idx_audit_log_occurred_at ON fgc.audit_log (occurred_at DESC);
+CREATE INDEX idx_audit_log_entity ON fgc.audit_log (entity_type, entity_id, occurred_at DESC);
+CREATE INDEX idx_audit_log_user ON fgc.audit_log (user_id, occurred_at DESC);

--- a/src/main/resources/mapper/audit/AuditLogMapper.xml
+++ b/src/main/resources/mapper/audit/AuditLogMapper.xml
@@ -12,11 +12,13 @@
     <insert id="insert">
         INSERT INTO fgc.audit_log (
             user_id, action_code, entity_type, entity_id,
-            before_value, after_value, reason, request_id, client_ip
+            before_value, after_value, reason, request_id, client_ip,
+            policy_version_id
         ) VALUES (
             #{userId}, #{actionCode}, #{entityType}, #{entityId},
             #{beforeValue}::jsonb, #{afterValue}::jsonb,
-            #{reason}, #{requestId}, #{clientIp}::inet
+            #{reason}, #{requestId}, #{clientIp}::inet,
+            #{policyVersionId}
         )
     </insert>
 

--- a/src/main/resources/mapper/audit/AuditLogQueryMapper.xml
+++ b/src/main/resources/mapper/audit/AuditLogQueryMapper.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<!-- FUN-061 IF-API-52 감사로그 조회. INSERT 는 AuditLogMapper.xml(append-only) 에만 둔다. -->
+<mapper namespace="com.susukkang.fgc.audit.mapper.AuditLogQueryMapper">
+
+    <sql id="auditLogSearchConditions">
+        1 = 1
+        <if test="c.entityType != null">
+            AND al.entity_type = #{c.entityType}
+        </if>
+        <if test="c.entityId != null">
+            AND al.entity_id = #{c.entityId}
+        </if>
+        <if test="c.userId != null">
+            AND al.user_id = #{c.userId}
+        </if>
+        <if test="c.action != null">
+            AND al.action_code = #{c.action}
+        </if>
+        <if test="c.from != null">
+            AND al.occurred_at &gt;= #{c.from}
+        </if>
+        <if test="c.toExclusive != null">
+            AND al.occurred_at &lt; #{c.toExclusive}
+        </if>
+    </sql>
+
+    <!-- before/after 는 jsonb 라 ::text 캐스트 없이는 String 프로젝션에 매핑되지 않는다 (CapCheckMapper 선례). -->
+    <select id="selectAuditLogs" resultType="com.susukkang.fgc.audit.dto.AuditLogRow">
+        SELECT al.audit_log_id       AS auditLogId,
+               al.occurred_at        AS occurredAt,
+               al.user_id            AS userId,
+               u.login_id            AS userLoginId,
+               al.action_code        AS actionCode,
+               al.entity_type        AS entityType,
+               al.entity_id          AS entityId,
+               al.before_value::text AS beforeValue,
+               al.after_value::text  AS afterValue,
+               al.reason             AS reason,
+               al.request_id         AS requestId,
+               al.policy_version_id  AS policyVersionId
+          FROM fgc.audit_log al
+          LEFT JOIN fgc.app_user u ON u.user_id = al.user_id
+         WHERE <include refid="auditLogSearchConditions"/>
+         ORDER BY al.occurred_at DESC, al.audit_log_id DESC
+         LIMIT #{limit}
+        OFFSET #{offset}
+    </select>
+
+    <select id="countAuditLogs" resultType="long">
+        SELECT COUNT(*)
+          FROM fgc.audit_log al
+         WHERE <include refid="auditLogSearchConditions"/>
+    </select>
+
+    <select id="selectDistinctActionCodes" resultType="string">
+        SELECT DISTINCT action_code
+          FROM fgc.audit_log
+         ORDER BY action_code
+    </select>
+
+    <select id="selectDistinctEntityTypes" resultType="string">
+        SELECT DISTINCT entity_type
+          FROM fgc.audit_log
+         ORDER BY entity_type
+    </select>
+
+    <select id="selectAuditUsers" resultType="com.susukkang.fgc.audit.dto.AuditUserRow">
+        SELECT DISTINCT al.user_id AS userId,
+               u.login_id          AS loginId
+          FROM fgc.audit_log al
+          JOIN fgc.app_user u ON u.user_id = al.user_id
+         ORDER BY u.login_id
+    </select>
+
+</mapper>

--- a/src/main/resources/templates/audit/list.html
+++ b/src/main/resources/templates/audit/list.html
@@ -5,16 +5,13 @@
   데이터  읽기 audit_log  (UPDATE · DELETE 를 DB 트리거가 거부하는 append-only 테이블)
   API     GET /api/v1/audit-logs?entityType=&entityId=&userId=&action=&from=&to=
   권한    COMPLIANCE(준법·감사) · SYSTEM_ADMIN
-  라우트  GET /audit-logs → audit/list.html
+  라우트  GET /audit-logs → audit/list.html (AuditLogViewController 서버 렌더링, Ajax 없음)
 
   [막을 것] 수정 · 삭제 버튼 자체를 만들지 않습니다.
             감사로그를 고칠 수 있으면 감사로그가 아닙니다.
   [주의] before_value / after_value 는 JSON 입니다.
-         전부 늘어놓지 말고 바뀐 칸만 노랗게 강조합니다.
-
-  [정적 부착 단계] 목업(30_산출물/화면_MVP/FGC-UI-AUDT-W01)의 정적 골격만 옮겼다.
-  데이터 영역(필터 선택지·목록·변경 내용 비교)은
-  감사로그 조회 API(GET /api/v1/audit-logs) 연동 시 서버 렌더링으로 채운다.
+         전부 늘어놓지 말고 바뀐 칸만 노랗게 강조합니다 (DiffEntry.changed).
+  행 선택은 selected 파라미터로 같은 검색조건을 유지한 채 재요청합니다 (§4-1 공통 규칙 7).
 -->
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-AUDT-W01', '감사로그 조회', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
@@ -36,37 +33,59 @@
     </span>
   </div>
 
-  <!-- ① 검색 -->
+  <!-- ① 검색 — GET 폼이라 검색조건이 URL 에 남는다 (§4-1 공통 규칙 7) -->
   <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__body fgc-toolbar">
+    <form class="fgc-card__body fgc-toolbar" method="get" th:action="@{/audit-logs}">
       <div class="fgc-field" style="min-width:150px">
         <label class="fgc-label" for="f-from">발생 시각 (시작)</label>
-        <input class="fgc-input" id="f-from" type="date" value="2026-07-01">
+        <input class="fgc-input" id="f-from" name="from" type="date" th:value="${form.from}">
       </div>
       <div class="fgc-field" style="min-width:150px">
         <label class="fgc-label" for="f-to">발생 시각 (끝)</label>
-        <input class="fgc-input" id="f-to" type="date" value="2026-08-31">
+        <input class="fgc-input" id="f-to" name="to" type="date" th:value="${form.to}">
       </div>
       <div class="fgc-field" style="min-width:130px">
         <label class="fgc-label" for="f-user">행위자</label>
-        <select class="fgc-select" id="f-user"><option value="">전체</option></select>
+        <select class="fgc-select" id="f-user" name="userId">
+          <option value="">전체</option>
+          <option th:each="user : ${auditUsers}"
+                  th:value="${user.userId}"
+                  th:text="${user.loginId}"
+                  th:selected="${user.userId == form.userId}">settle01</option>
+        </select>
       </div>
       <div class="fgc-field" style="min-width:180px">
         <label class="fgc-label" for="f-action">행위 종류</label>
-        <select class="fgc-select" id="f-action"><option value="">전체</option></select>
+        <select class="fgc-select" id="f-action" name="action">
+          <option value="">전체</option>
+          <option th:each="code : ${actionCodes}"
+                  th:value="${code}"
+                  th:text="${code}"
+                  th:selected="${code == form.action}">PAYMENT_CONFIRMED</option>
+        </select>
       </div>
       <div class="fgc-field" style="min-width:180px">
         <label class="fgc-label" for="f-entity">대상 종류</label>
-        <select class="fgc-select" id="f-entity"><option value="">전체</option></select>
+        <select class="fgc-select" id="f-entity" name="entityType">
+          <option value="">전체</option>
+          <option th:each="type : ${entityTypes}"
+                  th:value="${type}"
+                  th:text="${type}"
+                  th:selected="${type == form.entityType}">COMMISSION_PAYMENT</option>
+        </select>
       </div>
       <div class="fgc-field" style="min-width:130px">
         <label class="fgc-label" for="f-eid">대상 ID</label>
-        <input class="fgc-input" id="f-eid" type="text" placeholder="4104">
+        <input class="fgc-input" id="f-eid" name="entityId" type="text" placeholder="4104"
+               th:value="${form.entityId}">
       </div>
-      <button class="fgc-btn fgc-btn--ghost" id="f-reset">
-        <span class="material-symbols-outlined" style="font-size:18px">restart_alt</span> 초기화
+      <button class="fgc-btn fgc-btn--primary" type="submit">
+        <span class="material-symbols-outlined" style="font-size:18px">search</span> 조회
       </button>
-    </div>
+      <a class="fgc-btn fgc-btn--ghost" id="f-reset" th:href="@{/audit-logs}">
+        <span class="material-symbols-outlined" style="font-size:18px">restart_alt</span> 초기화
+      </a>
+    </form>
   </section>
 
   <div class="fgc-responsive-split" style="margin-top:16px;display:grid;grid-template-columns:1.5fr 1fr;gap:16px" id="audit-grid">
@@ -75,7 +94,7 @@
     <section class="fgc-card">
       <div class="fgc-card__head">
         <span class="fgc-card__title">감사 기록</span>
-        <span class="fgc-muted" style="font-size:12px"><span id="row-count">0</span>건 · 한 화면 20행</span>
+        <span class="fgc-muted" style="font-size:12px"><span id="row-count" th:text="${logs.totalElements}">0</span>건 · 한 화면 20행</span>
       </div>
       <div style="overflow-x:auto">
         <table class="fgc-table">
@@ -92,27 +111,84 @@
             </tr>
           </thead>
           <tbody id="list-body">
-            <tr><td colspan="8"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
+            <tr th:if="${logs.content.isEmpty()}">
+              <td colspan="8"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td>
+            </tr>
+            <tr th:each="row : ${logs.content}"
+                th:style="${selectedLog != null and row.auditLogId == selectedLog.auditLogId} ? 'background:#eef4ff'">
+              <td>
+                <a class="fgc-mono" style="text-decoration:underline"
+                   th:href="@{/audit-logs(entityType=${form.entityType},entityId=${form.entityId},userId=${form.userId},action=${form.action},from=${form.from},to=${form.to},page=${logs.page},selected=${row.auditLogId})}"
+                   th:text="${#temporals.format(row.occurredAt, 'yyyy-MM-dd HH:mm:ss')}">2026-08-16 10:00:00</a>
+              </td>
+              <td th:text="${row.userLoginId} ?: 'BATCH'">settle01</td>
+              <td class="fgc-mono" th:text="${row.actionCode}">PAYMENT_CONFIRMED</td>
+              <td class="fgc-mono" th:text="${row.entityType}">COMMISSION_PAYMENT</td>
+              <td class="fgc-mono" th:text="${row.entityId}">42</td>
+              <td th:text="${row.reason}"></td>
+              <td class="fgc-mono" th:text="${row.policyVersionId}"></td>
+              <td class="fgc-mono" th:text="${row.requestId}">20260816-1a2b3c</td>
+            </tr>
           </tbody>
         </table>
       </div>
+      <div class="fgc-card__body" style="display:flex;gap:8px;align-items:center;justify-content:flex-end"
+           th:if="${logs.totalPages > 1}">
+        <a class="fgc-btn fgc-btn--ghost" th:if="${logs.page > 1}"
+           th:href="@{/audit-logs(entityType=${form.entityType},entityId=${form.entityId},userId=${form.userId},action=${form.action},from=${form.from},to=${form.to},page=${logs.page - 1})}">이전</a>
+        <span class="fgc-muted" style="font-size:12px"
+              th:text="${logs.page} + ' / ' + ${logs.totalPages}">1 / 1</span>
+        <a class="fgc-btn fgc-btn--ghost" th:if="${logs.page < logs.totalPages}"
+           th:href="@{/audit-logs(entityType=${form.entityType},entityId=${form.entityId},userId=${form.userId},action=${form.action},from=${form.from},to=${form.to},page=${logs.page + 1})}">다음</a>
+      </div>
     </section>
 
-    <!-- ③ 변경 내용 비교 -->
+    <!-- ③ 변경 내용 비교 — 서버가 계산한 DiffEntry 를 렌더링, 바뀐 칸만 노랗게 -->
     <section class="fgc-card" style="align-self:start">
       <div class="fgc-card__head">
         <span class="fgc-card__title">변경 내용 비교</span>
         <span class="fgc-muted" style="font-size:11px">바뀐 칸만 노랗게</span>
       </div>
       <div class="fgc-card__body" id="diff-body">
-        <p class="fgc-muted" style="font-size:13px;margin:0">왼쪽 목록에서 한 건을 고르세요.</p>
+        <p class="fgc-muted" style="font-size:13px;margin:0" th:if="${selectedLog == null}">왼쪽 목록에서 한 건을 고르세요.</p>
+        <div th:if="${selectedLog != null}">
+          <p class="fgc-muted" style="font-size:12px;margin:0 0 8px">
+            <span class="fgc-mono" th:text="${selectedLog.actionCode}">PAYMENT_CONFIRMED</span> ·
+            <span class="fgc-mono" th:text="${selectedLog.entityType + ' #' + selectedLog.entityId}">COMMISSION_PAYMENT #42</span>
+          </p>
+          <div style="overflow-x:auto">
+            <table class="fgc-table">
+              <thead>
+                <tr>
+                  <th style="width:130px">항목</th>
+                  <th>이전값</th>
+                  <th>이후값</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr th:if="${diffEntries.isEmpty()}">
+                  <td colspan="3"><div class="fgc-empty">기록된 변경 전·후 값이 없습니다.</div></td>
+                </tr>
+                <tr th:each="entry : ${diffEntries}">
+                  <td class="fgc-mono" th:text="${entry.field}">status</td>
+                  <td class="fgc-mono" style="word-break:break-all"
+                      th:style="${entry.changed} ? 'background:#fff3bf;word-break:break-all'"
+                      th:text="${entry.before}">DRAFT</td>
+                  <td class="fgc-mono" style="word-break:break-all"
+                      th:style="${entry.changed} ? 'background:#fff3bf;word-break:break-all'"
+                      th:text="${entry.after}">CONFIRMED</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
       </div>
     </section>
   </div>
 
 <!-- 스크립트는 main 안에 둔다 - 셸의 page()는 ~{::main}만 삽입하므로 main 밖 스크립트는 렌더링에서 사라진다 -->
 <script>
-/* 화면 폭이 좁으면 목록·비교 패널을 세로로 — 데이터 렌더링은 API 연동 시 추가 */
+/* 화면 폭이 좁으면 목록·비교 패널을 세로로 — 데이터는 전부 서버 렌더링이라 JS 는 레이아웃만 만진다 */
 (function () {
   "use strict";
   function reflow() {

--- a/src/test/java/com/susukkang/fgc/arbitrage/service/ArbitrageServiceTest.java
+++ b/src/test/java/com/susukkang/fgc/arbitrage/service/ArbitrageServiceTest.java
@@ -2,6 +2,7 @@ package com.susukkang.fgc.arbitrage.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.susukkang.fgc.arbitrage.dto.ArbitrageCalculationSource;
+import com.susukkang.fgc.audit.service.AuditLogService;
 import com.susukkang.fgc.arbitrage.dto.ConfirmedCommissionSummary;
 import com.susukkang.fgc.arbitrage.dto.ReArbitrageCheckRequest;
 import com.susukkang.fgc.arbitrage.dto.ReArbitrageCheckResponse;
@@ -43,6 +44,8 @@ class ArbitrageServiceTest {
     private ValidationRunMapper validationRunMapper;
     @Mock
     private ExceptionCaseMapper exceptionCaseMapper;
+    @Mock
+    private AuditLogService auditLogService;
 
     private ArbitrageService arbitrageService;
 
@@ -53,7 +56,8 @@ class ArbitrageServiceTest {
                 validationRunCreateService,
                 validationRunMapper,
                 exceptionCaseMapper,
-                new ObjectMapper().findAndRegisterModules()
+                new ObjectMapper().findAndRegisterModules(),
+                auditLogService
         );
     }
 
@@ -96,6 +100,52 @@ class ArbitrageServiceTest {
         verify(exceptionCaseMapper).insertArbitrageCandidate(
                 100L, 10L, 200L, "GA_TO_FC",
                 "지급예정 수수료를 포함하면 누적 납입보험료를 초과합니다.");
+    }
+
+    /**
+     * FUN-061·운영정책서 제51조 — 수동 재검증은 실행 사용자·사유와 함께 감사행을 남긴다.
+     * 실DB 통합 검증은 두지 않는다: 실행 생성이 REQUIRES_NEW 로 별도 커밋되어(ValidationRunCreateServiceImpl)
+     * 테스트 롤백으로 정리되지 않고 uq_validation_run_active_manual_contract 잔존 충돌을 일으킨다.
+     * 감사행의 DB 왕복은 AuditLogQueryMapperIntegrationTest 가 검증한다.
+     */
+    @Test
+    void recordsArbitrageRecheckedAudit() {
+        LocalDate asOfDate = LocalDate.of(2026, 7, 31);
+        ArbitrageCalculationSource source = calculationSource(
+                new BigDecimal("1200000"), 12, false, BigDecimal.ZERO);
+        given(arbitrageMapper.selectCalculationSource(10L, asOfDate)).willReturn(source);
+        given(arbitrageMapper.sumConfirmedCommissionAmount(
+                10L, PaymentStage.GA_TO_FC, asOfDate)).willReturn(confirmed("900000", "0"));
+        given(arbitrageMapper.sumPlannedCommissionAmount(
+                10L, PaymentStage.GA_TO_FC)).willReturn(new BigDecimal("400000"));
+        given(validationRunCreateService.create(any())).willReturn(validationRun(100L));
+        given(validationRunMapper.transitionToRunning(100L)).willReturn(1);
+        given(validationRunMapper.updateCurrentStep(100L, 5)).willReturn(1);
+        given(arbitrageMapper.insertArbitrageCheck(any())).willAnswer(invocation -> {
+            invocation.<com.susukkang.fgc.arbitrage.dto.ArbitrageCheckInsertDTO>getArgument(0)
+                    .setArbitrageCheckId(200L);
+            return 1;
+        });
+        given(validationRunMapper.transitionToCompleted(100L)).willReturn(1);
+
+        arbitrageService.reArbitrageCheck(
+                10L,
+                new ReArbitrageCheckRequest(asOfDate, "지급예정액 포함 재검증"),
+                1L
+        );
+
+        org.mockito.ArgumentCaptor<AuditLogService.AuditEvent> captor =
+                org.mockito.ArgumentCaptor.forClass(AuditLogService.AuditEvent.class);
+        verify(auditLogService).record(captor.capture());
+        AuditLogService.AuditEvent event = captor.getValue();
+        assertThat(event.actionCode()).isEqualTo("ARBITRAGE_RECHECKED");
+        assertThat(event.entityType()).isEqualTo("ARBITRAGE_CHECK");
+        assertThat(event.entityId()).isEqualTo("200");
+        assertThat(event.userId()).isEqualTo(1L);
+        assertThat(event.reason()).isEqualTo("지급예정액 포함 재검증");
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Object> after = (java.util.Map<String, Object>) event.after();
+        assertThat(after).containsKeys("validationRunId", "contractId", "resultStatus");
     }
 
     /**

--- a/src/test/java/com/susukkang/fgc/audit/AuditCoverageIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/audit/AuditCoverageIntegrationTest.java
@@ -1,0 +1,115 @@
+package com.susukkang.fgc.audit;
+
+import com.susukkang.fgc.contract.domain.ContractStatus;
+import com.susukkang.fgc.contract.domain.PaymentCycleCode;
+import com.susukkang.fgc.contract.dto.ContractCreateRequest;
+import com.susukkang.fgc.contract.dto.ContractResponse;
+import com.susukkang.fgc.contract.dto.ContractUpdateRequest;
+import com.susukkang.fgc.contract.service.ContractService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * FUN-061 인수조건 "핵심 변경 시나리오의 감사로그 기록률 100%" 통합 검증.
+ * 각 시나리오를 실제 서비스로 실행하고 같은 트랜잭션 안에서 audit_log 행을 센다 —
+ * 운영정책서 제51조 "각 서비스가 같은 트랜잭션에서 감사행을 명시적으로 생성".
+ *
+ * 지급 건(PAYMENT_*) 시나리오는 확정 게이트 픽스처가 무거워
+ * CommissionPaymentServiceImplTest 의 감사 호출 계약 테스트로 검증한다.
+ * audit_log 는 append-only 라 {@code @Transactional} 롤백으로만 정리한다.
+ */
+@SpringBootTest
+@Transactional
+class AuditCoverageIntegrationTest {
+
+    @Autowired
+    private ContractService contractService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    @DisplayName("계약 등록·수정은 CONTRACT_CREATED / CONTRACT_UPDATED 감사행을 남긴다")
+    void contractCreateAndUpdateLeaveAuditRows() {
+        Map<String, Object> reference = jdbcTemplate.queryForMap("""
+                SELECT insurer_id, product_offering_id, contract_date, agent_id, organization_id
+                  FROM fgc.insurance_contract
+                 ORDER BY contract_id
+                 LIMIT 1
+                """);
+        String contractNo = "AUD-" + UUID.randomUUID().toString().substring(0, 12);
+
+        ContractCreateRequest createRequest = new ContractCreateRequest(
+                ((Number) reference.get("insurer_id")).longValue(),
+                contractNo,
+                ((Number) reference.get("product_offering_id")).longValue(),
+                ((java.sql.Date) reference.get("contract_date")).toLocalDate(),
+                ContractStatus.ACTIVE,
+                ((Number) reference.get("agent_id")).longValue(),
+                ((Number) reference.get("organization_id")).longValue(),
+                PaymentCycleCode.MONTHLY,
+                new BigDecimal("100000"),
+                new BigDecimal("100000"),
+                120,
+                BigDecimal.ZERO
+        );
+
+        ContractResponse created = contractService.createContract(createRequest);
+
+        assertThat(auditCount("CONTRACT_CREATED", "CONTRACT", String.valueOf(created.getContractId())))
+                .isEqualTo(1);
+        String afterValue = jdbcTemplate.queryForObject("""
+                SELECT after_value::text FROM fgc.audit_log
+                 WHERE action_code = 'CONTRACT_CREATED' AND entity_type = 'CONTRACT' AND entity_id = ?
+                """, String.class, String.valueOf(created.getContractId()));
+        assertThat(afterValue).contains(contractNo);
+
+        ContractUpdateRequest updateRequest = new ContractUpdateRequest(
+                contractNo,
+                createRequest.getInsurerId(),
+                createRequest.getProductOfferingId(),
+                createRequest.getContractDate(),
+                ContractStatus.LAPSED,
+                createRequest.getAgentId(),
+                createRequest.getOrganizationId(),
+                PaymentCycleCode.MONTHLY,
+                new BigDecimal("100000"),
+                new BigDecimal("100000"),
+                120,
+                BigDecimal.ZERO
+        );
+
+        contractService.updateContract(created.getContractId(), updateRequest);
+
+        Map<String, Object> updatedAudit = jdbcTemplate.queryForMap("""
+                SELECT before_value::text AS before_value, after_value::text AS after_value
+                  FROM fgc.audit_log
+                 WHERE action_code = 'CONTRACT_UPDATED' AND entity_type = 'CONTRACT' AND entity_id = ?
+                """, String.valueOf(created.getContractId()));
+        assertThat((String) updatedAudit.get("before_value")).contains("ACTIVE");
+        assertThat((String) updatedAudit.get("after_value")).contains("LAPSED");
+    }
+
+    // ARBITRAGE_RECHECKED 는 실DB 통합으로 검증하지 않는다 — 검증 실행 생성이
+    // REQUIRES_NEW 로 별도 커밋되어(ValidationRunCreateServiceImpl) 테스트 롤백으로 정리되지
+    // 않고 uq_validation_run_active_manual_contract 잔존 충돌을 일으킨다.
+    // 감사 호출 계약은 ArbitrageServiceTest.recordsArbitrageRecheckedAudit 가 검증한다.
+
+    private long auditCount(String actionCode, String entityType, String entityId) {
+        Long count = jdbcTemplate.queryForObject("""
+                SELECT count(*) FROM fgc.audit_log
+                 WHERE action_code = ? AND entity_type = ? AND entity_id = ?
+                """, Long.class, actionCode, entityType, entityId);
+        return count == null ? 0 : count;
+    }
+}

--- a/src/test/java/com/susukkang/fgc/audit/controller/AuditLogControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/audit/controller/AuditLogControllerTest.java
@@ -1,0 +1,152 @@
+package com.susukkang.fgc.audit.controller;
+
+import com.susukkang.fgc.audit.dto.AuditLogResponse;
+import com.susukkang.fgc.audit.service.AuditLogQueryService;
+import com.susukkang.fgc.common.config.SecurityConfig;
+import com.susukkang.fgc.common.exception.ConstraintErrorCodeResolver;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.exception.FgcMessageResolver;
+import com.susukkang.fgc.common.exception.GlobalExceptionHandler;
+import com.susukkang.fgc.common.web.PageResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * FUN-061 IF-API-52 감사로그 조회 API 슬라이스 테스트.
+ * 인수조건(FUN-002): COMPLIANCE·SYSTEM_ADMIN 만 200, 그 외 역할은 직접 호출도 403.
+ */
+@WebMvcTest(AuditLogController.class)
+@Import({AuditLogController.class, GlobalExceptionHandler.class, SecurityConfig.class})
+class AuditLogControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuditLogQueryService auditLogQueryService;
+
+    @MockitoBean
+    private FgcMessageResolver messageResolver;
+
+    @MockitoBean
+    private ConstraintErrorCodeResolver constraintErrorCodeResolver;
+
+    private static AuditLogResponse sampleLog() {
+        return new AuditLogResponse(
+                1L,
+                OffsetDateTime.parse("2026-08-16T10:00:00+09:00"),
+                12L,
+                "settle01",
+                "PAYMENT_CONFIRMED",
+                "COMMISSION_PAYMENT",
+                "42",
+                "{\"status\":\"DRAFT\"}",
+                "{\"status\":\"CONFIRMED\"}",
+                null,
+                "20260816-1a2b3c",
+                3L
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"COMPLIANCE", "SYSTEM_ADMIN"})
+    void returnsAuditLogsForAllowedRoles(String role) throws Exception {
+        given(auditLogQueryService.search(
+                eq("COMMISSION_PAYMENT"), eq("42"), eq(12L), eq("PAYMENT_CONFIRMED"),
+                eq(LocalDate.parse("2026-08-01")), eq(LocalDate.parse("2026-08-16")), eq(1), eq(20)))
+                .willReturn(PageResponse.of(List.of(sampleLog()), 1, 20, 1, "occurredAt,desc"));
+
+        mockMvc.perform(get("/api/v1/audit-logs")
+                        .param("entityType", "COMMISSION_PAYMENT")
+                        .param("entityId", "42")
+                        .param("userId", "12")
+                        .param("action", "PAYMENT_CONFIRMED")
+                        .param("from", "2026-08-01")
+                        .param("to", "2026-08-16")
+                        .with(user("audit01").roles(role)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].auditLogId").value(1))
+                .andExpect(jsonPath("$.data.content[0].userLoginId").value("settle01"))
+                .andExpect(jsonPath("$.data.content[0].actionCode").value("PAYMENT_CONFIRMED"))
+                .andExpect(jsonPath("$.data.content[0].entityType").value("COMMISSION_PAYMENT"))
+                .andExpect(jsonPath("$.data.content[0].entityId").value("42"))
+                .andExpect(jsonPath("$.data.content[0].beforeValue").value("{\"status\":\"DRAFT\"}"))
+                .andExpect(jsonPath("$.data.content[0].afterValue").value("{\"status\":\"CONFIRMED\"}"))
+                .andExpect(jsonPath("$.data.content[0].requestId").value("20260816-1a2b3c"))
+                .andExpect(jsonPath("$.data.content[0].policyVersionId").value(3))
+                .andExpect(jsonPath("$.data.totalElements").value(1))
+                .andExpect(jsonPath("$.requestId", matchesPattern("^\\d{8}-[0-9a-f]{6}$")));
+
+        verify(auditLogQueryService).search(
+                "COMMISSION_PAYMENT", "42", 12L, "PAYMENT_CONFIRMED",
+                LocalDate.parse("2026-08-01"), LocalDate.parse("2026-08-16"), 1, 20);
+    }
+
+    /** 배치 발 감사행은 userLoginId 가 null 로 내려간다 — "BATCH" 표기는 화면 책임. */
+    @Test
+    void returnsNullUserLoginIdForBatchRows() throws Exception {
+        AuditLogResponse batchRow = new AuditLogResponse(
+                2L, OffsetDateTime.parse("2026-08-16T02:00:00+09:00"), null, null,
+                "VALIDATION_RUN_STARTED", "VALIDATION_RUN", "7", null, null, null, "batch-req", null);
+        given(auditLogQueryService.search(any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+                .willReturn(PageResponse.of(List.of(batchRow), 1, 20, 1, "occurredAt,desc"));
+
+        mockMvc.perform(get("/api/v1/audit-logs").with(user("audit01").roles("COMPLIANCE")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].userId").isEmpty())
+                .andExpect(jsonPath("$.data.content[0].userLoginId").isEmpty());
+    }
+
+    /** FUN-002 인수조건: 권한 없는 역할은 직접 API 호출도 403 으로 차단된다. */
+    @ParameterizedTest
+    @ValueSource(strings = {"SETTLEMENT", "GA_ADMIN"})
+    void rejectsRolesWithoutAuditPermission(String role) throws Exception {
+        mockMvc.perform(get("/api/v1/audit-logs").with(user("fgc-user").roles(role)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void requiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/audit-logs"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void rejectsInvalidDateRange() throws Exception {
+        given(auditLogQueryService.search(any(), any(), any(), any(),
+                eq(LocalDate.parse("2026-08-16")), eq(LocalDate.parse("2026-08-01")), anyInt(), anyInt()))
+                .willThrow(new FgcBusinessException(
+                        FgcErrorCode.COMMON_002, "from", Map.of("field", "from"), null));
+
+        mockMvc.perform(get("/api/v1/audit-logs")
+                        .param("from", "2026-08-16")
+                        .param("to", "2026-08-01")
+                        .with(user("audit01").roles("COMPLIANCE")))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("FGC-COMMON-002"))
+                .andExpect(jsonPath("$.error.field").value("from"));
+    }
+}

--- a/src/test/java/com/susukkang/fgc/audit/controller/AuditLogViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/audit/controller/AuditLogViewControllerTest.java
@@ -135,6 +135,29 @@ class AuditLogViewControllerTest {
                 .andExpect(content().string(containsString("background:#fff3bf")));
     }
 
+    /** 한쪽이 JSON 객체가 아니면(파싱 실패 포함) 필드 비교 대신 원문 한 줄 비교 — 원문이 diff 에서 사라지면 안 된다. */
+    @Test
+    void falls_back_to_raw_comparison_when_before_is_not_a_json_object() throws Exception {
+        stubSearch(List.of(log(1L, "settle01",
+                "not-a-json-object",
+                "{\"status\":\"CONFIRMED\"}")));
+        mvc.perform(get("/audit-logs").param("selected", "1").with(user(complianceUser())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("not-a-json-object")))
+                .andExpect(content().string(containsString("{&quot;status&quot;:&quot;CONFIRMED&quot;}")));
+    }
+
+    @Test
+    void falls_back_to_raw_comparison_when_after_is_not_a_json_object() throws Exception {
+        stubSearch(List.of(log(1L, "settle01",
+                "{\"status\":\"DRAFT\"}",
+                "[1,2,3]")));
+        mvc.perform(get("/audit-logs").param("selected", "1").with(user(complianceUser())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("{&quot;status&quot;:&quot;DRAFT&quot;}")))
+                .andExpect(content().string(containsString("[1,2,3]")));
+    }
+
     /** 화면정의서 "막아야 할 것": 수정·삭제 버튼 자체를 만들지 않는다 — 안내 배너만 있고 버튼은 없다. */
     @Test
     void never_renders_mutation_buttons() throws Exception {

--- a/src/test/java/com/susukkang/fgc/audit/controller/AuditLogViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/audit/controller/AuditLogViewControllerTest.java
@@ -17,14 +17,20 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.regex.Pattern;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -95,11 +101,70 @@ class AuditLogViewControllerTest {
                 .andExpect(content().string(containsString("FGC-UI-AUDT-W01")));
     }
 
+    @Test
+    void audit_log_screen_renders_for_system_admin() throws Exception {
+        stubSearch(List.of());
+        mvc.perform(get("/audit-logs").with(user(userWithRole(4L, "admin", "SYSTEM_ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("FGC-UI-AUDT-W01")));
+    }
+
     /** FUN-002 인수조건: 권한 없는 역할의 직접 URL 호출은 403 으로 차단된다. */
     @Test
     void audit_log_screen_forbidden_for_settlement() throws Exception {
         mvc.perform(get("/audit-logs").with(user(userWithRole(1L, "settle01", "SETTLEMENT"))))
                 .andExpect(status().isForbidden());
+    }
+
+    /**
+     * MPA 는 GlobalExceptionHandler(@RestController 한정) 밖 — 사용자가 폼으로 만들 수 있는
+     * 시작일 > 종료일 입력이 업무 예외로 500 화면에 떨어지지 않고 조용히 정상화되어야 한다.
+     */
+    @Test
+    void swaps_inverted_date_range_instead_of_error_page() throws Exception {
+        stubSearch(List.of());
+        mvc.perform(get("/audit-logs")
+                        .param("from", "2026-08-16")
+                        .param("to", "2026-08-01")
+                        .with(user(complianceUser())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("FGC-UI-AUDT-W01")));
+        verify(auditLogQueryService).search(isNull(), isNull(), isNull(), isNull(),
+                eq(LocalDate.parse("2026-08-01")), eq(LocalDate.parse("2026-08-16")), eq(1), eq(20));
+    }
+
+    @Test
+    void clamps_invalid_page_to_first_page() throws Exception {
+        stubSearch(List.of());
+        mvc.perform(get("/audit-logs").param("page", "0").with(user(complianceUser())))
+                .andExpect(status().isOk());
+        verify(auditLogQueryService).search(isNull(), isNull(), isNull(), isNull(),
+                isNull(), isNull(), eq(1), eq(20));
+    }
+
+    /** 검색조건이 서비스로 그대로 전달되고, 20행을 넘으면 페이지 이동이 렌더링된다 (§4-1 공통 규칙 7). */
+    @Test
+    void passes_filters_to_service_and_renders_pagination() throws Exception {
+        stubSearch(List.of());
+        given(auditLogQueryService.search(
+                eq("COMMISSION_PAYMENT"), eq("42"), eq(12L), eq("PAYMENT_CONFIRMED"),
+                eq(LocalDate.parse("2026-08-01")), eq(LocalDate.parse("2026-08-16")), eq(2), eq(20)))
+                .willReturn(PageResponse.of(
+                        List.of(log(21L, "settle01", null, null)), 2, 20, 50, "occurredAt,desc"));
+
+        mvc.perform(get("/audit-logs")
+                        .param("entityType", "COMMISSION_PAYMENT")
+                        .param("entityId", "42")
+                        .param("userId", "12")
+                        .param("action", "PAYMENT_CONFIRMED")
+                        .param("from", "2026-08-01")
+                        .param("to", "2026-08-16")
+                        .param("page", "2")
+                        .with(user(complianceUser())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("2 / 3")))
+                .andExpect(content().string(containsString("이전")))
+                .andExpect(content().string(containsString("다음")));
     }
 
     @Test
@@ -147,7 +212,14 @@ class AuditLogViewControllerTest {
                 .andExpect(content().string(containsString("attributions[0].contractId")))
                 .andExpect(content().string(containsString("500000")))
                 .andExpect(content().string(containsString("700000")))
-                .andExpect(content().string(containsString("background:#fff3bf")));
+                // 변경된 payment.amount 의 이전·이후 두 칸만 노랗다 —
+                // 변경 없는 payment.status·attributions[0].contractId 행은 칠하지 않는다
+                .andExpect(result -> {
+                    String html = result.getResponse().getContentAsString();
+                    long highlightedCells = Pattern.compile("background:#fff3bf")
+                            .matcher(html).results().count();
+                    assertThat(highlightedCells).isEqualTo(2);
+                });
     }
 
     /** 한쪽이 JSON 객체가 아니면(파싱 실패 포함) 필드 비교 대신 원문 한 줄 비교 — 원문이 diff 에서 사라지면 안 된다. */

--- a/src/test/java/com/susukkang/fgc/audit/controller/AuditLogViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/audit/controller/AuditLogViewControllerTest.java
@@ -1,0 +1,147 @@
+package com.susukkang.fgc.audit.controller;
+
+import com.susukkang.fgc.audit.dto.AuditLogResponse;
+import com.susukkang.fgc.audit.dto.AuditUserRow;
+import com.susukkang.fgc.audit.service.AuditLogQueryService;
+import com.susukkang.fgc.auth.dto.AppUserView;
+import com.susukkang.fgc.auth.dto.FgcUserDetails;
+import com.susukkang.fgc.common.config.SecurityConfig;
+import com.susukkang.fgc.common.web.PageResponse;
+import com.susukkang.fgc.common.web.ShellAdvice;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * FGC-UI-AUDT-W01 감사로그 조회 화면 테스트 (FUN-061).
+ * 역할 제한 스모크(ScreenViewControllerTest 에서 이관)와 서버 렌더링(목록·BATCH 표기·diff)을 본다.
+ */
+@WebMvcTest(AuditLogViewController.class)
+@Import({ShellAdvice.class, SecurityConfig.class, MessageSourceAutoConfiguration.class,
+        com.susukkang.fgc.common.exception.FgcMessageResolver.class,
+        com.susukkang.fgc.common.exception.ConstraintErrorCodeResolver.class})
+@TestPropertySource(properties = "fgc.demo-month=2026-07")
+class AuditLogViewControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockitoBean
+    AuditLogQueryService auditLogQueryService;
+
+    private static FgcUserDetails userWithRole(Long userId, String loginId, String roleCode) {
+        var view = new AppUserView();
+        view.setUserId(userId);
+        view.setLoginId(loginId);
+        view.setPasswordHash("x");
+        view.setUserName(loginId);
+        view.setRoleCode(roleCode);
+        return new FgcUserDetails(view, true, true);
+    }
+
+    private static FgcUserDetails complianceUser() {
+        return userWithRole(2L, "audit01", "COMPLIANCE");
+    }
+
+    private static AuditLogResponse log(Long id, String loginId, String beforeJson, String afterJson) {
+        return new AuditLogResponse(
+                id,
+                OffsetDateTime.parse("2026-08-16T10:00:00+09:00"),
+                loginId == null ? null : 12L,
+                loginId,
+                "PAYMENT_CONFIRMED",
+                "COMMISSION_PAYMENT",
+                "42",
+                beforeJson,
+                afterJson,
+                "확정 처리",
+                "20260816-1a2b3c",
+                3L
+        );
+    }
+
+    private void stubSearch(List<AuditLogResponse> rows) {
+        given(auditLogQueryService.search(any(), any(), any(), any(), any(), any(), anyInt(), anyInt()))
+                .willReturn(PageResponse.of(rows, 1, 20, rows.size(), "occurredAt,desc"));
+        given(auditLogQueryService.actionCodes()).willReturn(List.of("PAYMENT_CONFIRMED"));
+        given(auditLogQueryService.entityTypes()).willReturn(List.of("COMMISSION_PAYMENT"));
+        given(auditLogQueryService.auditUsers()).willReturn(List.of(new AuditUserRow(12L, "settle01")));
+    }
+
+    /** AUDT-W01(FUN-061)은 COMPLIANCE·SYSTEM_ADMIN 전용 — 화면정의서 :1530. */
+    @Test
+    void audit_log_screen_renders_for_compliance() throws Exception {
+        stubSearch(List.of());
+        mvc.perform(get("/audit-logs").with(user(complianceUser())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("FGC-UI-AUDT-W01")));
+    }
+
+    /** FUN-002 인수조건: 권한 없는 역할의 직접 URL 호출은 403 으로 차단된다. */
+    @Test
+    void audit_log_screen_forbidden_for_settlement() throws Exception {
+        mvc.perform(get("/audit-logs").with(user(userWithRole(1L, "settle01", "SETTLEMENT"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void renders_rows_and_filter_options_from_server() throws Exception {
+        stubSearch(List.of(log(1L, "settle01", null, null)));
+        mvc.perform(get("/audit-logs").with(user(complianceUser())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("PAYMENT_CONFIRMED")))
+                .andExpect(content().string(containsString("settle01")))
+                .andExpect(content().string(containsString("20260816-1a2b3c")))
+                .andExpect(content().string(containsString("확정 처리")));
+    }
+
+    /** 배치 발 감사행(user_id NULL)은 행위자를 "BATCH" 로 표기한다 — 화면정의서 :1517. */
+    @Test
+    void renders_batch_for_rows_without_user() throws Exception {
+        stubSearch(List.of(log(1L, null, null, null)));
+        mvc.perform(get("/audit-logs").with(user(complianceUser())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("BATCH")));
+    }
+
+    /** 선택한 행의 before/after 를 서버가 diff 계산해 바뀐 칸만 노랗게 칠한다. */
+    @Test
+    void renders_diff_panel_highlighting_only_changed_fields() throws Exception {
+        stubSearch(List.of(log(1L, "settle01",
+                "{\"status\":\"DRAFT\",\"amount\":500000}",
+                "{\"status\":\"CONFIRMED\",\"amount\":500000}")));
+        mvc.perform(get("/audit-logs").param("selected", "1").with(user(complianceUser())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("DRAFT")))
+                .andExpect(content().string(containsString("CONFIRMED")))
+                .andExpect(content().string(containsString("background:#fff3bf")));
+    }
+
+    /** 화면정의서 "막아야 할 것": 수정·삭제 버튼 자체를 만들지 않는다 — 안내 배너만 있고 버튼은 없다. */
+    @Test
+    void never_renders_mutation_buttons() throws Exception {
+        stubSearch(List.of(log(1L, "settle01", null, null)));
+        mvc.perform(get("/audit-logs").with(user(complianceUser())))
+                .andExpect(content().string(not(containsString("삭제</button>"))))
+                .andExpect(content().string(not(containsString("수정</button>"))))
+                .andExpect(content().string(containsString("수정·삭제 버튼이 없습니다")));
+    }
+}

--- a/src/test/java/com/susukkang/fgc/audit/controller/AuditLogViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/audit/controller/AuditLogViewControllerTest.java
@@ -135,6 +135,21 @@ class AuditLogViewControllerTest {
                 .andExpect(content().string(containsString("background:#fff3bf")));
     }
 
+    /** 중첩 객체는 리프 경로 단위로 비교한다 — payment/attributions 가 통째로 한 칸이 되면 "바뀐 칸만 노랗게"가 무의미하다. */
+    @Test
+    void renders_field_level_diff_for_nested_payment_values() throws Exception {
+        stubSearch(List.of(log(1L, "settle01",
+                "{\"payment\":{\"amount\":500000,\"status\":\"DRAFT\"},\"attributions\":[{\"contractId\":3}]}",
+                "{\"payment\":{\"amount\":700000,\"status\":\"DRAFT\"},\"attributions\":[{\"contractId\":3}]}")));
+        mvc.perform(get("/audit-logs").param("selected", "1").with(user(complianceUser())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("payment.amount")))
+                .andExpect(content().string(containsString("attributions[0].contractId")))
+                .andExpect(content().string(containsString("500000")))
+                .andExpect(content().string(containsString("700000")))
+                .andExpect(content().string(containsString("background:#fff3bf")));
+    }
+
     /** 한쪽이 JSON 객체가 아니면(파싱 실패 포함) 필드 비교 대신 원문 한 줄 비교 — 원문이 diff 에서 사라지면 안 된다. */
     @Test
     void falls_back_to_raw_comparison_when_before_is_not_a_json_object() throws Exception {

--- a/src/test/java/com/susukkang/fgc/audit/mapper/AuditLogQueryMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/audit/mapper/AuditLogQueryMapperIntegrationTest.java
@@ -1,0 +1,187 @@
+package com.susukkang.fgc.audit.mapper;
+
+import com.susukkang.fgc.audit.dto.AuditLogInsertRow;
+import com.susukkang.fgc.audit.dto.AuditLogRow;
+import com.susukkang.fgc.audit.dto.AuditLogSearchCriteria;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * FUN-061 감사로그 조회 매퍼 통합 테스트.
+ * audit_log 는 append-only(trg_audit_log_append_only)라 명시적 DELETE 로 정리할 수 없다 —
+ * {@code @Transactional} 롤백으로만 정리한다.
+ * 다른 테스트·시드 데이터와 격리하기 위해 행위·대상 코드에 실행별 고유 접미사를 붙인다.
+ */
+@SpringBootTest
+@Transactional
+class AuditLogQueryMapperIntegrationTest {
+
+    /** 시드·데모 데이터와 절대 겹치지 않는 미래 시각 — 기간 필터 검증용. */
+    private static final LocalDateTime BASE = LocalDateTime.of(2097, 1, 1, 10, 0);
+
+    @Autowired
+    private AuditLogQueryMapper queryMapper;
+
+    @Autowired
+    private AuditLogMapper auditLogMapper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private String marker;
+    private String actionA;
+    private String actionB;
+    private String entityTypeA;
+    private String entityTypeB;
+    private Long userId;
+    private String loginId;
+
+    @BeforeEach
+    void insertFixtures() {
+        marker = UUID.randomUUID().toString().substring(0, 8);
+        actionA = "T_ACT_A_" + marker;
+        actionB = "T_ACT_B_" + marker;
+        entityTypeA = "T_ENT_A_" + marker;
+        entityTypeB = "T_ENT_B_" + marker;
+        userId = jdbcTemplate.queryForObject(
+                "SELECT user_id FROM fgc.app_user ORDER BY user_id LIMIT 1", Long.class);
+        loginId = jdbcTemplate.queryForObject(
+                "SELECT login_id FROM fgc.app_user WHERE user_id = ?", String.class, userId);
+
+        insertRow(BASE, userId, actionA, entityTypeA, "9001", "첫 행");
+        insertRow(BASE.plusHours(1), null, actionB, entityTypeA, "9002", null); // 배치 발(user_id NULL)
+        insertRow(BASE.plusHours(2), userId, actionA, entityTypeB, "9003", null);
+    }
+
+    private void insertRow(
+            LocalDateTime occurredAt,
+            Long userId,
+            String actionCode,
+            String entityType,
+            String entityId,
+            String reason
+    ) {
+        jdbcTemplate.update("""
+                INSERT INTO fgc.audit_log
+                       (occurred_at, user_id, action_code, entity_type, entity_id,
+                        before_value, after_value, reason, request_id)
+                VALUES (?, ?, ?, ?, ?, '{"status":"DRAFT"}'::jsonb, '{"status":"CONFIRMED"}'::jsonb, ?, ?)
+                """, occurredAt, userId, actionCode, entityType, entityId, reason, "req-" + marker);
+    }
+
+    private AuditLogSearchCriteria criteria(
+            String entityType, String entityId, Long userId, String action,
+            LocalDateTime from, LocalDateTime toExclusive
+    ) {
+        return new AuditLogSearchCriteria(entityType, entityId, userId, action, from, toExclusive);
+    }
+
+    @Test
+    @DisplayName("대상 종류 필터 + 최신순 정렬 + LEFT JOIN 으로 배치 행의 userLoginId 는 null")
+    void filtersByEntityTypeAndSortsDescending() {
+        List<AuditLogRow> rows = queryMapper.selectAuditLogs(
+                criteria(entityTypeA, null, null, null, null, null), 0, 20);
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows.get(0).entityId()).isEqualTo("9002"); // 나중 시각이 먼저
+        assertThat(rows.get(0).userId()).isNull();
+        assertThat(rows.get(0).userLoginId()).isNull();       // 화면 표기 "BATCH"
+        assertThat(rows.get(1).entityId()).isEqualTo("9001");
+        assertThat(rows.get(1).userLoginId()).isEqualTo(loginId);
+        assertThat(rows.get(1).beforeValue()).contains("DRAFT");
+        assertThat(rows.get(1).afterValue()).contains("CONFIRMED");
+        assertThat(rows.get(1).reason()).isEqualTo("첫 행");
+        assertThat(rows.get(1).requestId()).isEqualTo("req-" + marker);
+    }
+
+    @Test
+    @DisplayName("대상 ID·행위자·행위 종류 필터 (IF-API-52 검색조건 — entityId 는 쿡북에 없던 조건)")
+    void filtersByEntityIdUserIdAndAction() {
+        assertThat(queryMapper.selectAuditLogs(
+                criteria(entityTypeA, "9001", null, null, null, null), 0, 20))
+                .singleElement()
+                .satisfies(row -> assertThat(row.entityId()).isEqualTo("9001"));
+
+        assertThat(queryMapper.selectAuditLogs(
+                criteria(entityTypeA, null, userId, null, null, null), 0, 20))
+                .singleElement()
+                .satisfies(row -> assertThat(row.entityId()).isEqualTo("9001"));
+
+        assertThat(queryMapper.selectAuditLogs(
+                criteria(null, null, null, actionB, null, null), 0, 20))
+                .singleElement()
+                .satisfies(row -> assertThat(row.actionCode()).isEqualTo(actionB));
+    }
+
+    @Test
+    @DisplayName("기간 필터 — from 포함, toExclusive 미포함")
+    void filtersByOccurredAtRange() {
+        List<AuditLogRow> rows = queryMapper.selectAuditLogs(
+                criteria(entityTypeA, null, null, null, BASE, BASE.plusHours(1)), 0, 20);
+
+        assertThat(rows).singleElement()
+                .satisfies(row -> assertThat(row.entityId()).isEqualTo("9001"));
+    }
+
+    @Test
+    @DisplayName("count 는 목록과 같은 조건을 공유하고 페이징은 LIMIT/OFFSET 으로 동작한다")
+    void countsAndPaginates() {
+        assertThat(queryMapper.countAuditLogs(
+                criteria(entityTypeA, null, null, null, null, null))).isEqualTo(2);
+
+        List<AuditLogRow> secondPage = queryMapper.selectAuditLogs(
+                criteria(entityTypeA, null, null, null, null, null), 1, 1);
+        assertThat(secondPage).singleElement()
+                .satisfies(row -> assertThat(row.entityId()).isEqualTo("9001"));
+    }
+
+    @Test
+    @DisplayName("필터 선택지 — 행위·대상 종류 DISTINCT 와 감사행을 남긴 사용자 목록")
+    void returnsFilterOptions() {
+        assertThat(queryMapper.selectDistinctActionCodes()).contains(actionA, actionB);
+        assertThat(queryMapper.selectDistinctEntityTypes()).contains(entityTypeA, entityTypeB);
+        assertThat(queryMapper.selectAuditUsers())
+                .anySatisfy(user -> {
+                    assertThat(user.userId()).isEqualTo(userId);
+                    assertThat(user.loginId()).isEqualTo(loginId);
+                });
+    }
+
+    @Test
+    @DisplayName("AuditLogMapper.insert 가 policy_version_id 를 저장하고 조회로 돌아온다")
+    void insertRoundTripsPolicyVersionId() {
+        Long policyVersionId = jdbcTemplate.queryForObject(
+                "SELECT policy_version_id FROM fgc.policy_version ORDER BY policy_version_id LIMIT 1",
+                Long.class);
+        String action = "T_PV_" + marker;
+
+        int affected = auditLogMapper.insert(AuditLogInsertRow.builder()
+                .userId(userId)
+                .actionCode(action)
+                .entityType(entityTypeB)
+                .entityId("9100")
+                .beforeValue(null)
+                .afterValue("{\"policy\":true}")
+                .policyVersionId(policyVersionId)
+                .build());
+
+        assertThat(affected).isEqualTo(1);
+        List<AuditLogRow> rows = queryMapper.selectAuditLogs(
+                criteria(null, null, null, action, null, null), 0, 20);
+        assertThat(rows).singleElement().satisfies(row -> {
+            assertThat(row.policyVersionId()).isEqualTo(policyVersionId);
+            assertThat(row.afterValue()).contains("policy");
+        });
+    }
+}

--- a/src/test/java/com/susukkang/fgc/audit/service/AuditLogServiceTest.java
+++ b/src/test/java/com/susukkang/fgc/audit/service/AuditLogServiceTest.java
@@ -1,0 +1,135 @@
+package com.susukkang.fgc.audit.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.susukkang.fgc.audit.dto.AuditLogInsertRow;
+import com.susukkang.fgc.audit.mapper.AuditLogMapper;
+import com.susukkang.fgc.auth.dto.AppUserView;
+import com.susukkang.fgc.auth.dto.FgcUserDetails;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * FUN-061 공통 감사 기록 서비스 단위 테스트.
+ * 기록 실패가 예외로 전파되는지(기록률 100% — 업무 트랜잭션 동반 롤백)와
+ * 컬럼 길이 clamp(감사행 조용한 유실 방지)를 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class AuditLogServiceTest {
+
+    @Mock
+    private AuditLogMapper auditLogMapper;
+
+    private AuditLogService auditLogService;
+
+    @BeforeEach
+    void setUp() {
+        auditLogService = new AuditLogService(auditLogMapper, new ObjectMapper());
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("before/after 를 JSON 으로 직렬화하고 entityId·reason 을 컬럼 길이로 자른다")
+    void serializesValuesAndClampsLengths() {
+        given(auditLogMapper.insert(any())).willReturn(1);
+
+        auditLogService.record(AuditLogService.AuditEvent.builder()
+                .actionCode("CONTRACT_CREATED")
+                .entityType("CONTRACT")
+                .entityId("x".repeat(150))
+                .userId(12L)
+                .before(Map.of("status", "DRAFT"))
+                .after(Map.of("status", "CONFIRMED"))
+                .reason("r".repeat(1100))
+                .policyVersionId(3L)
+                .build());
+
+        ArgumentCaptor<AuditLogInsertRow> captor = ArgumentCaptor.forClass(AuditLogInsertRow.class);
+        verify(auditLogMapper).insert(captor.capture());
+        AuditLogInsertRow row = captor.getValue();
+        assertThat(row.getActionCode()).isEqualTo("CONTRACT_CREATED");
+        assertThat(row.getEntityType()).isEqualTo("CONTRACT");
+        assertThat(row.getEntityId()).hasSize(100);
+        assertThat(row.getReason()).hasSize(1000);
+        assertThat(row.getUserId()).isEqualTo(12L);
+        assertThat(row.getBeforeValue()).isEqualTo("{\"status\":\"DRAFT\"}");
+        assertThat(row.getAfterValue()).isEqualTo("{\"status\":\"CONFIRMED\"}");
+        assertThat(row.getPolicyVersionId()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("userId 를 지정하지 않으면 SecurityContext 의 로그인 사용자로 해석한다")
+    void resolvesUserIdFromSecurityContext() {
+        given(auditLogMapper.insert(any())).willReturn(1);
+        AppUserView view = new AppUserView();
+        view.setUserId(7L);
+        view.setLoginId("settle01");
+        view.setPasswordHash("x");
+        view.setUserName("정산담당");
+        view.setRoleCode("SETTLEMENT");
+        FgcUserDetails details = new FgcUserDetails(view, true, true);
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(details, null, details.getAuthorities()));
+
+        auditLogService.record(AuditLogService.AuditEvent.builder()
+                .actionCode("PAYMENT_CREATED")
+                .entityType("COMMISSION_PAYMENT")
+                .entityId("1")
+                .build());
+
+        ArgumentCaptor<AuditLogInsertRow> captor = ArgumentCaptor.forClass(AuditLogInsertRow.class);
+        verify(auditLogMapper).insert(captor.capture());
+        assertThat(captor.getValue().getUserId()).isEqualTo(7L);
+    }
+
+    @Test
+    @DisplayName("로그인 사용자도 명시 userId 도 없으면 null(배치 표기 BATCH)로 남긴다")
+    void leavesUserIdNullWithoutAuthentication() {
+        given(auditLogMapper.insert(any())).willReturn(1);
+
+        auditLogService.record(AuditLogService.AuditEvent.builder()
+                .actionCode("VALIDATION_RUN_STARTED")
+                .entityType("VALIDATION_RUN")
+                .entityId("1")
+                .build());
+
+        ArgumentCaptor<AuditLogInsertRow> captor = ArgumentCaptor.forClass(AuditLogInsertRow.class);
+        verify(auditLogMapper).insert(captor.capture());
+        assertThat(captor.getValue().getUserId()).isNull();
+        assertThat(captor.getValue().getBeforeValue()).isNull();
+        assertThat(captor.getValue().getAfterValue()).isNull();
+    }
+
+    @Test
+    @DisplayName("INSERT 가 1행이 아니면 예외를 던져 호출자 트랜잭션을 롤백시킨다 — 기록률 100% 인수조건")
+    void throwsWhenInsertDoesNotAffectOneRow() {
+        given(auditLogMapper.insert(any())).willReturn(0);
+
+        assertThatThrownBy(() -> auditLogService.record(AuditLogService.AuditEvent.builder()
+                .actionCode("CONTRACT_UPDATED")
+                .entityType("CONTRACT")
+                .entityId("9")
+                .build()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("CONTRACT_UPDATED");
+    }
+}

--- a/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
@@ -81,20 +81,8 @@ class ScreenViewControllerTest {
         return new com.susukkang.fgc.auth.dto.FgcUserDetails(view, true, true);
     }
 
-    /** AUDT-W01(FUN-061)은 COMPLIANCE·SYSTEM_ADMIN 전용 — 화면정의서 :1530. */
-    @Test
-    void audit_log_screen_renders_for_compliance() throws Exception {
-        mvc.perform(get("/audit-logs").with(user(complianceUser())))
-                .andExpect(status().isOk())
-                .andExpect(content().string(org.hamcrest.Matchers.containsString("FGC-UI-AUDT-W01")));
-    }
-
-    /** FUN-002 인수조건: 권한 없는 역할의 직접 URL 호출은 403 으로 차단된다. */
-    @Test
-    void audit_log_screen_forbidden_for_settlement() throws Exception {
-        mvc.perform(get("/audit-logs").with(user(settleUser())))
-                .andExpect(status().isForbidden());
-    }
+    // AUDT-W01(/audit-logs) 스모크·역할 테스트는 데이터 바인딩 이관과 함께
+    // audit.controller.AuditLogViewControllerTest 로 옮겼다 (FUN-061).
 
     /**
      * COMPLIANCE "모든 처리 버튼 회색"(화면정의서 :229) — readOnly 모델값이 아니라

--- a/src/test/java/com/susukkang/fgc/contract/service/ContractServiceTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/service/ContractServiceTest.java
@@ -1,4 +1,5 @@
 package com.susukkang.fgc.contract.service;
+import com.susukkang.fgc.audit.service.AuditLogService;
 import com.susukkang.fgc.common.web.PageResponse;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.contract.domain.DataOrigin;
@@ -64,6 +65,9 @@ class ContractServiceTest {
 
     @Mock
     private ScheduleService scheduleService;
+
+    @Mock
+    private AuditLogService auditLogService;
 
     @InjectMocks
     private ContractService contractService;

--- a/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
@@ -1134,17 +1134,19 @@ class CommissionPaymentServiceImplTest {
         AuditLogService.AuditEvent event = captor.getValue();
         assertThat(event.actionCode()).isEqualTo("PAYMENT_UPDATED");
         assertThat(event.entityId()).isEqualTo("101");
-        // before 는 after 와 같은 payment/attributions 구조 — diff 화면에서 필드끼리 비교된다
+        // before/after 모두 같은 조회 DTO(Row) 기반 payment/attributions 구조 —
+        // 스키마가 일치해야 diff 화면이 필드 단위로 비교된다
         @SuppressWarnings("unchecked")
         java.util.Map<String, Object> before = (java.util.Map<String, Object>) event.before();
         assertThat(before).containsKeys("payment", "attributions");
-        @SuppressWarnings("unchecked")
-        java.util.Map<String, Object> beforePayment = (java.util.Map<String, Object>) before.get("payment");
-        assertThat(beforePayment.get("status")).isEqualTo(CommissionPaymentStatus.DRAFT);
+        assertThat(((CommissionPaymentRow) before.get("payment")).status())
+                .isEqualTo(CommissionPaymentStatus.DRAFT);
         assertThat((List<?>) before.get("attributions")).hasSize(1);
         @SuppressWarnings("unchecked")
         java.util.Map<String, Object> after = (java.util.Map<String, Object>) event.after();
         assertThat(after).containsKeys("payment", "attributions");
+        assertThat(after.get("payment")).isInstanceOf(CommissionPaymentRow.class);
+        assertThat(before.get("payment").getClass()).isEqualTo(after.get("payment").getClass());
     }
 
     /** 확정 감사행의 after 에는 1,200% 판정 요약(capChecks)이 담긴다 — REG-22·포함/제외 판단 근거. */

--- a/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
@@ -1134,8 +1134,17 @@ class CommissionPaymentServiceImplTest {
         AuditLogService.AuditEvent event = captor.getValue();
         assertThat(event.actionCode()).isEqualTo("PAYMENT_UPDATED");
         assertThat(event.entityId()).isEqualTo("101");
-        assertThat(event.before()).isNotNull();
-        assertThat(event.after()).isNotNull();
+        // before 는 after 와 같은 payment/attributions 구조 — diff 화면에서 필드끼리 비교된다
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Object> before = (java.util.Map<String, Object>) event.before();
+        assertThat(before).containsKeys("payment", "attributions");
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Object> beforePayment = (java.util.Map<String, Object>) before.get("payment");
+        assertThat(beforePayment.get("status")).isEqualTo(CommissionPaymentStatus.DRAFT);
+        assertThat((List<?>) before.get("attributions")).hasSize(1);
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Object> after = (java.util.Map<String, Object>) event.after();
+        assertThat(after).containsKeys("payment", "attributions");
     }
 
     /** 확정 감사행의 after 에는 1,200% 판정 요약(capChecks)이 담긴다 — REG-22·포함/제외 판단 근거. */

--- a/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/transaction/service/CommissionPaymentServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.susukkang.fgc.transaction.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.susukkang.fgc.audit.service.AuditLogService;
 import com.susukkang.fgc.cap.dto.CapCalculationCommand;
 import com.susukkang.fgc.cap.dto.CapCalculationResult;
 import com.susukkang.fgc.cap.service.CapCalculator;
@@ -75,6 +76,8 @@ class CommissionPaymentServiceImplTest {
     private CapCalculator capCalculator;
     @Mock
     private CapExceptionService capExceptionService;
+    @Mock
+    private AuditLogService auditLogService;
 
     private CommissionPaymentServiceImpl service;
     private FgcMessageResolver messageResolver;
@@ -93,7 +96,8 @@ class CommissionPaymentServiceImplTest {
                 capValidator,
                 capCalculator,
                 capExceptionService,
-                messageResolver
+                messageResolver,
+                auditLogService
         );
     }
 
@@ -1084,6 +1088,113 @@ class CommissionPaymentServiceImplTest {
         assertThat(transactional).isNotNull();
         assertThat(transactional.noRollbackFor())
                 .containsExactly(CommissionPaymentConfirmationRejectedException.class);
+    }
+
+    // FUN-061·운영정책서 제51조 — 지급 건 등록·수정·확정은 같은 트랜잭션에서 감사행을 남긴다.
+    // 감사행 저장 자체(clamp·직렬화·실패 전파)는 AuditLogServiceTest, DB 왕복은
+    // AuditLogQueryMapperIntegrationTest 가 검증하므로 여기서는 호출 계약만 본다.
+    @Test
+    void recordsPaymentCreatedAuditWithAttributionSnapshot() {
+        stubReferences(3L);
+        stubInsertAndResponse(List.of(attributionRow(1, 3L, "500000")));
+
+        service.create(createRequest(List.of(
+                attribution(3L, "500000", AttributionMethod.APPROVED_ALLOCATION))));
+
+        ArgumentCaptor<AuditLogService.AuditEvent> captor =
+                ArgumentCaptor.forClass(AuditLogService.AuditEvent.class);
+        verify(auditLogService).record(captor.capture());
+        AuditLogService.AuditEvent event = captor.getValue();
+        assertThat(event.actionCode()).isEqualTo("PAYMENT_CREATED");
+        assertThat(event.entityType()).isEqualTo("COMMISSION_PAYMENT");
+        assertThat(event.entityId()).isEqualTo("101");
+        assertThat(event.policyVersionId()).isEqualTo(3L);
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Object> after = (java.util.Map<String, Object>) event.after();
+        assertThat(after).containsKeys("payment", "attributions");
+    }
+
+    @Test
+    void recordsPaymentUpdatedAuditWithBeforeSnapshot() {
+        stubReferences(3L, 9L);
+        given(mapper.findConfirmationDataForUpdate(101L)).willReturn(List.of(confirmation(
+                201L, 3L, "500000", "500000", InclusionDecisionStatus.INCLUDED,
+                ExclusionType.NONE, AttributionMethod.DIRECT, "EVIDENCE"
+        )));
+        given(mapper.findById(101L)).willReturn(row(CommissionPaymentStatus.DRAFT));
+        given(mapper.findAttributions(101L)).willReturn(List.of(attributionRow(1, 9L, "500000")));
+        given(mapper.updateTransaction(any(CommissionPaymentCommand.class))).willReturn(1);
+
+        service.update(101L, updateRequest(List.of(
+                attribution(9L, "500000", AttributionMethod.APPROVED_ALLOCATION))));
+
+        ArgumentCaptor<AuditLogService.AuditEvent> captor =
+                ArgumentCaptor.forClass(AuditLogService.AuditEvent.class);
+        verify(auditLogService).record(captor.capture());
+        AuditLogService.AuditEvent event = captor.getValue();
+        assertThat(event.actionCode()).isEqualTo("PAYMENT_UPDATED");
+        assertThat(event.entityId()).isEqualTo("101");
+        assertThat(event.before()).isNotNull();
+        assertThat(event.after()).isNotNull();
+    }
+
+    /** 확정 감사행의 after 에는 1,200% 판정 요약(capChecks)이 담긴다 — REG-22·포함/제외 판단 근거. */
+    @Test
+    void recordsPaymentConfirmedAuditWithCapCheckSummaries() {
+        List<ConfirmationData> data = List.of(
+                confirmation(201L, 3L, "300000", "500000", InclusionDecisionStatus.INCLUDED,
+                        ExclusionType.NONE, AttributionMethod.APPROVED_ALLOCATION, "EVIDENCE-1"),
+                confirmation(202L, 9L, "200000", "500000", InclusionDecisionStatus.INCLUDED,
+                        ExclusionType.NONE, AttributionMethod.APPROVED_ALLOCATION, "EVIDENCE-2")
+        );
+        given(mapper.findConfirmationDataForUpdate(101L)).willReturn(data);
+        given(mapper.findCapRuleSnapshot(101L, 201L)).willReturn(capRule("0", null));
+        given(mapper.findCapRuleSnapshot(101L, 202L)).willReturn(capRule("0", null));
+        given(capCalculator.calculate(any())).willReturn(capCalculation(3L), capCalculation(9L));
+        doAnswer(invocation -> {
+            invocation.<CapCheckCommand>getArgument(0).setCapCheckId(55L);
+            return null;
+        }).when(mapper).insertCapCheck(any());
+        given(mapper.confirm(101L, null, "55,55")).willReturn(1);
+        given(mapper.findById(101L)).willReturn(row(CommissionPaymentStatus.CONFIRMED));
+        given(mapper.findAttributions(101L)).willReturn(List.of(
+                attributionRow(1, 3L, "300000"),
+                attributionRow(2, 9L, "200000")
+        ));
+
+        service.confirm(101L, null);
+
+        ArgumentCaptor<AuditLogService.AuditEvent> captor =
+                ArgumentCaptor.forClass(AuditLogService.AuditEvent.class);
+        verify(auditLogService).record(captor.capture());
+        AuditLogService.AuditEvent event = captor.getValue();
+        assertThat(event.actionCode()).isEqualTo("PAYMENT_CONFIRMED");
+        assertThat(event.entityId()).isEqualTo("101");
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Object> after = (java.util.Map<String, Object>) event.after();
+        assertThat(after.get("status")).isEqualTo(CommissionPaymentStatus.CONFIRMED);
+        assertThat((List<?>) after.get("capChecks")).hasSize(2);
+    }
+
+    /** 멱등키 재요청은 상태 변경이 아니므로 감사행을 다시 남기지 않는다. */
+    @Test
+    void doesNotRecordAuditOnIdempotentReconfirm() {
+        ConfirmationData confirmed = withConfirmationState(
+                confirmation(
+                        201L, 3L, "500000", "500000", InclusionDecisionStatus.INCLUDED,
+                        ExclusionType.NONE, AttributionMethod.DIRECT, "EVIDENCE"
+                ),
+                CommissionPaymentStatus.CONFIRMED,
+                "confirm-101"
+        );
+        given(mapper.findConfirmationDataForUpdate(101L)).willReturn(List.of(confirmed));
+        given(mapper.findCapCheckIds(101L)).willReturn(List.of(55L));
+        given(mapper.findById(101L)).willReturn(row(CommissionPaymentStatus.CONFIRMED));
+        given(mapper.findAttributions(101L)).willReturn(List.of(attributionRow(1, 3L, "500000")));
+
+        service.confirm(101L, "confirm-101");
+
+        verify(auditLogService, never()).record(any());
     }
 
     private void stubReferences(Long... contractIds) {


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* FGC-FUN-061 「핵심 업무 감사로그」 개발 — 기록 커버리지 확장(계약·지급 건·수동 차익거래 재검증) + 조회 API(IF-API-52) + 감사로그 조회 화면(FGC-UI-AUDT-W01) 서버 렌더링 + 조회 인덱스 추가

## 🔗 2. 관련 이슈

* Closes #185

## 🛠 3. 구현 내용

* **공통 감사 기록 서비스 `AuditLogService` 신설** — 운영정책서 제51조("각 서비스가 같은 트랜잭션에서 감사행을 명시적으로 생성")에 따라 AOP 대신 공통 서비스 + 명시 호출 방식 채택. SecurityContext 사용자 해석, before/after JSON 직렬화, 컬럼 길이 clamp(감사행 조용한 유실 방지), **INSERT 실패 시 예외 전파로 업무 트랜잭션 동반 롤백**(기록률 100% 인수조건). 기존 4곳(로그인·예외·분개·검증배치)은 의도된 개별 정책(실패-삼킴, 배치 userId 규약)이라 리팩터링하지 않음
* **신규 기록 지점 3파일** (모두 `@Transactional` 내부 호출 = 같은 트랜잭션)
    * `ContractService` 등록·수정 → `CONTRACT_CREATED` / `CONTRACT_UPDATED` (before/after 계약 전체 스냅샷)
    * `CommissionPaymentServiceImpl` 등록·수정·확정 → `PAYMENT_CREATED` / `PAYMENT_UPDATED` / `PAYMENT_CONFIRMED` — after JSON에 지급단계·포함/제외 판단(capChecks 요약)·정착지원금 귀속·배부정책·증빙(REG-20·22)과 `policy_version_id` 기록. 멱등키 재확정은 상태 변경이 아니므로 기록하지 않고, 확정 거절 경로는 exception_case가 근거를 보존하므로 감사행을 남기지 않음(의도, 주석 명시)
    * `ArbitrageService.reArbitrageCheck()` → `ARBITRAGE_RECHECKED` (실행 사용자·사유 포함)
* **`AuditLogInsertRow`·`AuditLogMapper.xml` 갭 해소** — 테이블에는 있으나 DTO/XML에 누락됐던 `policy_version_id` 추가 (FUN-061 "정책버전 기록" 요구)
* **조회 API IF-API-52** `GET /api/v1/audit-logs` — FUN-006 7파일 패턴(Controller → Service I/F+Impl → Response/Row record → Mapper I/F+XML). INSERT 전용 `AuditLogMapper`와 분리한 **`AuditLogQueryMapper` 신설**로 append-only 계약을 매퍼 단위로 유지. entityType·entityId·userId·action·from·to 필터(entityId는 쿡북 누락분 보완), `app_user` LEFT JOIN(배치 행 userLoginId null), 페이징·`from>to` 검증(COMMON_002)
* **AUDT-W01 화면** — `AuditLogViewController` 신설, `ScreenViewController`의 `/audit-logs` 매핑 이관. 인터페이스정의서 §5-2 "Ajax 없음"대로 순수 MPA 서버 렌더링: 필터 선택지 DISTINCT 바인딩, 20행 서버 페이징 + 검색조건 URL 유지(§4-1 공통 규칙 7), before/after **서버 diff 계산으로 바뀐 칸만 노랗게**, 행위자 NULL→"BATCH", 수정·삭제 버튼 금지 유지
* **`V20__audit_log_indexes.sql`** — audit_log 조회 인덱스 3개(occurred_at DESC / entity_type+entity_id / user_id). 기존 인덱스 0개였음

## 🧪 4. 테스트 방법

1. `docker compose up -d fgc-db` 후 `./gradlew build` — 전체 테스트(830개) 통과 확인
2. 애플리케이션 실행 후 `audit01`(COMPLIANCE)로 로그인 → 관리 > 감사로그(`/audit-logs`)에서 목록·필터·페이징·행 선택 시 diff 하이라이트 확인. `settle01`로 직접 URL 접근 시 403 확인
3. 계약 등록/수정, 지급 건 등록/수정/확정 수행 후 감사로그 화면(또는 `GET /api/v1/audit-logs?entityType=COMMISSION_PAYMENT`)에서 해당 감사행 기록 확인

## 🗄️ 5. DB / Flyway 변경

* [ ] DB 변경 없음
* [x] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* V20__audit_log_indexes.sql (인덱스 3개 추가 — 스키마·데이터 변경 없음)

## 📋 6. 리뷰 요구사항

* `AuditLogService`의 실패 정책(예외 전파 = 업무 롤백)이 신규 기록 지점 전용이고, 로그인 감사(AuthAuditListener)의 실패-삼킴 정책과 의도적으로 다르다는 점 — 두 정책을 통합하면 안 됩니다
* `CommissionPaymentServiceImpl.confirm()`의 감사행 위치(확정 성공 직후)와 거절 경로(noRo않는 것이 의도인지 검토
* `AuditLogQueryMapper.xml`의 jsonb `::text` 캐스트와 동적 조건, V20 인덱스 구성이 조회 패턴에 적절한지

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* FGC-UI-AUDT-W01 감사로그 조회(`audit/list.html`) — 정적 골격에 서버 렌더링 데이터 바인딩: 검색 폼(GET, 조건 URL 유지), 필터 선택지, 목록 8컬럼(행위자 NULL→"BATCH"), 20행 페이징, 변경 내용 비교 패널(바뀐 칸만 노랗게). 수정·삭제 버튼 없음(화면정의서 "막아야 할 것" 유지)

## 💬 9. 참고 사항

* **범위 밖(해당 기능 개발 시 감사행 추가 필요, 이슈 #185 본문에 후속 메모)**: 정책버전 활성화·종료(1차엔 정책 CRUD 없음 — 운영정책서 제50조, Flyway 시드만), 검증 확정 FUN-044 finalize API, 원장 역분개·재기표, 권한 CRUD. 환수 워크플로 감사는 2차
* `ARBITRAGE_RECHECKED`는 실DB 통합 테스트를 두지 않았습니다 — 검증 실행 생성(`ValidationRunCreateServiceImpl`)이 REQUIRES_NEW로 별도 커밋되어 테스트 롤백으로 정리되지 않고 `uq_validation_run_active_manual_contract` 잔존 충돌을 일으키기 때문입니다. 감사 호출 계약은 `ArbitrageServiceTest.recordsArbitrageRecheckedAudit`가 검증합니다(코드 주석에 사유 명시)
* audit_log는 append-only(DB 트리거)라 통합 테스트 정리는 `@Transactional` 롤백으로만 가능합니다
* 화면 필터 선택지의 DISTINCT 쿼리는 데이터가 커지면 enum 승격을 검토합니다
* 쿡북 §4-13의 GA_ADMIN 권한 표기는 화면정의서·인터페이스정의서와 불일치 — **COMPLIANCE·SYSTEM_ADMIN만**이 정본이며 코드도 이를 따릅니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 감사 로그 조회 화면과 API를 추가했습니다.
  - 대상, 행위자, 행위, 기간별 필터와 페이지네이션을 지원합니다.
  - 선택한 기록의 변경 전·후 값을 비교하고 변경 내용을 강조 표시합니다.
  - 계약 등록·수정, 지급 처리, 수동 재검증 결과를 감사 로그로 기록합니다.
  - 요청 사유, 실행 사용자, 요청 ID, 정책 버전 등의 정보를 확인할 수 있습니다.
- **개선**
  - 권한이 있는 사용자만 감사 로그를 조회할 수 있습니다.
  - 검색 조건과 선택한 기록을 유지해 편리하게 확인할 수 있습니다.
  - 최신순 조회와 인덱스를 적용해 감사 로그 검색 성능을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->