### PR TITLE
[Fix]: Validation 대상 선별 상품코드 비교를 표준상품코드 기준으로 정정

### DIFF
--- a/src/main/resources/mapper/validation/ValidationTargetSelectionMapper.xml
+++ b/src/main/resources/mapper/validation/ValidationTargetSelectionMapper.xml
@@ -15,7 +15,7 @@
                    ic.payment_term_months,
                    po.product_id,
                    po.channel_code,
-                   p.insurer_product_code
+                   p.standard_product_code
               FROM insurance_contract ic
               JOIN product_offering po
                 ON po.product_offering_id = ic.product_offering_id
@@ -31,7 +31,11 @@
         candidate AS (
             SELECT ec.*,
                    rrt.refund_rate_table_id,
-                   (rrt.source_product_code = ec.insurer_product_code) AS product_code_matches
+                   <!-- 환급률표 정본은 표준상품코드 기준이다(시드데이터 명세서 §환급률표 필수 조합:
+                        상품 식별을 STD-* 로 하고, V3 시드도 source_product_code 에 표준코드를 적재).
+                        보험사 상품코드(insurer_product_code)와 비교하면 전 계약이 "상품코드 불일치"로
+                        REVIEW_REQUIRED 처리되어 하위 검증(1,200%·차익거래·원장·대사·예외)이 전부 빈다. -->
+                   (rrt.source_product_code = ec.standard_product_code) AS product_code_matches
               FROM eligible_contract ec
               LEFT JOIN refund_rate_table rrt
                 ON rrt.insurer_id = ec.insurer_id
@@ -63,13 +67,13 @@
                    insurer_id,
                    payment_term_months,
                    channel_code,
-                   insurer_product_code,
+                   standard_product_code,
                    COUNT(refund_rate_table_id) AS candidate_count,
                    COUNT(refund_rate_table_id) FILTER (WHERE product_code_matches) AS matching_count,
                    MIN(refund_rate_table_id) FILTER (WHERE product_code_matches) AS refund_rate_table_id
               FROM candidate
              GROUP BY contract_id, product_offering_id, contract_date, current_status,
-                      insurer_id, payment_term_months, channel_code, insurer_product_code
+                      insurer_id, payment_term_months, channel_code, standard_product_code
         )
         INSERT INTO validation_target (
             validation_run_id,
@@ -99,7 +103,7 @@
                    'insurerId', insurer_id,
                    'paymentTermMonths', payment_term_months,
                    'channelCode', channel_code,
-                   'insurerProductCode', insurer_product_code,
+                   'standardProductCode', standard_product_code,
                    'refundRateCandidateCount', candidate_count,
                    'refundRateMatchingCount', matching_count
                )

--- a/src/test/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobIntegrationTest.java
@@ -67,8 +67,10 @@ class MonthlyValidationJobIntegrationTest {
     //       실제로 대상이 선정되어 arbitrage_check·journal·reconciliation·exception_case가
     //       생성되고 validation_run DELETE가 FK 위반으로 실패했다.
     // 개선: validation_run을 참조하는 자식(손자 포함)을 FK 순서대로 전부 지운다.
-    //       스케줄(schedule_header/line)은 실행 FK가 없는 계약 단위 재생성이라 지우지 않는다
-    //       — 재실행 시 멱등 재생성되는 실제 배치의 부수효과와 같다.
+    //       스케줄(schedule_header/line)은 실행 FK가 없지만, 이 실행의 대상 계약에 재생성된
+    //       채로 남기면 자기 스케줄을 직접 넣는 다른 통합테스트(CapCalculator·Reconciliation
+    //       계열)와 활성 OPERATIONAL 부분 UNIQUE가 실행 순서에 따라 충돌한다 — 대상 계약
+    //       기준으로 함께 지운다(validation_target 삭제보다 먼저).
     @AfterEach
     void cleanUp() {
         createdValidationRunIds.forEach(id -> {
@@ -123,6 +125,22 @@ class MonthlyValidationJobIntegrationTest {
                     "DELETE FROM fgc.maintenance_check WHERE validation_run_id = ?", id);
             jdbcTemplate.update(
                     "DELETE FROM fgc.contract_status_event_processing WHERE validation_run_id = ?", id);
+            jdbcTemplate.update("""
+                    DELETE FROM fgc.schedule_line
+                     WHERE schedule_header_id IN (
+                         SELECT sh.schedule_header_id
+                           FROM fgc.schedule_header sh
+                          WHERE sh.contract_id IN (
+                              SELECT contract_id FROM fgc.validation_target WHERE validation_run_id = ?
+                          )
+                     )
+                    """, id);
+            jdbcTemplate.update("""
+                    DELETE FROM fgc.schedule_header
+                     WHERE contract_id IN (
+                         SELECT contract_id FROM fgc.validation_target WHERE validation_run_id = ?
+                     )
+                    """, id);
             jdbcTemplate.update(
                     "DELETE FROM fgc.validation_target WHERE validation_run_id = ?", id);
             jdbcTemplate.update(
@@ -168,13 +186,14 @@ class MonthlyValidationJobIntegrationTest {
      * 개선: 9개 Step 전부가 COMPLETED로 끝나고 validation_run도 COMPLETED로 전이하는 정상
      *       완료 경로를 검증하도록 갱신한다(클래스 Javadoc에서 예고한 #60 갱신 지점).
      *
-     * 2026-08-17 - 대상 선별 상품코드 비교 수정에 따른 전제 갱신
+     * 2026-08-17 - 대상 선별(FUN-042) 상품코드 비교 수정에 따른 전제 갱신
      * 기존 코드: "TEST_MONTH에는 대상 데이터가 없다"는 전제로 0건 완료 경로를 검증했다.
      * 문제: 그 0건은 실은 선별 SQL이 insurer_product_code와 비교하던 버그로 전 계약이
      *       REVIEW_REQUIRED가 된 결과였다. 표준상품코드 비교로 고치면 2031-03 asOfDate에도
      *       시드 계약이 선정되어 하위 Step들이 실제 결과를 만든다.
-     * 개선: 같은 실행이 "시드 데이터를 실제로 검증하며" 9개 Step 전부 COMPLETED로 끝나는
-     *       경로를 검증한다(메서드명 갱신). 생성물 정리는 확장된 cleanUp이 담당한다.
+     * 개선: 같은 실행이 "시드 데이터를 실제로 검증하며" 9개 Step 전부 COMPLETED로 끝나고,
+     *       Batch 완료 상태만이 아니라 실제 처리 결과(SELECTED 대상·하위 검증 산출물)까지
+     *       남는지 검증한다(메서드명 갱신). 생성물 정리는 확장된 cleanUp이 담당한다.
      */
     void completesAllStepsAgainstSeedData() throws Exception {
         jobLauncherTestUtils.setJob(monthlyValidationJob);
@@ -221,6 +240,22 @@ class MonthlyValidationJobIntegrationTest {
         assertThat(row.getRunNo()).isEqualTo(Math.toIntExact(runNo));
         assertThat(row.getStartedAt()).isNotNull();
         assertThat(row.getCompletedAt()).isNotNull();
+
+        // Batch COMPLETED만으로는 "빈 실행"과 구분이 안 된다 — 선별이 실제로 시드 계약을
+        // 선정했고(FUN-042), 하위 Step이 이 실행 스코프의 산출물을 남겼는지까지 본다.
+        // (선별이 전 계약을 REVIEW_REQUIRED로 흘려보내던 상품코드 비교 버그의 회귀 방지)
+        long selectedTargets = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM fgc.validation_target WHERE validation_run_id = ? AND selection_status = 'SELECTED'",
+                Long.class, validationRunId);
+        assertThat(selectedTargets).isPositive();
+        long reconciliationRuns = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM fgc.reconciliation_run WHERE validation_run_id = ?",
+                Long.class, validationRunId);
+        assertThat(reconciliationRuns).isPositive();
+        long arbitrageChecks = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM fgc.arbitrage_check WHERE validation_run_id = ?",
+                Long.class, validationRunId);
+        assertThat(arbitrageChecks).isPositive();
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobIntegrationTest.java
@@ -60,9 +60,51 @@ class MonthlyValidationJobIntegrationTest {
 
     private final List<Long> createdValidationRunIds = new ArrayList<>();
 
+    // 2026-08-17 - 대상 선별 상품코드 비교 수정에 따른 정리 범위 확장
+    // 기존 코드: cap_check(_detail)·validation_target·validation_run만 지웠다.
+    // 문제: 선별 SQL이 insurer_product_code와 비교하던 버그로 전 계약이 REVIEW_REQUIRED가 되어
+    //       하위 Step이 결과를 만들지 않았기에 그 정리로 충분했지만, 표준상품코드 비교로 고치자
+    //       실제로 대상이 선정되어 arbitrage_check·journal·reconciliation·exception_case가
+    //       생성되고 validation_run DELETE가 FK 위반으로 실패했다.
+    // 개선: validation_run을 참조하는 자식(손자 포함)을 FK 순서대로 전부 지운다.
+    //       스케줄(schedule_header/line)은 실행 FK가 없는 계약 단위 재생성이라 지우지 않는다
+    //       — 재실행 시 멱등 재생성되는 실제 배치의 부수효과와 같다.
     @AfterEach
     void cleanUp() {
         createdValidationRunIds.forEach(id -> {
+            jdbcTemplate.update("""
+                    DELETE FROM fgc.exception_action
+                     WHERE exception_case_id IN (
+                         SELECT exception_case_id FROM fgc.exception_case WHERE validation_run_id = ?
+                     )
+                    """, id);
+            jdbcTemplate.update(
+                    "DELETE FROM fgc.exception_case WHERE validation_run_id = ?", id);
+            jdbcTemplate.update("""
+                    DELETE FROM fgc.reconciliation_match
+                     WHERE reconciliation_result_id IN (
+                         SELECT rr.reconciliation_result_id
+                           FROM fgc.reconciliation_result rr
+                           JOIN fgc.reconciliation_run r ON r.reconciliation_run_id = rr.reconciliation_run_id
+                          WHERE r.validation_run_id = ?
+                     )
+                    """, id);
+            jdbcTemplate.update("""
+                    DELETE FROM fgc.reconciliation_result
+                     WHERE reconciliation_run_id IN (
+                         SELECT reconciliation_run_id FROM fgc.reconciliation_run WHERE validation_run_id = ?
+                     )
+                    """, id);
+            jdbcTemplate.update(
+                    "DELETE FROM fgc.reconciliation_run WHERE validation_run_id = ?", id);
+            jdbcTemplate.update("""
+                    DELETE FROM fgc.journal_line
+                     WHERE journal_header_id IN (
+                         SELECT journal_header_id FROM fgc.journal_header WHERE validation_run_id = ?
+                     )
+                    """, id);
+            jdbcTemplate.update(
+                    "DELETE FROM fgc.journal_header WHERE validation_run_id = ?", id);
             jdbcTemplate.update("""
                     DELETE FROM fgc.cap_check_detail
                      WHERE cap_check_id IN (
@@ -73,6 +115,14 @@ class MonthlyValidationJobIntegrationTest {
                     """, id);
             jdbcTemplate.update(
                     "DELETE FROM fgc.cap_check WHERE validation_run_id = ?", id);
+            jdbcTemplate.update(
+                    "DELETE FROM fgc.arbitrage_check WHERE validation_run_id = ?", id);
+            jdbcTemplate.update(
+                    "DELETE FROM fgc.acquisition_cost_check WHERE validation_run_id = ?", id);
+            jdbcTemplate.update(
+                    "DELETE FROM fgc.maintenance_check WHERE validation_run_id = ?", id);
+            jdbcTemplate.update(
+                    "DELETE FROM fgc.contract_status_event_processing WHERE validation_run_id = ?", id);
             jdbcTemplate.update(
                     "DELETE FROM fgc.validation_target WHERE validation_run_id = ?", id);
             jdbcTemplate.update(
@@ -117,8 +167,16 @@ class MonthlyValidationJobIntegrationTest {
      *       완료되고, Job 전체가 COMPLETED로 끝난다.
      * 개선: 9개 Step 전부가 COMPLETED로 끝나고 validation_run도 COMPLETED로 전이하는 정상
      *       완료 경로를 검증하도록 갱신한다(클래스 Javadoc에서 예고한 #60 갱신 지점).
+     *
+     * 2026-08-17 - 대상 선별 상품코드 비교 수정에 따른 전제 갱신
+     * 기존 코드: "TEST_MONTH에는 대상 데이터가 없다"는 전제로 0건 완료 경로를 검증했다.
+     * 문제: 그 0건은 실은 선별 SQL이 insurer_product_code와 비교하던 버그로 전 계약이
+     *       REVIEW_REQUIRED가 된 결과였다. 표준상품코드 비교로 고치면 2031-03 asOfDate에도
+     *       시드 계약이 선정되어 하위 Step들이 실제 결과를 만든다.
+     * 개선: 같은 실행이 "시드 데이터를 실제로 검증하며" 9개 Step 전부 COMPLETED로 끝나는
+     *       경로를 검증한다(메서드명 갱신). 생성물 정리는 확장된 cleanUp이 담당한다.
      */
-    void completesAllStepsWhenNoTargetDataExists() throws Exception {
+    void completesAllStepsAgainstSeedData() throws Exception {
         jobLauncherTestUtils.setJob(monthlyValidationJob);
         long runNo = ThreadLocalRandom.current().nextLong(1, Integer.MAX_VALUE);
 

--- a/src/test/java/com/susukkang/fgc/validation/mapper/ValidationTargetSelectionMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/mapper/ValidationTargetSelectionMapperIntegrationTest.java
@@ -19,7 +19,7 @@ class ValidationTargetSelectionMapperIntegrationTest {
     @Autowired JdbcTemplate jdbcTemplate;
 
     /**
-     * 데모 시드 기준 회귀 — insertTargets가 환급률표의 source_product_code(표준상품코드,
+     * FUN-042 데모 시드 기준 회귀 — insertTargets가 환급률표의 source_product_code(표준상품코드,
      * 시드데이터 명세서 §환급률표 필수 조합)를 product.standard_product_code와 비교해야 한다.
      * 보험사 상품코드(insurer_product_code)와 비교하던 버그에서는 전 계약이
      * "상품코드 불일치" REVIEW_REQUIRED로 빠져 하위 검증이 전부 비었다(대시보드 0건의 원인).
@@ -44,10 +44,19 @@ class ValidationTargetSelectionMapperIntegrationTest {
                  WHERE validation_run_id = ? AND selection_status = 'SELECTED'
                    AND refund_rate_table_id IS NULL
                 """, Long.class, runId);
+        // 판정에 실제로 쓴 코드가 snapshot 증거로 남아야 한다 — 키 교체(insurerProductCode
+        // → standardProductCode)가 되돌아가면 여기서 잡힌다.
+        long withoutStandardCodeEvidence = jdbcTemplate.queryForObject("""
+                SELECT COUNT(*) FROM fgc.validation_target
+                 WHERE validation_run_id = ?
+                   AND (snapshot ->> 'standardProductCode' IS NULL
+                        OR snapshot ->> 'insurerProductCode' IS NOT NULL)
+                """, Long.class, runId);
 
         assertThat(selected).isPositive();          // 시드의 정상 시나리오 계약이 선정돼야 한다
         assertThat(productCodeMismatch).isZero();   // 시드 정본 코드 체계에서 불일치는 없어야 한다
         assertThat(selectedWithoutTable).isZero();  // 선정 건은 환급률표가 반드시 배정된다
+        assertThat(withoutStandardCodeEvidence).isZero();
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/validation/mapper/ValidationTargetSelectionMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/mapper/ValidationTargetSelectionMapperIntegrationTest.java
@@ -19,18 +19,25 @@ class ValidationTargetSelectionMapperIntegrationTest {
     @Autowired JdbcTemplate jdbcTemplate;
 
     /**
-     * FUN-042 데모 시드 기준 회귀 — insertTargets가 환급률표의 source_product_code(표준상품코드,
+     * FGC-FUN-042 데모 시드 기준 회귀 — insertTargets가 환급률표의 source_product_code(표준상품코드,
      * 시드데이터 명세서 §환급률표 필수 조합)를 product.standard_product_code와 비교해야 한다.
      * 보험사 상품코드(insurer_product_code)와 비교하던 버그에서는 전 계약이
      * "상품코드 불일치" REVIEW_REQUIRED로 빠져 하위 검증이 전부 비었다(대시보드 0건의 원인).
      */
     @Test
-    void insertTargetsSelectsSeedContractsByStandardProductCode() {
-        Long runId = insertValidationRun(LocalDate.of(2098, 1, 1));
+    void fgcFun042InsertTargetsSelectsSeedContractsByStandardProductCode() {
+        LocalDate validationMonth = LocalDate.of(2026, 7, 1);
+        Long runId = insertValidationRun(validationMonth);
 
-        int inserted = mapper.insertTargets(runId, LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 31));
+        int inserted = mapper.insertTargets(runId, validationMonth, LocalDate.of(2026, 7, 31));
 
         assertThat(inserted).isPositive();
+        List<String> selectedContractNos = jdbcTemplate.queryForList("""
+                SELECT ic.contract_no
+                  FROM fgc.validation_target vt
+                  JOIN fgc.insurance_contract ic ON ic.contract_id = vt.contract_id
+                 WHERE vt.validation_run_id = ? AND vt.selection_status = 'SELECTED'
+                """, String.class, runId);
         long selected = jdbcTemplate.queryForObject("""
                 SELECT COUNT(*) FROM fgc.validation_target
                  WHERE validation_run_id = ? AND selection_status = 'SELECTED'
@@ -53,6 +60,13 @@ class ValidationTargetSelectionMapperIntegrationTest {
                         OR snapshot ->> 'insurerProductCode' IS NOT NULL)
                 """, Long.class, runId);
 
+        assertThat(selectedContractNos).containsExactlyInAnyOrder(
+                "FGC-FGL01-202607-0001",
+                "FGC-FGL01-202607-0002",
+                "FGC-FGL01-202607-0003",
+                "FGC-FGL01-202607-0004",
+                "FGC-FGL01-202607-0005",
+                "FGC-FGL02-202605-0001");
         assertThat(selected).isPositive();          // 시드의 정상 시나리오 계약이 선정돼야 한다
         assertThat(productCodeMismatch).isZero();   // 시드 정본 코드 체계에서 불일치는 없어야 한다
         assertThat(selectedWithoutTable).isZero();  // 선정 건은 환급률표가 반드시 배정된다

--- a/src/test/java/com/susukkang/fgc/validation/mapper/ValidationTargetSelectionMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/mapper/ValidationTargetSelectionMapperIntegrationTest.java
@@ -18,6 +18,38 @@ class ValidationTargetSelectionMapperIntegrationTest {
     @Autowired ValidationTargetSelectionMapper mapper;
     @Autowired JdbcTemplate jdbcTemplate;
 
+    /**
+     * 데모 시드 기준 회귀 — insertTargets가 환급률표의 source_product_code(표준상품코드,
+     * 시드데이터 명세서 §환급률표 필수 조합)를 product.standard_product_code와 비교해야 한다.
+     * 보험사 상품코드(insurer_product_code)와 비교하던 버그에서는 전 계약이
+     * "상품코드 불일치" REVIEW_REQUIRED로 빠져 하위 검증이 전부 비었다(대시보드 0건의 원인).
+     */
+    @Test
+    void insertTargetsSelectsSeedContractsByStandardProductCode() {
+        Long runId = insertValidationRun(LocalDate.of(2098, 1, 1));
+
+        int inserted = mapper.insertTargets(runId, LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 31));
+
+        assertThat(inserted).isPositive();
+        long selected = jdbcTemplate.queryForObject("""
+                SELECT COUNT(*) FROM fgc.validation_target
+                 WHERE validation_run_id = ? AND selection_status = 'SELECTED'
+                """, Long.class, runId);
+        long productCodeMismatch = jdbcTemplate.queryForObject("""
+                SELECT COUNT(*) FROM fgc.validation_target
+                 WHERE validation_run_id = ? AND selection_reason = '상품코드 불일치'
+                """, Long.class, runId);
+        long selectedWithoutTable = jdbcTemplate.queryForObject("""
+                SELECT COUNT(*) FROM fgc.validation_target
+                 WHERE validation_run_id = ? AND selection_status = 'SELECTED'
+                   AND refund_rate_table_id IS NULL
+                """, Long.class, runId);
+
+        assertThat(selected).isPositive();          // 시드의 정상 시나리오 계약이 선정돼야 한다
+        assertThat(productCodeMismatch).isZero();   // 시드 정본 코드 체계에서 불일치는 없어야 한다
+        assertThat(selectedWithoutTable).isZero();  // 선정 건은 환급률표가 반드시 배정된다
+    }
+
     @Test
     void selectsOnlySelectedContractsFromRequestedRunInContractOrder() {
         Long requestedRunId = insertValidationRun(LocalDate.of(2097, 1, 1));


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* 월 통합검증 대상 선별(FUN-042)의 상품코드 비교 버그 수정 — 환급률표 `source_product_code`(표준상품코드)를 `product.insurer_product_code`와 비교해 **전 계약이 "상품코드 불일치" REVIEW_REQUIRED로 빠지던 문제**를 `standard_product_code` 비교로 정정. 이 버그로 선정 계약이 0건이라 하위 검증 결과가 전부 비었고, 업무 대시보드 KPI·예외함이 0건이었다(#188/#192 실행 경로는 정상이었으나 검증할 대상이 없었던 것)

## 🔗 2. 관련 이슈

* 없음 (#192 머지 후 로컬 E2E 테스트 중 발견한 기존 FUN-042 선별 로직 버그 — 관련 맥락: #188)

## 🛠 3. 구현 내용

* **`ValidationTargetSelectionMapper.xml`** — 환급률표 매칭 판정을 `rrt.source_product_code = ec.standard_product_code`로 정정 (eligible_contract CTE·resolved CTE·snapshot 키 포함)
    * 근거: 시드데이터 명세서 §환급률표 "필수 조합"이 상품 식별을 표준코드(STD-*)로 정의하고, V3 시드도 `source_product_code`에 표준코드를 적재. 보험사 코드(P-A-001)와는 어떤 상품도 일치할 수 없어 매칭이 항상 0건이었음
    * snapshot jsonb 키 `insurerProductCode` → `standardProductCode` (판정에 실제 사용한 코드를 기록; 이 키를 읽는 소비자 없음 확인)
* **`ValidationTargetSelectionMapperIntegrationTest`** — 데모 시드 기준 회귀 테스트 추가: 2026-07 선별 시 SELECTED > 0, "상품코드 불일치" 0건, 선정 건에 환급률표 배정 필수
* **`MonthlyValidationJobIntegrationTest`** — 선별이 정상화되며 실제 결과(arbitrage·journal·reconciliation·exception)가 생성돼 기존 cleanup(cap·target·run만 삭제)이 FK 위반으로 실패 → 자식·손자 테이블 전체를 FK 순서대로 삭제하도록 확장(reconciliation_match 포함), "대상 데이터가 없다"던 테스트 전제·메서드명 갱신(`completesAllStepsAgainstSeedData`)

## 🧪 4. 테스트 방법

1. `./gradlew test` — 전체 926개 테스트 통과 확인
2. 앱 실행 → `admin` 로그인 → `/validation-runs`에서 검증월 **2026-07**·MONTHLY [실행 생성] → 상세에서 [실행] → 완료 후 ③대상 선별이 **선정 6건**(검토필요 0), ④결과 요약에 실측치 확인
3. 대시보드(`/`) 이동 → **차익거래 검토대상·대사 불일치·미처리 예외 KPI와 최근 예외 목록이 채워짐** 확인 (수정 검증 시 실측: 차익 5 · 대사 불일치 43 · 미처리 예외 49)
4. 1,200% 위반·주의 카드와 원장 불균형 카드는 **0건이 정상** — 축소 시드의 한도 사용률 최고치가 82.3%(주의 기준 미만)이고, 불균형이 있으면 배치가 6단계에서 FAILED로 멈추는 설계

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* 비교 기준을 시드 수정(보험사 코드 적재)이 아니라 **SQL 수정(표준코드 비교)**으로 잡은 판단 — 시드데이터 명세서의 환급률표 카탈로그가 표준코드 기준이라 시드가 정본이라고 봤습니다
* `MonthlyValidationJobIntegrationTest` cleanup의 삭제 순서(FK 역순)가 빠짐없는지

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음 (화면 코드 무수정 — 선별 정상화로 VRUN-W02 ③④와 대시보드 KPI에 실데이터가 표시되기 시작함)

## 💬 9. 참고 사항

* 수정 검증은 실제 E2E로 수행: 2026-07·2026-08 MONTHLY 실행을 API로 기동해 선정 6건/13건·차익 5/15·대사 43/52·예외 49/113 생성과 대시보드 반영을 확인 후, 검증 산출 데이터는 DB에서 정리했습니다
* **로컬 통합테스트 34개(Dashboard·CapCalculator·Reconciliation 계열)는 결과 테이블이 빈 DB를 전제**로 건수를 단언합니다 — 화면에서 검증 실행을 돌려 데이터를 만든 뒤 `./gradlew test`를 돌리면 오염으로 실패할 수 있습니다. 데모 데이터와 테스트 격리의 구조적 충돌로, 테스트 전용 DB 분리 등은 별도 과제로 제안합니다
* POSTED 분개는 DB 트리거(`guard_journal_line_write`)가 삭제를 막으므로 수동 정리 시 superuser의 `session_replication_role=replica` 우회가 필요했습니다(트리거 설계는 의도대로 동작 중)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 환급률표 상품 비교 기준을 표준상품코드로 통일해 상품 매칭의 일관성과 정확도를 높였습니다.
  * 대상 계약 조회, 그룹화, 매칭 집계 및 결과 스냅샷에 동일한 표준상품코드 기준을 적용했습니다.
  * 상품코드 불일치 및 환급률표 배정 결과를 보다 정확하게 확인할 수 있습니다.
  * 월간 검증 처리와 대상 계약 선정 과정의 안정성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->