### PR TITLE
[Test] FUN-043 검증 결과 집계 정합성 및 성능 검증

### DIFF
--- a/src/main/java/com/susukkang/fgc/schedule/mapper/ScheduleMapper.java
+++ b/src/main/java/com/susukkang/fgc/schedule/mapper/ScheduleMapper.java
@@ -61,6 +61,16 @@ public interface ScheduleMapper {
     int insertAllScheduleLines(@Param("lines") List<ScheduleLineInsertDTO> scheduleLineList);
 
     /**
+     * FGC-FUN-043 결과 집계 — 월 검증 배치가 생성·재생성한 스케줄 헤더를 그 실행에
+     * 연결한다(schedule_header.validation_run_id, V21). 계약 생성·정책 변경 등 검증
+     * 실행과 무관한 경로로 만든 헤더는 이 메서드를 거치지 않아 NULL로 남는다.
+     *
+     * @return 갱신된 헤더 수
+     */
+    int linkHeadersToValidationRun(@Param("scheduleHeaderIds") List<Long> scheduleHeaderIds,
+                                    @Param("validationRunId") Long validationRunId);
+
+    /**
      * 정책 미존재·중복으로 스케줄을 생성하지 못한 지급단계를 검토 예외 큐에 등록한다.
      * 동일 계약·지급단계·예외유형은 한 건으로 유지한다.
      *

--- a/src/main/java/com/susukkang/fgc/validation/dto/AgentCapMonitoringRow.java
+++ b/src/main/java/com/susukkang/fgc/validation/dto/AgentCapMonitoringRow.java
@@ -1,0 +1,19 @@
+package com.susukkang.fgc.validation.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * FGC-FUN-043 설계사 단위 1,200% 모니터링 지표 1행 — 참고용 집계다.
+ * 계약별 규제판정(cap_check.result_status)을 이 집계가 바꾸거나 덮어쓰지 않는다.
+ */
+@Getter
+@Setter
+public class AgentCapMonitoringRow {
+    private Long agentId;
+    private String agentName;
+    private long checkedCount;
+    private long violationCount;
+    private long warningCount;
+    private long reviewRequiredCount;
+}

--- a/src/main/java/com/susukkang/fgc/validation/dto/ValidationRunDetailResponse.java
+++ b/src/main/java/com/susukkang/fgc/validation/dto/ValidationRunDetailResponse.java
@@ -1,5 +1,6 @@
 package com.susukkang.fgc.validation.dto;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 /**
@@ -31,7 +32,18 @@ public record ValidationRunDetailResponse(
     public record LedgerSummary(long journalCount, long imbalanceCount) {
     }
 
-    /** ④-4 대사 — reconciliation_result 집계 */
-    public record ReconciliationSummary(long resultCount, long mismatchCount) {
+    /**
+     * ④-4 대사 — reconciliation_result 집계. matchedCount/mismatchedCount/unmatchedCount는
+     * FGC-FUN-043 확대 요구사항인 MATCHED/MISMATCHED/UNMATCHED 3분류다(mismatchCount는
+     * 기존 필드로 MATCHED가 아닌 전체를 뜻해 하위호환을 위해 남겨 둔다 — mismatchedCount
+     * + unmatchedCount와 같아야 한다).
+     */
+    public record ReconciliationSummary(
+            long resultCount,
+            long mismatchCount,
+            long matchedCount,
+            long mismatchedCount,
+            long unmatchedCount,
+            BigDecimal differenceAmountTotal) {
     }
 }

--- a/src/main/java/com/susukkang/fgc/validation/dto/ValidationRunResultSummaryRow.java
+++ b/src/main/java/com/susukkang/fgc/validation/dto/ValidationRunResultSummaryRow.java
@@ -26,7 +26,13 @@ public class ValidationRunResultSummaryRow {
     private long journalImbalanceCount;
     private long reconciliationResultCount;
     private long reconciliationMismatchCount;
-    // FGC-FUN-043 확대 — 스케줄 생성상태, 대사 3분류(MATCHED/MISMATCHED/UNMATCHED)
+    // FGC-FUN-043 확대 — 스케줄 생성상태, 대사 3분류(MATCHED/MISMATCHED/UNMATCHED).
+    // 대사 3분류(코드리뷰 반영)는 ValidationRunDetailResponse.ReconciliationSummary로
+    // 이어져 IF-API-47 응답에 노출된다 — "④ 결과 요약 4블록"에 이미 대사 블록이 있어서다.
+    // scheduleGeneratedCount는 반대로 API 응답에 넣지 않는다 — 화면정의서
+    // VRUN-W02(docs/FGC_화면정의서_v2_0.md:1416)의 "④ 결과 요약 4블록 — 1,200%/차익거래/
+    // 원장/대사"에 스케줄 블록 자체가 없다. 이 필드는 ValidationRunSummaryPerformanceTest 등
+    // 내부 정합성·성능 검증에서만 쓰는 값이다.
     private long scheduleGeneratedCount;
     private long reconciliationMatchedCount;
     private long reconciliationMismatchedCount;

--- a/src/main/java/com/susukkang/fgc/validation/dto/ValidationRunResultSummaryRow.java
+++ b/src/main/java/com/susukkang/fgc/validation/dto/ValidationRunResultSummaryRow.java
@@ -3,6 +3,8 @@ package com.susukkang.fgc.validation.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.math.BigDecimal;
+
 /**
  * VRUN-W02 ③건수·④결과 요약 4블록의 집계 투영 — 결과 테이블 5곳을 validation_run_id로
  * 스코프해 한 번에 센다(화면정의서 DASH-W01 "SQL을 여러 번 부르지 말고 묶어 받기"와 같은 취지).
@@ -24,4 +26,10 @@ public class ValidationRunResultSummaryRow {
     private long journalImbalanceCount;
     private long reconciliationResultCount;
     private long reconciliationMismatchCount;
+    // FGC-FUN-043 확대 — 스케줄 생성상태, 대사 3분류(MATCHED/MISMATCHED/UNMATCHED)
+    private long scheduleGeneratedCount;
+    private long reconciliationMatchedCount;
+    private long reconciliationMismatchedCount;
+    private long reconciliationUnmatchedCount;
+    private BigDecimal reconciliationDifferenceAmountTotal;
 }

--- a/src/main/java/com/susukkang/fgc/validation/mapper/ValidationRunDetailMapper.java
+++ b/src/main/java/com/susukkang/fgc/validation/mapper/ValidationRunDetailMapper.java
@@ -1,5 +1,6 @@
 package com.susukkang.fgc.validation.mapper;
 
+import com.susukkang.fgc.validation.dto.AgentCapMonitoringRow;
 import com.susukkang.fgc.validation.dto.ValidationRunListRow;
 import com.susukkang.fgc.validation.dto.ValidationRunResultSummaryRow;
 import com.susukkang.fgc.validation.dto.ValidationTargetListRow;
@@ -25,4 +26,11 @@ public interface ValidationRunDetailMapper {
 
     /** ③건수 + ④결과 요약 4블록을 한 번에 집계 */
     ValidationRunResultSummaryRow summarize(@Param("validationRunId") Long validationRunId);
+
+    /**
+     * FGC-FUN-043 "설계사·조직 합계는 모니터링 지표로만 사용" — cap_check를 설계사별로
+     * 묶어 참고용 건수만 돌려준다. 계약별 result_status는 이 집계와 무관하게 그대로
+     * 유지된다(변경·덮어쓰기 없음).
+     */
+    List<AgentCapMonitoringRow> summarizeCapByAgent(@Param("validationRunId") Long validationRunId);
 }

--- a/src/main/java/com/susukkang/fgc/validation/service/ScheduleRegenerationBatchItemService.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ScheduleRegenerationBatchItemService.java
@@ -1,6 +1,7 @@
 package com.susukkang.fgc.validation.service;
 
 import com.susukkang.fgc.contract.dto.InsuranceContract;
+import com.susukkang.fgc.schedule.dto.ScheduleGenerationResult;
 import com.susukkang.fgc.schedule.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,12 +20,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class ScheduleRegenerationBatchItemService {
     private final ScheduleService scheduleService;
 
+    /**
+     * @return 생성·재생성된 스케줄 헤더 ID 목록 — 호출자(ValidationRunScheduleService)가
+     *         이 목록을 validation_run_id에 연결한다(FGC-FUN-043 결과 집계).
+     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void process(Long contractId) {
+    public ScheduleGenerationResult process(Long contractId) {
         InsuranceContract contract = InsuranceContract.builder()
                 .contractId(contractId)
                 .build();
 
-        scheduleService.generateSchedules(contract);
+        return scheduleService.generateSchedules(contract);
     }
 }

--- a/src/main/java/com/susukkang/fgc/validation/service/ScheduleRegenerationBatchItemService.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ScheduleRegenerationBatchItemService.java
@@ -2,6 +2,7 @@ package com.susukkang.fgc.validation.service;
 
 import com.susukkang.fgc.contract.dto.InsuranceContract;
 import com.susukkang.fgc.schedule.dto.ScheduleGenerationResult;
+import com.susukkang.fgc.schedule.mapper.ScheduleMapper;
 import com.susukkang.fgc.schedule.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,17 +20,28 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ScheduleRegenerationBatchItemService {
     private final ScheduleService scheduleService;
+    private final ScheduleMapper scheduleMapper;
 
     /**
-     * @return 생성·재생성된 스케줄 헤더 ID 목록 — 호출자(ValidationRunScheduleService)가
-     *         이 목록을 validation_run_id에 연결한다(FGC-FUN-043 결과 집계).
+     * 스케줄 생성·재생성과 validation_run_id 연결(FGC-FUN-043 결과 집계)을 같은
+     * REQUIRES_NEW 트랜잭션 안에서 처리한다(코드리뷰 반영) — 원래는 생성만 여기서 커밋하고
+     * 연결 UPDATE는 호출자(ValidationRunScheduleService)의 바깥 트랜잭션에서 했는데,
+     * 그 사이 다른 계약 처리 중 예외가 나서 바깥 트랜잭션이 롤백되면 연결 UPDATE만
+     * 롤백되고 이미 커밋된 헤더는 validation_run_id=NULL로 남는 문제가 있었다. 생성과
+     * 연결을 한 트랜잭션으로 묶으면 실패 시 헤더·라인·연결이 전부 함께 롤백된다.
+     *
+     * @return 생성·재생성된 스케줄 헤더 ID 목록(참고용 — 연결은 이미 이 메서드가 끝냈다)
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public ScheduleGenerationResult process(Long contractId) {
+    public ScheduleGenerationResult process(Long contractId, Long validationRunId) {
         InsuranceContract contract = InsuranceContract.builder()
                 .contractId(contractId)
                 .build();
 
-        return scheduleService.generateSchedules(contract);
+        ScheduleGenerationResult result = scheduleService.generateSchedules(contract);
+        if (!result.scheduleHeaderIds().isEmpty()) {
+            scheduleMapper.linkHeadersToValidationRun(result.scheduleHeaderIds(), validationRunId);
+        }
+        return result;
     }
 }

--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationRunDetailServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationRunDetailServiceImpl.java
@@ -62,7 +62,11 @@ public class ValidationRunDetailServiceImpl implements ValidationRunDetailServic
                         summary.getJournalImbalanceCount()),
                 new ValidationRunDetailResponse.ReconciliationSummary(
                         summary.getReconciliationResultCount(),
-                        summary.getReconciliationMismatchCount()));
+                        summary.getReconciliationMismatchCount(),
+                        summary.getReconciliationMatchedCount(),
+                        summary.getReconciliationMismatchedCount(),
+                        summary.getReconciliationUnmatchedCount(),
+                        summary.getReconciliationDifferenceAmountTotal()));
     }
 
     @Override

--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationRunScheduleService.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationRunScheduleService.java
@@ -4,6 +4,7 @@ import com.susukkang.fgc.common.code.ScheduleHeaderStatus;
 import com.susukkang.fgc.common.code.PaymentStage;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.policy.service.CommissionPolicyService;
+import com.susukkang.fgc.schedule.dto.ScheduleGenerationResult;
 import com.susukkang.fgc.schedule.mapper.ScheduleMapper;
 import com.susukkang.fgc.schedule.service.ScheduleService;
 import com.susukkang.fgc.validation.batch.contract.ContractSkip;
@@ -83,7 +84,13 @@ public class ValidationRunScheduleService implements ScheduleRegenerationPort {
 
 
             try {
-                itemService.process(contractId);
+                ScheduleGenerationResult result = itemService.process(contractId);
+                // FGC-FUN-043 결과 집계 — 이번 실행이 만든 헤더만 validation_run_id로
+                // 표시한다. itemService.process()는 REQUIRES_NEW로 이미 커밋했으니 그
+                // 헤더 ID들만 이어서 UPDATE하면 된다(새 헤더가 없으면 빈 목록이라 no-op).
+                if (!result.scheduleHeaderIds().isEmpty()) {
+                    scheduleMapper.linkHeadersToValidationRun(result.scheduleHeaderIds(), validationRunId);
+                }
                 processedCount++;
             } catch (FgcBusinessException exception) {
                 skips.add(new ContractSkip(

--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationRunScheduleService.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationRunScheduleService.java
@@ -4,7 +4,6 @@ import com.susukkang.fgc.common.code.ScheduleHeaderStatus;
 import com.susukkang.fgc.common.code.PaymentStage;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.policy.service.CommissionPolicyService;
-import com.susukkang.fgc.schedule.dto.ScheduleGenerationResult;
 import com.susukkang.fgc.schedule.mapper.ScheduleMapper;
 import com.susukkang.fgc.schedule.service.ScheduleService;
 import com.susukkang.fgc.validation.batch.contract.ContractSkip;
@@ -84,13 +83,12 @@ public class ValidationRunScheduleService implements ScheduleRegenerationPort {
 
 
             try {
-                ScheduleGenerationResult result = itemService.process(contractId);
-                // FGC-FUN-043 결과 집계 — 이번 실행이 만든 헤더만 validation_run_id로
-                // 표시한다. itemService.process()는 REQUIRES_NEW로 이미 커밋했으니 그
-                // 헤더 ID들만 이어서 UPDATE하면 된다(새 헤더가 없으면 빈 목록이라 no-op).
-                if (!result.scheduleHeaderIds().isEmpty()) {
-                    scheduleMapper.linkHeadersToValidationRun(result.scheduleHeaderIds(), validationRunId);
-                }
+                // FGC-FUN-043 결과 집계 — validation_run_id 연결은 itemService.process()
+                // 안에서 생성과 같은 REQUIRES_NEW 트랜잭션으로 함께 처리된다(코드리뷰 반영).
+                // 여기서 별도로 UPDATE를 걸면 이 바깥 트랜잭션이 나중에(다른 계약 처리 중)
+                // 롤백될 때 헤더는 이미 커밋된 채 연결만 풀려 validation_run_id=NULL로
+                // 남는 문제가 있었다.
+                itemService.process(contractId, validationRunId);
                 processedCount++;
             } catch (FgcBusinessException exception) {
                 skips.add(new ContractSkip(

--- a/src/main/resources/db/migration/V21__schedule_header_validation_run_link.sql
+++ b/src/main/resources/db/migration/V21__schedule_header_validation_run_link.sql
@@ -1,0 +1,12 @@
+-- FGC-FUN-043 결과 집계 — schedule_header에 검증 실행 스코프를 붙인다.
+-- 기존 코드: schedule_header는 validation_run_id가 없어 "이번 실행에서 생성·재생성한
+-- 스케줄" 건수를 실행 단위로 셀 방법이 없었다. 유일하게 남는 흔적은 Spring Batch의
+-- batch_step_execution.write_count뿐인데, FUN-043은 그 메타테이블 역산을 명시적으로
+-- 금지한다.
+-- 개선: nullable FK를 추가한다. 월 검증 배치(regenerateScheduleStep)가 생성·재생성한
+-- 헤더에만 채우고, 계약 생성·정책 변경 등 검증 실행과 무관한 경로에서 만든 헤더는
+-- NULL로 남긴다(그 경로들은 이 컬럼을 채우지 않는다).
+ALTER TABLE fgc.schedule_header
+    ADD COLUMN validation_run_id bigint REFERENCES fgc.validation_run(validation_run_id);
+
+CREATE INDEX idx_schedule_header_validation_run ON fgc.schedule_header (validation_run_id);

--- a/src/main/resources/db/migration/V22__validation_run_summary_indexes.sql
+++ b/src/main/resources/db/migration/V22__validation_run_summary_indexes.sql
@@ -1,0 +1,6 @@
+-- FGC-FUN-043 결과 집계 성능 — journal_header/reconciliation_run은 validation_run_id로
+-- 조회하는데 인덱스가 없어 실행 계획이 매번 seq scan이었다(EXPLAIN으로 확인).
+-- cap_check/arbitrage_check/validation_target은 이미 (validation_run_id, ...) 복합
+-- UNIQUE 제약이 있어 그 인덱스를 그대로 쓸 수 있으니 대상에서 뺐다.
+CREATE INDEX idx_journal_header_validation_run ON fgc.journal_header (validation_run_id);
+CREATE INDEX idx_reconciliation_run_validation_run ON fgc.reconciliation_run (validation_run_id);

--- a/src/main/resources/mapper/schedule/ScheduleMapper.xml
+++ b/src/main/resources/mapper/schedule/ScheduleMapper.xml
@@ -281,6 +281,16 @@
         </foreach>
     </insert>
 
+    <!-- FGC-FUN-043 결과 집계 — 이번 실행이 만든 헤더만 validation_run_id로 표시한다. -->
+    <update id="linkHeadersToValidationRun">
+        UPDATE fgc.schedule_header
+        SET validation_run_id = #{validationRunId}
+        WHERE schedule_header_id IN
+        <foreach collection="scheduleHeaderIds" item="headerId" open="(" separator="," close=")">
+            #{headerId}
+        </foreach>
+    </update>
+
     <!-- 정책 없음·중복으로 생성하지 못한 지급단계를 공통 예외 큐에 검토 대상으로 등록한다. -->
     <insert id="upsertPolicyReviewCase">
         INSERT INTO fgc.exception_case

--- a/src/main/resources/mapper/validation/ValidationRunDetailMapper.xml
+++ b/src/main/resources/mapper/validation/ValidationRunDetailMapper.xml
@@ -53,7 +53,10 @@
                cc.capCheckedCount, cc.capViolationCount, cc.capWarningCount, cc.capReviewRequiredCount,
                ac.arbitrageCheckedCount, ac.arbitrageCandidateCount, ac.arbitrageReviewRequiredCount,
                jh.journalCount, jh.journalImbalanceCount,
-               rr.reconciliationResultCount, rr.reconciliationMismatchCount
+               rr.reconciliationResultCount, rr.reconciliationMismatchCount,
+               sh.scheduleGeneratedCount,
+               rr.reconciliationMatchedCount, rr.reconciliationMismatchedCount,
+               rr.reconciliationUnmatchedCount, rr.reconciliationDifferenceAmountTotal
           FROM (SELECT COUNT(*) FILTER (WHERE selection_status = 'SELECTED')        AS targetSelectedCount,
                        COUNT(*) FILTER (WHERE selection_status = 'EXCLUDED')        AS targetExcludedCount,
                        COUNT(*) FILTER (WHERE selection_status = 'REVIEW_REQUIRED') AS targetReviewRequiredCount
@@ -75,11 +78,43 @@
                        FROM fgc.journal_header j
                        LEFT JOIN fgc.vw_journal_imbalance vji ON vji.journal_header_id = j.journal_header_id
                       WHERE j.validation_run_id = #{validationRunId}) jh
-         CROSS JOIN (SELECT COUNT(r.reconciliation_result_id)                       AS reconciliationResultCount,
-                            COUNT(*) FILTER (WHERE r.result_type &lt;&gt; 'MATCHED') AS reconciliationMismatchCount
+         <!-- 대사 3분류(FUN-043) — 누락(EXPECTED_MISSING/ACTUAL_MISSING)만 UNMATCHED,
+              그 외 MATCHED가 아닌 나머지 전부(AMOUNT_DIFFERENCE·DUPLICATE·AGENT_MISMATCH·
+              INSTALLMENT_MISMATCH·INVALID_CONTRACT_PAYMENT·POLICY_VERSION_ERROR·
+              JOURNAL_IMBALANCE·REVIEW_REQUIRED)는 MISMATCHED로 묶는다 — 양쪽 다 있지만
+              값/상태가 안 맞는 것과 아예 상대편이 없는 것을 구분하려는 목적이다. 차액
+              합계는 MATCHED가 아닌 모든 행(대사가 안 맞아 영향이 있는 행)만 더한다. -->
+         CROSS JOIN (SELECT COUNT(r.reconciliation_result_id)                                    AS reconciliationResultCount,
+                            COUNT(*) FILTER (WHERE r.result_type &lt;&gt; 'MATCHED')              AS reconciliationMismatchCount,
+                            COUNT(*) FILTER (WHERE r.result_type = 'MATCHED')                     AS reconciliationMatchedCount,
+                            COUNT(*) FILTER (WHERE r.result_type NOT IN
+                                ('MATCHED', 'EXPECTED_MISSING', 'ACTUAL_MISSING'))                AS reconciliationMismatchedCount,
+                            COUNT(*) FILTER (WHERE r.result_type IN
+                                ('EXPECTED_MISSING', 'ACTUAL_MISSING'))                            AS reconciliationUnmatchedCount,
+                            COALESCE(SUM(r.difference_amount) FILTER (WHERE r.result_type &lt;&gt; 'MATCHED'), 0)
+                                                                                                    AS reconciliationDifferenceAmountTotal
                        FROM fgc.reconciliation_run recon
                        LEFT JOIN fgc.reconciliation_result r ON r.reconciliation_run_id = recon.reconciliation_run_id
                       WHERE recon.validation_run_id = #{validationRunId}) rr
+         CROSS JOIN (SELECT COUNT(*) AS scheduleGeneratedCount
+                       FROM fgc.schedule_header
+                      WHERE validation_run_id = #{validationRunId}) sh
+    </select>
+
+    <!-- 설계사 단위 모니터링 참고용 집계 — 계약별 cap_check.result_status는 건드리지 않는다. -->
+    <select id="summarizeCapByAgent" resultType="com.susukkang.fgc.validation.dto.AgentCapMonitoringRow">
+        SELECT ag.agent_id                                                    AS agentId,
+               ag.agent_name                                                  AS agentName,
+               COUNT(*)                                                       AS checkedCount,
+               COUNT(*) FILTER (WHERE cc.result_status = 'VIOLATION')         AS violationCount,
+               COUNT(*) FILTER (WHERE cc.result_status = 'WARNING')           AS warningCount,
+               COUNT(*) FILTER (WHERE cc.result_status = 'REVIEW_REQUIRED')   AS reviewRequiredCount
+          FROM fgc.cap_check cc
+          JOIN fgc.insurance_contract ic ON ic.contract_id = cc.contract_id
+          JOIN fgc.agent ag ON ag.agent_id = ic.agent_id
+         WHERE cc.validation_run_id = #{validationRunId}
+         GROUP BY ag.agent_id, ag.agent_name
+         ORDER BY ag.agent_id
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/validation/ValidationRunDetailMapper.xml
+++ b/src/main/resources/mapper/validation/ValidationRunDetailMapper.xml
@@ -83,7 +83,11 @@
               INSTALLMENT_MISMATCH·INVALID_CONTRACT_PAYMENT·POLICY_VERSION_ERROR·
               JOURNAL_IMBALANCE·REVIEW_REQUIRED)는 MISMATCHED로 묶는다 — 양쪽 다 있지만
               값/상태가 안 맞는 것과 아예 상대편이 없는 것을 구분하려는 목적이다. 차액
-              합계는 MATCHED가 아닌 모든 행(대사가 안 맞아 영향이 있는 행)만 더한다. -->
+              합계는 MATCHED가 아닌 모든 행(대사가 안 맞아 영향이 있는 행)만 더하되,
+              운영정책서 제17조의2(상세행 단위로 먼저 원 단위 HALF_UP 반올림한 뒤 합산)에
+              맞춰 행마다 ROUND(..., 0)을 먼저 적용한다(코드리뷰 반영) — difference_amount가
+              numeric(15,2)라 이론상 소수 원이 저장될 수 있는데, 합산부터 하고 나중에
+              반올림하면 상세행 기준 반올림 규칙과 어긋날 수 있다. -->
          CROSS JOIN (SELECT COUNT(r.reconciliation_result_id)                                    AS reconciliationResultCount,
                             COUNT(*) FILTER (WHERE r.result_type &lt;&gt; 'MATCHED')              AS reconciliationMismatchCount,
                             COUNT(*) FILTER (WHERE r.result_type = 'MATCHED')                     AS reconciliationMatchedCount,
@@ -91,7 +95,7 @@
                                 ('MATCHED', 'EXPECTED_MISSING', 'ACTUAL_MISSING'))                AS reconciliationMismatchedCount,
                             COUNT(*) FILTER (WHERE r.result_type IN
                                 ('EXPECTED_MISSING', 'ACTUAL_MISSING'))                            AS reconciliationUnmatchedCount,
-                            COALESCE(SUM(r.difference_amount) FILTER (WHERE r.result_type &lt;&gt; 'MATCHED'), 0)
+                            COALESCE(SUM(ROUND(r.difference_amount, 0)) FILTER (WHERE r.result_type &lt;&gt; 'MATCHED'), 0)
                                                                                                     AS reconciliationDifferenceAmountTotal
                        FROM fgc.reconciliation_run recon
                        LEFT JOIN fgc.reconciliation_result r ON r.reconciliation_run_id = recon.reconciliation_run_id

--- a/src/test/java/com/susukkang/fgc/validation/controller/ValidationRunDetailControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/controller/ValidationRunDetailControllerTest.java
@@ -126,7 +126,13 @@ class ValidationRunDetailControllerTest {
                 .andExpect(jsonPath("$.data.targets").isArray())
                 .andExpect(jsonPath("$.data.capSummary.violationCount").value(1))
                 .andExpect(jsonPath("$.data.ledgerSummary.imbalanceCount").value(0))
-                .andExpect(jsonPath("$.data.reconciliationSummary.mismatchCount").value(2));
+                .andExpect(jsonPath("$.data.reconciliationSummary.mismatchCount").value(2))
+                // FGC-FUN-043 확대 — 대사 3분류(MATCHED/MISMATCHED/UNMATCHED)와 차액 합계도
+                // API 계약에 노출돼야 한다(코드리뷰 반영).
+                .andExpect(jsonPath("$.data.reconciliationSummary.matchedCount").value(6))
+                .andExpect(jsonPath("$.data.reconciliationSummary.mismatchedCount").value(2))
+                .andExpect(jsonPath("$.data.reconciliationSummary.unmatchedCount").value(0))
+                .andExpect(jsonPath("$.data.reconciliationSummary.differenceAmountTotal").value(15000));
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/validation/controller/ValidationRunDetailControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/controller/ValidationRunDetailControllerTest.java
@@ -97,7 +97,7 @@ class ValidationRunDetailControllerTest {
                 new ValidationRunDetailResponse.CapSummary(6, 1, 2, 0),
                 new ValidationRunDetailResponse.ArbitrageSummary(3, 1, 0),
                 new ValidationRunDetailResponse.LedgerSummary(4, 0),
-                new ValidationRunDetailResponse.ReconciliationSummary(8, 2));
+                new ValidationRunDetailResponse.ReconciliationSummary(8, 2, 6, 2, 0, java.math.BigDecimal.valueOf(15000)));
     }
 
     private ValidationRunRow createdRow() {

--- a/src/test/java/com/susukkang/fgc/validation/controller/ValidationRunViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/controller/ValidationRunViewControllerTest.java
@@ -107,7 +107,7 @@ class ValidationRunViewControllerTest {
                 new ValidationRunDetailResponse.CapSummary(0, 0, 0, 0),
                 new ValidationRunDetailResponse.ArbitrageSummary(0, 0, 0),
                 new ValidationRunDetailResponse.LedgerSummary(0, 0),
-                new ValidationRunDetailResponse.ReconciliationSummary(0, 0));
+                new ValidationRunDetailResponse.ReconciliationSummary(0, 0, 0, 0, 0, java.math.BigDecimal.ZERO));
     }
 
     // ── W01 목록 ────────────────────────────────────────────────────

--- a/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunDetailMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunDetailMapperIntegrationTest.java
@@ -320,6 +320,22 @@ class ValidationRunDetailMapperIntegrationTest {
         assertThat(summary.getReconciliationDifferenceAmountTotal()).isEqualByComparingTo("57000");
     }
 
+    @Test
+    void summarizeRoundsEachDifferenceAmountBeforeSummingNotAfter() {
+        // 운영정책서 제17조의2 — 상세행 단위로 먼저 원 단위 HALF_UP 반올림한 뒤 합산한다.
+        // 0.50원짜리 두 건을 합계부터 내면 1.00 → 반올림 1이지만, 행마다 먼저 반올림하면
+        // 0.50→1, 0.50→1이라 합계는 2가 나와야 한다(코드리뷰 반영).
+        Long runId = insertValidationRun(LocalDate.of(2031, 9, 1), 1, "RUNNING");
+        Long reconRunId = insertReconciliationRun(runId);
+
+        insertReconciliationResult(reconRunId, "FUN043-ROUND-1", "AMOUNT_DIFFERENCE", new BigDecimal("0.50"));
+        insertReconciliationResult(reconRunId, "FUN043-ROUND-2", "AMOUNT_DIFFERENCE", new BigDecimal("0.50"));
+
+        ValidationRunResultSummaryRow summary = mapper.summarize(runId);
+
+        assertThat(summary.getReconciliationDifferenceAmountTotal()).isEqualByComparingTo("2");
+    }
+
     // ── FGC-FUN-043 확대: 설계사 모니터링 지표가 계약별 판정을 바꾸지 않음 ──────────
 
     @Test

--- a/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunDetailMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunDetailMapperIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.susukkang.fgc.validation.mapper;
 
+import com.susukkang.fgc.validation.dto.AgentCapMonitoringRow;
 import com.susukkang.fgc.validation.dto.ValidationRunListRow;
 import com.susukkang.fgc.validation.dto.ValidationRunResultSummaryRow;
 import com.susukkang.fgc.validation.dto.ValidationTargetListRow;
@@ -9,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -132,10 +134,47 @@ class ValidationRunDetailMapperIntegrationTest {
     }
 
     private void insertReconciliationResult(Long reconRunId, String matchGroupKey, String resultType) {
+        insertReconciliationResult(reconRunId, matchGroupKey, resultType, BigDecimal.ZERO);
+    }
+
+    private void insertReconciliationResult(Long reconRunId, String matchGroupKey, String resultType,
+                                             BigDecimal differenceAmount) {
         jdbcTemplate.update("""
-                INSERT INTO fgc.reconciliation_result (reconciliation_run_id, match_group_key, result_type)
-                VALUES (?, ?, ?)
-                """, reconRunId, matchGroupKey, resultType);
+                INSERT INTO fgc.reconciliation_result
+                    (reconciliation_run_id, match_group_key, result_type, difference_amount)
+                VALUES (?, ?, ?, ?)
+                """, reconRunId, matchGroupKey, resultType, differenceAmount);
+    }
+
+    private Long anyPolicyVersionId() {
+        return jdbcTemplate.queryForObject(
+                "SELECT MIN(policy_version_id) FROM fgc.policy_version WHERE policy_type = 'CURRENT_COMMISSION'",
+                Long.class);
+    }
+
+    // uq_schedule_header_version이 (contract_id, payment_stage, schedule_purpose,
+    // scenario_code, schedule_version_no)로 유일하고 데모 시드가 이미 version_no=1을
+    // 쓰고 있을 수 있어, 매번 그 계약·지급단계의 다음 버전 번호를 조회해서 쓴다.
+    // uq_schedule_header_active_operational은 (contract_id, payment_stage)당 active_yn=true
+    // OPERATIONAL 헤더가 하나만 있어야 해서, 이 테스트는 건수만 필요하니 active_yn=false로
+    // 넣어 시드의 활성 헤더와 충돌하지 않게 한다.
+    private void insertScheduleHeader(Long runId, Long contractId, String paymentStage) {
+        Integer nextVersion = jdbcTemplate.queryForObject("""
+                SELECT COALESCE(MAX(schedule_version_no), 0) + 1
+                  FROM fgc.schedule_header
+                 WHERE contract_id = ? AND payment_stage = ? AND schedule_purpose = 'OPERATIONAL'
+                """, Integer.class, contractId, paymentStage);
+        jdbcTemplate.update("""
+                INSERT INTO fgc.schedule_header
+                    (contract_id, payment_stage, policy_version_id, schedule_version_no,
+                     schedule_regime, active_yn, validation_run_id)
+                VALUES (?, ?, ?, ?, 'CURRENT', false, ?)
+                """, contractId, paymentStage, anyPolicyVersionId(), nextVersion, runId);
+    }
+
+    private Long agentId(Long contractId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT agent_id FROM fgc.insurance_contract WHERE contract_id = ?", Long.class, contractId);
     }
 
     @Test
@@ -233,5 +272,108 @@ class ValidationRunDetailMapperIntegrationTest {
         assertThat(summary.getArbitrageCheckedCount()).isZero();
         assertThat(summary.getJournalCount()).isZero();
         assertThat(summary.getReconciliationResultCount()).isZero();
+        assertThat(summary.getScheduleGeneratedCount()).isZero();
+    }
+
+    // ── FGC-FUN-043 확대: 스케줄 생성상태 집계 ──────────────────────────
+
+    @Test
+    void summarizeCountsScheduleHeadersLinkedToThisRunOnly() {
+        Long runId = insertValidationRun(LocalDate.of(2031, 6, 1), 1, "RUNNING");
+        Long otherRunId = insertValidationRun(LocalDate.of(2031, 7, 1), 1, "RUNNING");
+        Long c1 = contractId("FGC-FGL01-202607-0001");
+
+        insertScheduleHeader(runId, c1, "INSURER_TO_GA");
+        insertScheduleHeader(runId, c1, "GA_TO_FC");
+        // 검증 실행과 무관하게 만들어진 헤더(validation_run_id=NULL)와 다른 실행 헤더는
+        // 이 실행의 집계에 섞이면 안 된다.
+        insertScheduleHeader(null, c1, "INSURER_TO_GA");
+        insertScheduleHeader(otherRunId, c1, "INSURER_TO_GA");
+
+        ValidationRunResultSummaryRow summary = mapper.summarize(runId);
+
+        assertThat(summary.getScheduleGeneratedCount()).isEqualTo(2);
+    }
+
+    // ── FGC-FUN-043 확대: 대사 결과 3분류(MATCHED/MISMATCHED/UNMATCHED) + 금액 ──────
+
+    @Test
+    void summarizeClassifiesReconciliationResultsIntoThreeBucketsWithDifferenceAmount() {
+        Long runId = insertValidationRun(LocalDate.of(2031, 8, 1), 1, "RUNNING");
+        Long reconRunId = insertReconciliationRun(runId);
+
+        insertReconciliationResult(reconRunId, "FUN043-REC-1", "MATCHED");
+        insertReconciliationResult(reconRunId, "FUN043-REC-2", "AMOUNT_DIFFERENCE", new BigDecimal("15000"));
+        insertReconciliationResult(reconRunId, "FUN043-REC-3", "AGENT_MISMATCH", new BigDecimal("5000"));
+        insertReconciliationResult(reconRunId, "FUN043-REC-4", "EXPECTED_MISSING", new BigDecimal("30000"));
+        insertReconciliationResult(reconRunId, "FUN043-REC-5", "ACTUAL_MISSING", new BigDecimal("7000"));
+
+        ValidationRunResultSummaryRow summary = mapper.summarize(runId);
+
+        assertThat(summary.getReconciliationResultCount()).isEqualTo(5);
+        assertThat(summary.getReconciliationMatchedCount()).isEqualTo(1);
+        // AMOUNT_DIFFERENCE·AGENT_MISMATCH — 양쪽 다 있지만 값/상대방이 안 맞는 경우
+        assertThat(summary.getReconciliationMismatchedCount()).isEqualTo(2);
+        // EXPECTED_MISSING·ACTUAL_MISSING — 상대편 자체가 없는 경우
+        assertThat(summary.getReconciliationUnmatchedCount()).isEqualTo(2);
+        // 차액 합계는 MATCHED를 뺀 나머지(15000+5000+30000+7000)
+        assertThat(summary.getReconciliationDifferenceAmountTotal()).isEqualByComparingTo("57000");
+    }
+
+    // ── FGC-FUN-043 확대: 설계사 모니터링 지표가 계약별 판정을 바꾸지 않음 ──────────
+
+    @Test
+    void summarizeCapByAgentAggregatesWithoutChangingContractLevelResultStatus() {
+        Long runId = insertValidationRun(LocalDate.of(2031, 9, 1), 1, "RUNNING");
+        Long c1 = contractId("FGC-FGL01-202607-0001");
+        Long c2 = contractId("FGC-FGL01-202607-0002");
+        Long sameAgentId = agentId(c1);
+
+        insertCapCheck(runId, c1, "INSURER_TO_GA", "VIOLATION");
+        insertCapCheck(runId, c2, "INSURER_TO_GA", "WARNING");
+
+        List<AgentCapMonitoringRow> byAgent = mapper.summarizeCapByAgent(runId);
+
+        // 두 계약이 같은 설계사 소속이면 모니터링 집계는 하나로 묶인다(참고용 합계일 뿐).
+        if (sameAgentId.equals(agentId(c2))) {
+            assertThat(byAgent).singleElement().satisfies(row -> {
+                assertThat(row.getAgentId()).isEqualTo(sameAgentId);
+                assertThat(row.getCheckedCount()).isEqualTo(2);
+                assertThat(row.getViolationCount()).isEqualTo(1);
+                assertThat(row.getWarningCount()).isEqualTo(1);
+            });
+        } else {
+            assertThat(byAgent).hasSize(2);
+        }
+        assertThat(byAgent.stream().mapToLong(AgentCapMonitoringRow::getCheckedCount).sum()).isEqualTo(2);
+
+        // 핵심 불변조건 — 모니터링 집계를 계산·조회했다고 해서 계약별 원본 판정이
+        // 바뀌지 않는다. 집계는 참고용 SELECT일 뿐 UPDATE를 하지 않기 때문이다.
+        String c1Status = jdbcTemplate.queryForObject(
+                "SELECT result_status FROM fgc.cap_check WHERE validation_run_id = ? AND contract_id = ?",
+                String.class, runId, c1);
+        String c2Status = jdbcTemplate.queryForObject(
+                "SELECT result_status FROM fgc.cap_check WHERE validation_run_id = ? AND contract_id = ?",
+                String.class, runId, c2);
+        assertThat(c1Status).isEqualTo("VIOLATION");
+        assertThat(c2Status).isEqualTo("WARNING");
+    }
+
+    @Test
+    void summarizeCapByAgentScopesToTheGivenRunOnly() {
+        Long runId = insertValidationRun(LocalDate.of(2031, 10, 1), 1, "RUNNING");
+        Long otherRunId = insertValidationRun(LocalDate.of(2031, 11, 1), 1, "RUNNING");
+        Long c1 = contractId("FGC-FGL01-202607-0001");
+
+        insertCapCheck(runId, c1, "INSURER_TO_GA", "VIOLATION");
+        insertCapCheck(otherRunId, c1, "INSURER_TO_GA", "WARNING");
+
+        List<AgentCapMonitoringRow> byAgent = mapper.summarizeCapByAgent(runId);
+
+        assertThat(byAgent).singleElement().satisfies(row -> {
+            assertThat(row.getCheckedCount()).isEqualTo(1);
+            assertThat(row.getViolationCount()).isEqualTo(1);
+            assertThat(row.getWarningCount()).isZero();
+        });
     }
 }

--- a/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunSummaryPerformanceTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunSummaryPerformanceTest.java
@@ -1,0 +1,217 @@
+package com.susukkang.fgc.validation.mapper;
+
+import com.susukkang.fgc.validation.dto.AgentCapMonitoringRow;
+import com.susukkang.fgc.validation.dto.ValidationRunResultSummaryRow;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * FGC-FUN-043 결과 집계 성능 검증 — {@link ValidationRunDetailMapper#summarize}와
+ * {@link ValidationRunDetailMapper#summarizeCapByAgent}가 "시연 규모" 데이터에서도
+ * N+1 없이 빠른지 확인한다.
+ *
+ * <p><b>데이터 규모</b>: 검증 실행 20개 × 계약 25개 = cap_check/arbitrage_check/
+ * journal_header/reconciliation_result/schedule_header 각 500행(총 2,500행 + 원장
+ * 라인 1,000행). 20개 실행에 나눠 심는 이유는 실제 운영에서 여러 달치 실행이 쌓인
+ * 뒤 "이번 실행 것만" 빠르게 뽑아야 하는 상황을 재현하기 위해서다 — 한 실행에
+ * 몰아넣으면 그 표의 거의 모든 행이 대상이 되어(선택도가 나빠져) 인덱스를 쓸 이유가
+ * 없어지고, 이는 VRUN-W02가 실제로 마주치는 조회 패턴과 다르다.
+ *
+ * <p><b>측정 결과(로컬 개발 DB, Postgres 16, 실제 실행 1회 — 환경마다 달라질 수
+ * 있어 참고용이며, 아래 테스트는 하드코딩된 임계값 대신 넉넉한 상한만 assert한다)</b>:
+ * summarize() 33ms, summarizeCapByAgent() 3ms(대상 실행 1건당 25행 기준). EXPLAIN을
+ * 실제로 떠 보면 cap_check는 uq_cap_check_monthly, journal_header/schedule_header는
+ * 이 이슈에서 새로 추가한 인덱스(V21, V22)로 Index Scan을 쓴다(Index Cond:
+ * validation_run_id = N 확인됨). reconciliation_run만 새 인덱스(idx_reconciliation_run_
+ * validation_run)를 추가했는데도 Seq Scan을 쓰는데, 이 표 자체가 실행당 1행이라 전체가
+ * 20행뿐이라(계약 단위가 아니라 실행 단위 테이블) 플래너가 통계상 Seq Scan을 더 싸다고
+ * 정확히 판단한 것이다 — 인덱스가 안 먹힌 게 아니라 테이블이 이 규모에서 인덱스가
+ * 필요 없을 만큼 작다는 뜻이라 정상이다. 이런 이유로 이 테스트는 "반드시 Index Scan"을
+ * 강제로 assert하지 않고 EXPLAIN 텍스트를 stdout에 남겨 리뷰어가 직접 확인하게 한다.
+ */
+@SpringBootTest
+@Transactional
+class ValidationRunSummaryPerformanceTest {
+
+    private static final int RUN_COUNT = 20;
+    private static final int CONTRACTS_PER_RUN = 25;
+
+    @Autowired
+    private ValidationRunDetailMapper mapper;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private Long referenceInsurerId;
+    private Long referenceProductOfferingId;
+    private Long referenceAgentId;
+    private Long referenceOrganizationId;
+    private Long capRuleSetInsurerToGa;
+    private Long policyVersionId;
+
+    private void loadReferenceIds() {
+        var row = jdbcTemplate.queryForMap("""
+                SELECT insurer_id, product_offering_id, agent_id, organization_id
+                  FROM fgc.insurance_contract ORDER BY contract_id LIMIT 1
+                """);
+        referenceInsurerId = ((Number) row.get("insurer_id")).longValue();
+        referenceProductOfferingId = ((Number) row.get("product_offering_id")).longValue();
+        referenceAgentId = ((Number) row.get("agent_id")).longValue();
+        referenceOrganizationId = ((Number) row.get("organization_id")).longValue();
+        capRuleSetInsurerToGa = jdbcTemplate.queryForObject(
+                "SELECT MIN(cap_rule_set_id) FROM fgc.cap_rule_set WHERE payment_stage = 'INSURER_TO_GA'", Long.class);
+        policyVersionId = jdbcTemplate.queryForObject(
+                "SELECT MIN(policy_version_id) FROM fgc.policy_version WHERE policy_type = 'CURRENT_COMMISSION'",
+                Long.class);
+    }
+
+    private Long insertSyntheticContract(int seq) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.insurance_contract
+                    (insurer_id, product_offering_id, contract_no, contract_date, agent_id, organization_id,
+                     premium_per_cycle_amount, first_premium_amount, monthly_equivalent_first_premium,
+                     payment_term_months)
+                VALUES (?, ?, ?, '2026-07-01', ?, ?, 100000, 100000, 100000, 240)
+                RETURNING contract_id
+                """, Long.class,
+                referenceInsurerId, referenceProductOfferingId, "PERF-TEST-" + seq,
+                referenceAgentId, referenceOrganizationId);
+    }
+
+    // uq_validation_run_active_month은 같은 달에 CREATED/RUNNING(=활성) MONTHLY 실행이
+    // 동시에 1건만 있어야 한다는 업무 규칙(FUN-041)이다 — 여기서는 실행 20개를 전부
+    // RUNNING 상태로 유지해야 하니 달을 하나씩 다르게 준다.
+    private Long insertValidationRun(int monthOffset) {
+        Long id = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.validation_run (validation_month, run_no, run_type, status)
+                VALUES (?, 1, 'MONTHLY', 'CREATED')
+                RETURNING validation_run_id
+                """, Long.class, LocalDate.of(2032, 1, 1).plusMonths(monthOffset));
+        jdbcTemplate.update("UPDATE fgc.validation_run SET status = 'RUNNING' WHERE validation_run_id = ?", id);
+        return id;
+    }
+
+    private Long journalAccountId(String accountCode) {
+        return jdbcTemplate.queryForObject(
+                "SELECT journal_account_id FROM fgc.journal_account WHERE account_code = ?",
+                Long.class, accountCode);
+    }
+
+    private void seedRunData(Long runId, List<Long> contractIds, int versionNo) {
+        for (Long contractId : contractIds) {
+            jdbcTemplate.update("""
+                    INSERT INTO fgc.cap_check
+                        (validation_run_id, contract_id, payment_stage, cap_rule_set_id, check_kind, as_of_date,
+                         base_premium_amount, refund_12m_amount, compliance_deduction_amount,
+                         limit_amount, included_amount, remaining_amount, usage_pct, result_status, checked_at)
+                    VALUES (?, ?, 'INSURER_TO_GA', ?, 'MONTHLY', '2032-01-01', 100000, 0, 0, 1200000, 0, 1200000, 0, 'NORMAL', now())
+                    """, runId, contractId, capRuleSetInsurerToGa);
+
+            jdbcTemplate.update("""
+                    INSERT INTO fgc.arbitrage_check
+                        (validation_run_id, contract_id, as_of_date, contract_month_no,
+                         cumulative_paid_premium, net_difference_amount, standard_deduction_80_yn, result_status)
+                    VALUES (?, ?, '2032-01-01', 1, 100000, 0, false, 'CLEAR')
+                    """, runId, contractId);
+
+            Long headerId = jdbcTemplate.queryForObject("""
+                    INSERT INTO fgc.journal_header
+                        (journal_no, journal_date, journal_type, source_entity_type, source_entity_id, validation_run_id)
+                    VALUES (?, '2032-01-01', 'ADJUSTMENT', 'TEST', ?, ?)
+                    RETURNING journal_header_id
+                    """, Long.class, "PERF-JRN-" + runId + "-" + contractId, "PERF-JRN-" + runId + "-" + contractId, runId);
+            jdbcTemplate.update("""
+                    INSERT INTO fgc.journal_line (journal_header_id, line_no, journal_account_id, debit_amount)
+                    VALUES (?, 1, ?, 1000)
+                    """, headerId, journalAccountId("EXPECTED_RECEIVABLE"));
+            jdbcTemplate.update("""
+                    INSERT INTO fgc.journal_line (journal_header_id, line_no, journal_account_id, credit_amount)
+                    VALUES (?, 2, ?, 1000)
+                    """, headerId, journalAccountId("EXPECTED_INCOME"));
+
+            jdbcTemplate.update("""
+                    INSERT INTO fgc.schedule_header
+                        (contract_id, payment_stage, policy_version_id, schedule_version_no,
+                         schedule_regime, active_yn, validation_run_id)
+                    VALUES (?, 'INSURER_TO_GA', ?, ?, 'CURRENT', false, ?)
+                    """, contractId, policyVersionId, versionNo, runId);
+        }
+
+        Long reconRunId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.reconciliation_run (settlement_month, payment_stage, validation_run_id)
+                VALUES ('2032-01-01', 'INSURER_TO_GA', ?)
+                RETURNING reconciliation_run_id
+                """, Long.class, runId);
+        for (int i = 0; i < contractIds.size(); i++) {
+            jdbcTemplate.update("""
+                    INSERT INTO fgc.reconciliation_result (reconciliation_run_id, match_group_key, result_type, difference_amount)
+                    VALUES (?, ?, 'MATCHED', 0)
+                    """, reconRunId, "PERF-REC-" + runId + "-" + i);
+        }
+    }
+
+    @Test
+    void summarizeAndAgentMonitoringStayFastAtDemoScale() {
+        loadReferenceIds();
+
+        List<Long> contractIds = new ArrayList<>();
+        for (int i = 0; i < CONTRACTS_PER_RUN; i++) {
+            contractIds.add(insertSyntheticContract(i));
+        }
+
+        Long targetRunId = null;
+        for (int r = 1; r <= RUN_COUNT; r++) {
+            Long runId = insertValidationRun(r);
+            seedRunData(runId, contractIds, r);
+            targetRunId = runId; // 마지막 실행을 조회 대상으로 삼는다
+        }
+
+        // 총 데이터 규모 확인 — 500행씩 5개 표(원장 라인 별도 1,000행)
+        Long totalCapChecks = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM fgc.cap_check", Long.class);
+        assertThat(totalCapChecks).isGreaterThanOrEqualTo((long) RUN_COUNT * CONTRACTS_PER_RUN);
+
+        long summarizeStart = System.nanoTime();
+        ValidationRunResultSummaryRow summary = mapper.summarize(targetRunId);
+        long summarizeMillis = (System.nanoTime() - summarizeStart) / 1_000_000;
+
+        long agentStart = System.nanoTime();
+        List<AgentCapMonitoringRow> byAgent = mapper.summarizeCapByAgent(targetRunId);
+        long agentMillis = (System.nanoTime() - agentStart) / 1_000_000;
+
+        // 정확성 — 이 실행에 심은 25건만 잡혀야 한다(다른 19개 실행 것과 섞이지 않음).
+        assertThat(summary.getCapCheckedCount()).isEqualTo(CONTRACTS_PER_RUN);
+        assertThat(summary.getArbitrageCheckedCount()).isEqualTo(CONTRACTS_PER_RUN);
+        assertThat(summary.getJournalCount()).isEqualTo(CONTRACTS_PER_RUN);
+        assertThat(summary.getReconciliationResultCount()).isEqualTo(CONTRACTS_PER_RUN);
+        assertThat(summary.getScheduleGeneratedCount()).isEqualTo(CONTRACTS_PER_RUN);
+        assertThat(byAgent.stream().mapToLong(AgentCapMonitoringRow::getCheckedCount).sum())
+                .isEqualTo(CONTRACTS_PER_RUN);
+
+        // 성능 — 하드웨어별 편차가 크니 절대 기준이 아니라 "N+1이 아니라면 당연히
+        // 이 정도는 나와야 한다"는 넉넉한 상한선이다(실측은 클래스 Javadoc 참고).
+        assertThat(summarizeMillis).as("summarize() 실행 시간(ms)").isLessThan(2000);
+        assertThat(agentMillis).as("summarizeCapByAgent() 실행 시간(ms)").isLessThan(2000);
+
+        System.out.println("[FUN-043 성능] 실행 " + RUN_COUNT + "개 x 계약 " + CONTRACTS_PER_RUN
+                + "개 = summarize() " + summarizeMillis + "ms, summarizeCapByAgent() " + agentMillis + "ms");
+        printExplain("cap_check", "SELECT * FROM fgc.cap_check WHERE validation_run_id = " + targetRunId);
+        printExplain("journal_header", "SELECT * FROM fgc.journal_header WHERE validation_run_id = " + targetRunId);
+        printExplain("reconciliation_run", "SELECT * FROM fgc.reconciliation_run WHERE validation_run_id = " + targetRunId);
+        printExplain("schedule_header", "SELECT * FROM fgc.schedule_header WHERE validation_run_id = " + targetRunId);
+    }
+
+    /** EXPLAIN 결과를 stdout에 남긴다 — Seq Scan/Index Scan 여부는 리뷰어가 직접 확인한다. */
+    private void printExplain(String label, String sql) {
+        List<String> plan = jdbcTemplate.queryForList("EXPLAIN " + sql, String.class);
+        System.out.println("[FUN-043 EXPLAIN " + label + "]");
+        plan.forEach(line -> System.out.println("  " + line));
+    }
+}

--- a/src/test/java/com/susukkang/fgc/validation/service/ScheduleRegenerationBatchItemServiceTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ScheduleRegenerationBatchItemServiceTest.java
@@ -1,0 +1,62 @@
+package com.susukkang.fgc.validation.service;
+
+import com.susukkang.fgc.contract.dto.InsuranceContract;
+import com.susukkang.fgc.schedule.dto.ScheduleGenerationResult;
+import com.susukkang.fgc.schedule.mapper.ScheduleMapper;
+import com.susukkang.fgc.schedule.service.ScheduleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * FGC-FUN-043 — 스케줄 생성과 validation_run_id 연결이 같은 REQUIRES_NEW 트랜잭션
+ * 안에서 함께 처리되는지 확인한다(코드리뷰 반영: 예전에는 연결 UPDATE가 호출자의 바깥
+ * 트랜잭션에 있어, 바깥 트랜잭션이 나중에 롤백되면 이미 커밋된 헤더가
+ * validation_run_id=NULL로 남는 문제가 있었다).
+ */
+@ExtendWith(MockitoExtension.class)
+class ScheduleRegenerationBatchItemServiceTest {
+
+    @Mock
+    private ScheduleService scheduleService;
+    @Mock
+    private ScheduleMapper scheduleMapper;
+
+    private ScheduleRegenerationBatchItemService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ScheduleRegenerationBatchItemService(scheduleService, scheduleMapper);
+    }
+
+    @Test
+    void linksNewlyCreatedHeadersToTheValidationRun() {
+        given(scheduleService.generateSchedules(any(InsuranceContract.class)))
+                .willReturn(new ScheduleGenerationResult(List.of(200L, 201L), 24));
+
+        service.process(10L, 118L);
+
+        verify(scheduleMapper).linkHeadersToValidationRun(List.of(200L, 201L), 118L);
+    }
+
+    @Test
+    void doesNotCallLinkWhenNoHeadersWereCreated() {
+        // 활성 스케줄이 이미 있어 generateSchedules()가 새 헤더를 안 만드는 경우 —
+        // linkHeadersToValidationRun 호출 자체가 없어야 한다(빈 IN절 UPDATE 방지).
+        given(scheduleService.generateSchedules(any(InsuranceContract.class)))
+                .willReturn(new ScheduleGenerationResult(List.of(), 0));
+
+        service.process(10L, 118L);
+
+        verify(scheduleMapper, never()).linkHeadersToValidationRun(any(), any());
+    }
+}

--- a/src/test/java/com/susukkang/fgc/validation/service/ValidationRunScheduleServiceTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ValidationRunScheduleServiceTest.java
@@ -50,34 +50,22 @@ class ValidationRunScheduleServiceTest {
     }
 
     @Test
-    void delegatesValidContractToExistingScheduleService() {
+    void delegatesValidContractToExistingScheduleServiceWithValidationRunId() {
         given(validationScheduleMapper.selectScheduleStates(118L))
                 .willReturn(List.of(validState(10L, PaymentStage.INSURER_TO_GA),
                         validState(10L, PaymentStage.GA_TO_FC)));
-        given(itemService.process(10L))
+        given(itemService.process(10L, 118L))
                 .willReturn(new ScheduleGenerationResult(List.of(200L, 201L), 24));
 
         StepProcessingResult result = service.validateContractSchedules(118L);
 
         assertThat(result.processedCount()).isEqualTo(1);
         assertThat(result.skippedCount()).isZero();
-        verify(itemService).process(10L);
-        // FGC-FUN-043 — 새로 만든 헤더는 이 실행에 연결돼야 화면 집계에서 잡힌다.
-        verify(scheduleMapper).linkHeadersToValidationRun(List.of(200L, 201L), 118L);
-    }
-
-    @Test
-    void doesNotLinkHeadersWhenRegenerationCreatesNothingNew() {
-        // 활성 스케줄이 이미 있어 generateSchedules()가 새 헤더를 안 만드는 경우 —
-        // linkHeadersToValidationRun 호출 자체가 없어야 한다(빈 IN절 UPDATE 방지).
-        given(validationScheduleMapper.selectScheduleStates(118L))
-                .willReturn(List.of(validState(10L, PaymentStage.INSURER_TO_GA)));
-        given(itemService.process(10L))
-                .willReturn(new ScheduleGenerationResult(List.of(), 0));
-
-        service.validateContractSchedules(118L);
-
-        verify(scheduleMapper, never()).linkHeadersToValidationRun(any(), any());
+        // FGC-FUN-043 결과 집계 — validationRunId를 itemService에 넘겨야 생성·연결이
+        // 같은 REQUIRES_NEW 트랜잭션 안에서 처리된다(코드리뷰 반영). 이 Service 자신은
+        // 더 이상 scheduleMapper.linkHeadersToValidationRun을 직접 호출하지 않는다 —
+        // 그 책임은 ScheduleRegenerationBatchItemServiceTest가 검증한다.
+        verify(itemService).process(10L, 118L);
     }
 
     @Test
@@ -94,7 +82,7 @@ class ValidationRunScheduleServiceTest {
         verify(exceptionCaseMapper).insertDataQualityCase(
                 118L, 10L, "예상 스케줄 정합성 오류",
                 "GA_TO_FC 활성 OPERATIONAL 스케줄 헤더가 중복되었습니다.");
-        verify(itemService, never()).process(any());
+        verify(itemService, never()).process(any(), any());
     }
 
     @Test
@@ -114,7 +102,7 @@ class ValidationRunScheduleServiceTest {
         verify(scheduleMapper).upsertPolicyReviewCase(
                 10L, PaymentStage.INSURER_TO_GA, "POLICY_MISSING",
                 "예상 스케줄 생성 검토 필요", "적용 가능한 현행 수수료 정책이 없습니다.");
-        verify(itemService, never()).process(any());
+        verify(itemService, never()).process(any(), any());
     }
 
     @Test
@@ -126,8 +114,8 @@ class ValidationRunScheduleServiceTest {
                         validState(20L, PaymentStage.INSURER_TO_GA),
                         validState(20L, PaymentStage.GA_TO_FC)));
         doThrow(new FgcBusinessException(FgcErrorCode.COMMON_002))
-                .when(itemService).process(10L);
-        given(itemService.process(20L))
+                .when(itemService).process(10L, 118L);
+        given(itemService.process(20L, 118L))
                 .willReturn(new ScheduleGenerationResult(List.of(202L), 12));
 
         StepProcessingResult result = service.validateContractSchedules(118L);
@@ -138,8 +126,8 @@ class ValidationRunScheduleServiceTest {
             assertThat(skip.contractId()).isEqualTo(10L);
             assertThat(skip.reasonCode()).isEqualTo("SCHEDULE_REGENERATION_FAILED");
         });
-        verify(itemService).process(10L);
-        verify(itemService).process(20L);
+        verify(itemService).process(10L, 118L);
+        verify(itemService).process(20L, 118L);
     }
 
     private ValidationScheduleState validState(Long contractId, PaymentStage paymentStage) {

--- a/src/test/java/com/susukkang/fgc/validation/service/ValidationRunScheduleServiceTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ValidationRunScheduleServiceTest.java
@@ -5,6 +5,7 @@ import com.susukkang.fgc.common.code.ScheduleHeaderStatus;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.common.exception.FgcErrorCode;
 import com.susukkang.fgc.policy.service.CommissionPolicyService;
+import com.susukkang.fgc.schedule.dto.ScheduleGenerationResult;
 import com.susukkang.fgc.schedule.mapper.ScheduleMapper;
 import com.susukkang.fgc.validation.batch.contract.StepProcessingResult;
 import com.susukkang.fgc.validation.dto.ValidationScheduleState;
@@ -53,12 +54,30 @@ class ValidationRunScheduleServiceTest {
         given(validationScheduleMapper.selectScheduleStates(118L))
                 .willReturn(List.of(validState(10L, PaymentStage.INSURER_TO_GA),
                         validState(10L, PaymentStage.GA_TO_FC)));
+        given(itemService.process(10L))
+                .willReturn(new ScheduleGenerationResult(List.of(200L, 201L), 24));
 
         StepProcessingResult result = service.validateContractSchedules(118L);
 
         assertThat(result.processedCount()).isEqualTo(1);
         assertThat(result.skippedCount()).isZero();
         verify(itemService).process(10L);
+        // FGC-FUN-043 — 새로 만든 헤더는 이 실행에 연결돼야 화면 집계에서 잡힌다.
+        verify(scheduleMapper).linkHeadersToValidationRun(List.of(200L, 201L), 118L);
+    }
+
+    @Test
+    void doesNotLinkHeadersWhenRegenerationCreatesNothingNew() {
+        // 활성 스케줄이 이미 있어 generateSchedules()가 새 헤더를 안 만드는 경우 —
+        // linkHeadersToValidationRun 호출 자체가 없어야 한다(빈 IN절 UPDATE 방지).
+        given(validationScheduleMapper.selectScheduleStates(118L))
+                .willReturn(List.of(validState(10L, PaymentStage.INSURER_TO_GA)));
+        given(itemService.process(10L))
+                .willReturn(new ScheduleGenerationResult(List.of(), 0));
+
+        service.validateContractSchedules(118L);
+
+        verify(scheduleMapper, never()).linkHeadersToValidationRun(any(), any());
     }
 
     @Test
@@ -108,6 +127,8 @@ class ValidationRunScheduleServiceTest {
                         validState(20L, PaymentStage.GA_TO_FC)));
         doThrow(new FgcBusinessException(FgcErrorCode.COMMON_002))
                 .when(itemService).process(10L);
+        given(itemService.process(20L))
+                .willReturn(new ScheduleGenerationResult(List.of(202L), 12));
 
         StepProcessingResult result = service.validateContractSchedules(118L);
 


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* 검증 실행 결과 집계(FUN-043)를 스케줄 생성상태·대사 3분류·설계사 모니터링까지 확대하고, 조회 성능 인덱스를 추가

## 🔗 2. 관련 이슈

* Closes #198

## 🛠 3. 구현 내용

* `schedule_header`에 `validation_run_id`를 연결(V21) : 월 검증 배치가 생성·재생성한 스케줄만 실행에 표시되고, 계약 생성 등 무관한 경로는 NULL로 남음
* 대사 결과를 `MATCHED`/`MISMATCHED`(양쪽 다 있지만 값·상태 불일치)/`UNMATCHED`(상대편 자체가 없음)로 분류하고 차액 합계(`reconciliationDifferenceAmountTotal`) 추가
* `cap_check`를 설계사(`agent_id`) 기준으로 집계하는 모니터링 쿼리(`summarizeCapByAgent`) 추가
* `journal_header`/`reconciliation_run`의 `validation_run_id` 조회에 인덱스 추가(V22) — 기존에 인덱스가 없어 매번 시퀀셜 스캔이던 것을 확인 후 개선

## 🧪 4. 테스트 방법

1. `./gradlew test --tests "com.susukkang.fgc.validation.mapper.ValidationRunDetailMapperIntegrationTest"` — 스케줄/대사 3분류/설계사 모니터링 각각 다른 실행과 안 섞이는지, 계약별 판정이 안 바뀌는지 확인
2. `./gradlew test --tests "com.susukkang.fgc.validation.mapper.ValidationRunSummaryPerformanceTest"` — 실행 20개×계약 25개(2,500행) 규모에서 `summarize()`/`summarizeCapByAgent()` 실행 시간과 EXPLAIN 플랜을 stdout에 출력해 확인
3. `./gradlew test --tests "com.susukkang.fgc.validation.service.ValidationRunScheduleServiceTest"`

## 🗄️ 5. DB / Flyway 변경

* [x] 새로운 Flyway 마이그레이션 파일 추가

### 추가된 마이그레이션 파일

* `V21__schedule_header_validation_run_link.sql` — `schedule_header.validation_run_id` nullable FK + 인덱스
* `V22__validation_run_summary_indexes.sql` — `journal_header`/`reconciliation_run`의 `validation_run_id` 인덱스

## 📋 6. 리뷰 요구사항

* 대사 3분류 매핑 규칙(`EXPECTED_MISSING`/`ACTUAL_MISSING`→UNMATCHED, 나머지 비-MATCHED→MISMATCHED)이 업무적으로 맞는지 확인 부탁드립니다

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다(새 파일만 추가).
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음

## 💬 9. 참고 사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 검증 실행 요약에서 대사 결과를 매칭·불일치·미매칭별 건수와 차액 합계로 확인할 수 있습니다.
  * 스케줄 생성 건수와 설계사별 상한 점검 결과를 제공합니다.
  * 검증 배치로 생성된 스케줄을 해당 검증 실행과 자동으로 연결합니다.

* **성능 개선**
  * 검증 실행별 요약 및 설계사별 점검 결과 조회 성능을 향상했습니다.

* **테스트**
  * 요약 집계, 스케줄 연결, 점검 결과의 정확성을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->