### PR TITLE
[Fix] 실제명세·확정지급 원천 조회에 cashflow_type=PAYMENT 필터 추가

### DIFF
--- a/src/main/resources/mapper/journal/JournalPostingSourceMapper.xml
+++ b/src/main/resources/mapper/journal/JournalPostingSourceMapper.xml
@@ -67,6 +67,7 @@
           AND vt.selection_status = 'SELECTED'
           AND ct.payment_stage = 'INSURER_TO_GA'
           AND ct.source_type = 'INSURER_STATEMENT'
+          AND ct.cashflow_type = 'PAYMENT'
           AND ct.status = 'CONFIRMED'
           AND ct.settlement_month = #{validationMonth}
           AND NOT EXISTS (
@@ -83,6 +84,11 @@
       운영정책서 제38조 "2차에서 ADJUSTMENT, CLAWBACK, RECOVERY를 활성화한다")과 개념이
       겹쳐 CONFIRMED_FC_PAYOUT으로 잘못 표시하면 안 된다. contractId 연결 방식은 위
       findActualInsurerStatementSources 주석 참고.
+      cashflow_type = 'PAYMENT'도 함께 건다 — GA_MANUAL_PAYMENT API의 validateCashflowType은
+      요청값이 항목의 cashflow_type과 일치하는지만 검사할 뿐 DEDUCTION(클로백·환수 항목)을
+      막지 않는다. source_type만으로는 이 DEDUCTION 건을 걸러내지 못해 대사 Mapper
+      (InsurerGaReconciliationMapper·GaFcReconciliationMapper)와 동일하게 명시적으로 제외한다
+      (코드리뷰로 발견).
     -->
     <select id="findConfirmedFcPayoutSources" resultType="com.susukkang.fgc.journal.dto.TransactionJournalSourceRow">
         SELECT ct.commission_transaction_id, ta.contract_id, ct.policy_version_id, ct.commission_item_id,
@@ -98,6 +104,7 @@
           AND vt.selection_status = 'SELECTED'
           AND ct.payment_stage = 'GA_TO_FC'
           AND ct.source_type IN ('GA_MANUAL_PAYMENT', 'GA_CONFIRMED_PAYMENT')
+          AND ct.cashflow_type = 'PAYMENT'
           AND ct.status = 'CONFIRMED'
           AND ct.settlement_month = #{validationMonth}
           AND ct.recipient_agent_id IS NOT NULL


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* JournalPostingSourceMapper의 실제명세·확정지급 원천 조회 쿼리에 cashflow_type='PAYMENT' 필터 추가

## 🔗 2. 관련 이슈

* Closes #142

## 🛠 3. 구현 내용

* findActualInsurerStatementSources/findConfirmedFcPayoutSources가 source_type만 걸러 DEDUCTION(클로백·환수) 거래가 그대로 기표될 수 있던 문제 수정
* 같은 원천을 읽는 대사 Mapper(InsurerGaReconciliationMapper, GaFcReconciliationMapper)와 동일하게 cashflow_type = 'PAYMENT' 조건 추가

## 🧪 4. 테스트 방법

1. `./gradlew compileTestJava` 통과 확인
2. `./gradlew test --tests "com.susukkang.fgc.journal.service.JournalPostingPortImplIntegrationTest"` 실행 (기존 픽스처가 이미 cashflow_type='PAYMENT'라 영향 없음)

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* JournalPostingSourceMapper.xml의 두 SELECT문 조건절

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [ ] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음

## 💬 9. 참고 사항

* #158 병합 후 코드리뷰에서 지적된 사항을 반영한 후속 수정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 실제 보험사 명세 및 확정 FC 지급 조회에서 공제성 거래를 제외하도록 개선했습니다.
  * 조회 대상과 계약 귀속 검증 흐름은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->