### PR TITLE
[Feat] FUN-051 #1 대사 실행 이력 조회 SQL·Service

### DIFF
--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/ReconciliationRunHistoryResponse.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/ReconciliationRunHistoryResponse.java
@@ -1,0 +1,40 @@
+package com.susukkang.fgc.reconciliation.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+/**
+ * RECO-W01 "④ 실행 이력" 응답 1건(IF-API-39). 일부러 정적 from() 팩토리를 두지 않았다 —
+ * matchRatePct 계산(대상 0건 처리 포함)과 라벨 변환이 이 이슈의 핵심 로직이라
+ * ReconciliationRunHistoryServiceImpl에서 직접 조립하도록 남겨 둔다.
+ *
+ * validationRunId/reconciliationRunId는 VRUN-W02·RECO-W02·EXCP-W01·LEDG-W01로 이동할 때
+ * 쓰는 식별자다(이슈의 "관련 화면으로 이동할 수 있도록 식별자 제공" 요구사항).
+ */
+public record ReconciliationRunHistoryResponse(
+        Long reconciliationRunId,
+        Long validationRunId,
+        LocalDate settlementMonth,
+        String paymentStage,
+        String paymentStageLabel,
+        Long insurerId,
+        String insurerName,
+        String status,
+        String statusLabel,
+        Long tolerancePolicyVersionId,
+        String createdBy,
+        OffsetDateTime createdAt,
+        OffsetDateTime startedAt,
+        OffsetDateTime completedAt,
+        OffsetDateTime finalizedAt,
+        String finalizedBy,
+        long targetCount,
+        long matchedCount,
+        long exceptionCount,
+        BigDecimal expectedTotal,
+        BigDecimal actualTotal,
+        BigDecimal differenceTotal,
+        BigDecimal matchRatePct
+) {
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/ReconciliationRunHistoryRow.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/ReconciliationRunHistoryRow.java
@@ -1,0 +1,44 @@
+package com.susukkang.fgc.reconciliation.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+/**
+ * 대사 실행 이력 1행. reconciliation_run + insurer(보험회사명) + app_user(생성자 login_id) +
+ * vw_reconciliation_summary(대상/일치/불일치 건수·금액) 조인 투영.
+ *
+ * vw_reconciliation_summary는 reconciliation_run을 LEFT JOIN reconciliation_result로
+ * 만들어서(V1__baseline_v2_1_2.sql:1490) 결과가 아직 없는 실행도 뷰에 항상 1행 존재하고
+ * COUNT/SUM이 0으로 채워진다 — 그래서 이 Row도 INNER JOIN으로 그 뷰를 붙여도 결과 없는
+ * 실행이 통째로 빠지는 일이 없다.
+ */
+@Getter
+@Setter
+public class ReconciliationRunHistoryRow {
+    private Long reconciliationRunId;
+    private Long validationRunId;
+    private LocalDate settlementMonth;
+    private String paymentStage;
+    private Long insurerId;
+    private String insurerName;
+    private String status;
+    private Long tolerancePolicyVersionId;
+    private String createdBy;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime startedAt;
+    private OffsetDateTime completedAt;
+    private OffsetDateTime finalizedAt;
+    private String finalizedBy;
+
+    // vw_reconciliation_summary
+    private Long targetCount;
+    private Long matchedCount;
+    private Long exceptionCount;
+    private BigDecimal expectedTotal;
+    private BigDecimal actualTotal;
+    private BigDecimal differenceTotal;
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/ReconciliationRunSearchCriteria.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/ReconciliationRunSearchCriteria.java
@@ -1,0 +1,14 @@
+package com.susukkang.fgc.reconciliation.dto;
+
+import java.time.LocalDate;
+
+/**
+ * 대사 실행 이력 검색조건(IF-API-39, RECO-W01 "④ 실행 이력"). settlementMonth/paymentStage가
+ * null이면 그 조건은 걸지 않는다(전체). settlementMonth는 그 달의 1일(reconciliation_run.
+ * settlement_month와 같은 CHECK(fgc.is_first_day_of_month)를 만족해야 한다).
+ */
+public record ReconciliationRunSearchCriteria(
+        LocalDate settlementMonth,
+        String paymentStage
+) {
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/mapper/ReconciliationRunHistoryMapper.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/mapper/ReconciliationRunHistoryMapper.java
@@ -1,0 +1,25 @@
+package com.susukkang.fgc.reconciliation.mapper;
+
+import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryRow;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * IF-API-39 대사 실행 이력 조회 전용 Mapper(RECO-W01 "④ 실행 이력"). 생성·상태전이는
+ * ReconciliationRunMapper 몫이라 여기서는 조회만 다룬다.
+ */
+@Mapper
+public interface ReconciliationRunHistoryMapper {
+
+    /**
+     * settlementMonth/paymentStage가 null이면 그 조건은 걸지 않는다(전체).
+     * created_at 내림차순(최신 실행·재실행이 먼저) — 같은 정산월·지급단계라도 월 검증
+     * 실행/보험회사가 다르면 uq_reconciliation_run(V1:1444-1445) 덕분에 서로 다른 행으로
+     * 자연히 분리돼 나온다.
+     */
+    List<ReconciliationRunHistoryRow> search(@Param("settlementMonth") LocalDate settlementMonth,
+                                              @Param("paymentStage") String paymentStage);
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryService.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryService.java
@@ -1,0 +1,15 @@
+package com.susukkang.fgc.reconciliation.service;
+
+import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryResponse;
+import com.susukkang.fgc.reconciliation.dto.ReconciliationRunSearchCriteria;
+
+import java.util.List;
+
+/**
+ * IF-API-39 대사 실행 이력 조회(RECO-W01 "④ 실행 이력"). 내부 Service 호출 전용
+ */
+public interface ReconciliationRunHistoryService {
+
+    /** criteria로 대사 실행 이력을 검색한다. 결과가 없으면 빈 리스트(오류 아님). */
+    List<ReconciliationRunHistoryResponse> findHistory(ReconciliationRunSearchCriteria criteria);
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImpl.java
@@ -33,15 +33,20 @@ public class ReconciliationRunHistoryServiceImpl implements ReconciliationRunHis
             PaymentStage paymentStage = PaymentStage.valueOf(row.getPaymentStage());
             ValidationRunStatus status = ValidationRunStatus.valueOf(row.getStatus());
 
-            // 일치율 계산
+            // 일치율 계산 — 반올림은 최종 결과 한 번만 한다(코드리뷰 반영). 먼저 소수
+            // 넷째 자리로 나눠서 반올림한 다음 100을 곱하고 다시 소수 첫째 자리로
+            // 반올림하면 두 번 반올림하는 셈이라 오차가 생긴다(예: matched=12449,
+            // target=100000 → 정확한 값은 12.449%라 첫째 자리 반올림 시 12.4가 맞는데,
+            // 넷째 자리에서 먼저 반올림하면 0.1245*100=12.45가 되고 그걸 다시 반올림해
+            // 12.5로 틀어진다). 그래서 100을 먼저 곱한 뒤 나눗셈에서 바로 소수 첫째
+            // 자리까지 한 번에 반올림한다.
             BigDecimal matchRatePct;
             if(row.getTargetCount()==0){
                 matchRatePct = null;
             } else {
                 matchRatePct = BigDecimal.valueOf(row.getMatchedCount())
-                        .divide(BigDecimal.valueOf(row.getTargetCount()), 4, RoundingMode.HALF_UP)
                         .multiply(BigDecimal.valueOf(100))
-                        .setScale(1, RoundingMode.HALF_UP);
+                        .divide(BigDecimal.valueOf(row.getTargetCount()), 1, RoundingMode.HALF_UP);
             }
 
             result.add(new ReconciliationRunHistoryResponse(

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImpl.java
@@ -1,0 +1,63 @@
+package com.susukkang.fgc.reconciliation.service;
+
+import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.common.code.ValidationRunStatus;
+import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryResponse;
+import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryRow;
+import com.susukkang.fgc.reconciliation.dto.ReconciliationRunSearchCriteria;
+import com.susukkang.fgc.reconciliation.mapper.ReconciliationRunHistoryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReconciliationRunHistoryServiceImpl implements ReconciliationRunHistoryService {
+
+    private final ReconciliationRunHistoryMapper reconciliationRunHistoryMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReconciliationRunHistoryResponse> findHistory(ReconciliationRunSearchCriteria criteria) {
+        // 1. 목록 조회
+        List<ReconciliationRunHistoryRow> rows =
+                reconciliationRunHistoryMapper.search(criteria.settlementMonth(), criteria.paymentStage());
+
+        List<ReconciliationRunHistoryResponse> result = new ArrayList<>();
+        for (ReconciliationRunHistoryRow row : rows) {
+            PaymentStage paymentStage = PaymentStage.valueOf(row.getPaymentStage());
+            ValidationRunStatus status = ValidationRunStatus.valueOf(row.getStatus());
+
+            // 일치율 계산
+            BigDecimal matchRatePct;
+            if(row.getTargetCount()==0){
+                matchRatePct = null;
+            } else {
+                matchRatePct = BigDecimal.valueOf(row.getMatchedCount())
+                        .divide(BigDecimal.valueOf(row.getTargetCount()), 4, RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.valueOf(100))
+                        .setScale(1, RoundingMode.HALF_UP);
+            }
+
+            result.add(new ReconciliationRunHistoryResponse(
+                    row.getReconciliationRunId(), row.getValidationRunId(),
+                    row.getSettlementMonth(), row.getPaymentStage(), paymentStage.label(),
+                    row.getInsurerId(), row.getInsurerName(),
+                    row.getStatus(), status.label(),
+                    row.getTolerancePolicyVersionId(),
+                    row.getCreatedBy(), row.getCreatedAt(),
+                    row.getStartedAt(), row.getCompletedAt(),
+                    row.getFinalizedAt(), row.getFinalizedBy(),
+                    row.getTargetCount(), row.getMatchedCount(), row.getExceptionCount(),
+                    row.getExpectedTotal(), row.getActualTotal(), row.getDifferenceTotal(),
+                    matchRatePct
+            ));
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/susukkang/fgc/validation/dto/AgentCapMonitoringRow.java
+++ b/src/main/java/com/susukkang/fgc/validation/dto/AgentCapMonitoringRow.java
@@ -6,12 +6,19 @@ import lombok.Setter;
 /**
  * FGC-FUN-043 설계사 단위 1,200% 모니터링 지표 1행 — 참고용 집계다.
  * 계약별 규제판정(cap_check.result_status)을 이 집계가 바꾸거나 덮어쓰지 않는다.
+ *
+ * paymentStage로 반드시 나눠야 한다(코드리뷰 반영) — 원수사→GA(INSURER_TO_GA)와
+ * GA→설계사(GA_TO_FC) 1,200%는 계산 규칙 자체가 다른 별도 게이지라 하나로 합치면
+ * 절대 금지사항 위반이다(docs/07_규제조문표_v0.2.1.md "보험회사→GA와 GA→설계사 1,200%
+ * 검증을 하나의 게이지로 합치지 않는다", 같은 문서 "1,200% 게이지 분리" 절;
+ * 화면정의서 v1.0→v2.0 변경이력에도 "1,200% 게이지 2개로 분리"가 명시돼 있다).
  */
 @Getter
 @Setter
 public class AgentCapMonitoringRow {
     private Long agentId;
     private String agentName;
+    private String paymentStage;
     private long checkedCount;
     private long violationCount;
     private long warningCount;

--- a/src/main/resources/mapper/reconciliation/ReconciliationRunHistoryMapper.xml
+++ b/src/main/resources/mapper/reconciliation/ReconciliationRunHistoryMapper.xml
@@ -32,6 +32,6 @@
                 AND rr.payment_stage = #{paymentStage}
             </if>
         </where>
-        ORDER BY rr.created_at DESC
+        ORDER BY rr.created_at DESC, rr.reconciliation_run_id DESC
     </select>
 </mapper>

--- a/src/main/resources/mapper/reconciliation/ReconciliationRunHistoryMapper.xml
+++ b/src/main/resources/mapper/reconciliation/ReconciliationRunHistoryMapper.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.susukkang.fgc.reconciliation.mapper.ReconciliationRunHistoryMapper">
+    <!--
+      vw_reconciliation_summary는 reconciliation_run을 LEFT JOIN reconciliation_result로
+      만든 뷰라(V1__baseline_v2_1_2.sql:1489-1494) reconciliation_run 1건당 항상 1행이
+      나온다(결과가 0건이어도 COUNT/SUM이 0으로 채워진 행이 존재) — 그래서 여기서는
+      안전하게 INNER JOIN한다. insurer/app_user는 insurer_id·created_by가 nullable이라
+      LEFT JOIN한다.
+    -->
+    <select id="search" resultType="com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryRow">
+        SELECT rr.reconciliation_run_id, rr.validation_run_id, rr.settlement_month, rr.payment_stage,
+               rr.insurer_id, ins.insurer_name AS insurerName,
+               rr.status, rr.tolerance_policy_version_id,
+               creator.login_id AS createdBy, rr.created_at AS createdAt,
+               rr.started_at AS startedAt, rr.completed_at AS completedAt,
+               rr.finalized_at AS finalizedAt, finalizer.login_id AS finalizedBy,
+               vw.result_count AS targetCount, vw.matched_count AS matchedCount,
+               vw.exception_count AS exceptionCount,
+               vw.expected_total AS expectedTotal, vw.actual_total AS actualTotal,
+               vw.difference_total AS differenceTotal
+        FROM fgc.reconciliation_run rr
+        JOIN fgc.vw_reconciliation_summary vw ON vw.reconciliation_run_id = rr.reconciliation_run_id
+        LEFT JOIN fgc.insurer ins ON ins.insurer_id = rr.insurer_id
+        LEFT JOIN fgc.app_user creator ON creator.user_id = rr.created_by
+        LEFT JOIN fgc.app_user finalizer ON finalizer.user_id = rr.finalized_by
+        <where>
+            <if test="settlementMonth != null">
+                AND rr.settlement_month = #{settlementMonth}
+            </if>
+            <if test="paymentStage != null">
+                AND rr.payment_stage = #{paymentStage}
+            </if>
+        </where>
+        ORDER BY rr.created_at DESC
+    </select>
+</mapper>

--- a/src/main/resources/mapper/validation/ValidationRunDetailMapper.xml
+++ b/src/main/resources/mapper/validation/ValidationRunDetailMapper.xml
@@ -105,10 +105,16 @@
                       WHERE validation_run_id = #{validationRunId}) sh
     </select>
 
-    <!-- 설계사 단위 모니터링 참고용 집계 — 계약별 cap_check.result_status는 건드리지 않는다. -->
+    <!-- 설계사 단위 모니터링 참고용 집계 — 계약별 cap_check.result_status는 건드리지 않는다.
+         payment_stage로 반드시 나눈다(코드리뷰 반영) — 원수사→GA와 GA→설계사 1,200%는
+         계산 규칙이 다른 별도 게이지라 합치면 안 된다(docs/07_규제조문표_v0.2.1.md
+         절대 금지사항). cap_check가 (validation_run_id, contract_id, payment_stage)로
+         유일해서(uq_cap_check_monthly) 같은 계약이 두 지급단계 행을 동시에 가질 수
+         있다 — GROUP BY에서 빠지면 그 두 행이 하나로 합산된다. -->
     <select id="summarizeCapByAgent" resultType="com.susukkang.fgc.validation.dto.AgentCapMonitoringRow">
         SELECT ag.agent_id                                                    AS agentId,
                ag.agent_name                                                  AS agentName,
+               cc.payment_stage                                               AS paymentStage,
                COUNT(*)                                                       AS checkedCount,
                COUNT(*) FILTER (WHERE cc.result_status = 'VIOLATION')         AS violationCount,
                COUNT(*) FILTER (WHERE cc.result_status = 'WARNING')           AS warningCount,
@@ -117,8 +123,8 @@
           JOIN fgc.insurance_contract ic ON ic.contract_id = cc.contract_id
           JOIN fgc.agent ag ON ag.agent_id = ic.agent_id
          WHERE cc.validation_run_id = #{validationRunId}
-         GROUP BY ag.agent_id, ag.agent_name
-         ORDER BY ag.agent_id
+         GROUP BY ag.agent_id, ag.agent_name, cc.payment_stage
+         ORDER BY ag.agent_id, cc.payment_stage
     </select>
 
 </mapper>

--- a/src/test/java/com/susukkang/fgc/reconciliation/mapper/ReconciliationRunHistoryMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/mapper/ReconciliationRunHistoryMapperIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.susukkang.fgc.reconciliation.mapper;
+
+import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryRow;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * FGC-FUN-051 / IF-API-39 — 대사 실행 이력 Mapper. vw_reconciliation_summary 조인이
+ * 결과 0건 실행도 빠뜨리지 않는지, 정산월·지급단계 필터가 맞는지, 같은 정산월·지급단계라도
+ * 보험회사·월 검증 실행이 다르면 별도 행으로 나오는지(재실행 이력) 확인한다.
+ */
+@SpringBootTest
+@Transactional
+class ReconciliationRunHistoryMapperIntegrationTest {
+
+    private static final LocalDate TEST_MONTH = LocalDate.of(2098, 6, 1);
+
+    @Autowired
+    private ReconciliationRunHistoryMapper mapper;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private Long insertInsurer(String code) {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.insurer (insurer_code, insurer_name, insurer_type)
+                VALUES (?, ?, 'LIFE')
+                RETURNING insurer_id
+                """, Long.class, code, code + "생명");
+    }
+
+    /** guard_run_lifecycle이 INSERT 시 CREATED만 허용한다 — 다른 상태는 UPDATE로 전이시킨다. */
+    private Long insertReconciliationRun(String paymentStage, Long insurerId, Long validationRunId) {
+        Long id = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.reconciliation_run (settlement_month, payment_stage, insurer_id, validation_run_id)
+                VALUES (?, ?, ?, ?)
+                RETURNING reconciliation_run_id
+                """, Long.class, TEST_MONTH, paymentStage, insurerId, validationRunId);
+        return id;
+    }
+
+    private void insertReconciliationResult(Long reconRunId, String matchGroupKey, String resultType) {
+        jdbcTemplate.update("""
+                INSERT INTO fgc.reconciliation_result (reconciliation_run_id, match_group_key, result_type)
+                VALUES (?, ?, ?)
+                """, reconRunId, matchGroupKey, resultType);
+    }
+
+    @Test
+    void searchIncludesRunsWithNoResultsAsZeroCounts() {
+        Long insurerId = insertInsurer("FUN051-1");
+        Long runId = insertReconciliationRun("GA_TO_FC", insurerId, null);
+
+        List<ReconciliationRunHistoryRow> rows = mapper.search(TEST_MONTH, "GA_TO_FC");
+
+        assertThat(rows).filteredOn(row -> row.getReconciliationRunId().equals(runId))
+                .singleElement()
+                .satisfies(row -> {
+                    assertThat(row.getTargetCount()).isZero();
+                    assertThat(row.getMatchedCount()).isZero();
+                    assertThat(row.getExceptionCount()).isZero();
+                    assertThat(row.getInsurerName()).isEqualTo("FUN051-1생명");
+                });
+    }
+
+    @Test
+    void searchAggregatesMatchExceptionCountsFromReconciliationResult() {
+        Long insurerId = insertInsurer("FUN051-2");
+        Long runId = insertReconciliationRun("GA_TO_FC", insurerId, null);
+        insertReconciliationResult(runId, "FUN051-A", "MATCHED");
+        insertReconciliationResult(runId, "FUN051-B", "MATCHED");
+        insertReconciliationResult(runId, "FUN051-C", "AMOUNT_DIFFERENCE");
+
+        List<ReconciliationRunHistoryRow> rows = mapper.search(TEST_MONTH, "GA_TO_FC");
+
+        assertThat(rows).filteredOn(row -> row.getReconciliationRunId().equals(runId))
+                .singleElement()
+                .satisfies(row -> {
+                    assertThat(row.getTargetCount()).isEqualTo(3);
+                    assertThat(row.getMatchedCount()).isEqualTo(2);
+                    assertThat(row.getExceptionCount()).isEqualTo(1);
+                });
+    }
+
+    @Test
+    void searchFiltersByPaymentStage() {
+        Long insurerId = insertInsurer("FUN051-3");
+        Long gaToFcId = insertReconciliationRun("GA_TO_FC", insurerId, null);
+        Long insurerToGaId = insertReconciliationRun("INSURER_TO_GA", insurerId, null);
+
+        List<ReconciliationRunHistoryRow> gaToFcRows = mapper.search(TEST_MONTH, "GA_TO_FC");
+        List<ReconciliationRunHistoryRow> insurerToGaRows = mapper.search(TEST_MONTH, "INSURER_TO_GA");
+
+        assertThat(gaToFcRows).extracting(ReconciliationRunHistoryRow::getReconciliationRunId)
+                .contains(gaToFcId).doesNotContain(insurerToGaId);
+        assertThat(insurerToGaRows).extracting(ReconciliationRunHistoryRow::getReconciliationRunId)
+                .contains(insurerToGaId).doesNotContain(gaToFcId);
+    }
+
+    @Test
+    void searchTreatsDifferentInsurersAsSeparateHistoryEvenWithSameMonthAndStage() {
+        // 이슈 요구사항 — "동일 정산월·지급단계라도 월 검증 실행 또는 보험회사 조건이
+        // 다르면 별도 실행 이력으로 조회한다" — uq_reconciliation_run이 보장하는 동작을
+        // Mapper 레벨에서도 그대로 확인한다.
+        Long insurerA = insertInsurer("FUN051-4A");
+        Long insurerB = insertInsurer("FUN051-4B");
+        Long runA = insertReconciliationRun("GA_TO_FC", insurerA, null);
+        Long runB = insertReconciliationRun("GA_TO_FC", insurerB, null);
+
+        List<ReconciliationRunHistoryRow> rows = mapper.search(TEST_MONTH, "GA_TO_FC");
+
+        assertThat(rows).extracting(ReconciliationRunHistoryRow::getReconciliationRunId)
+                .contains(runA, runB);
+    }
+
+    @Test
+    void searchWithNoFiltersReturnsAllMonthsAndStages() {
+        Long insurerId = insertInsurer("FUN051-5");
+        Long runId = insertReconciliationRun("GA_TO_FC", insurerId, null);
+
+        List<ReconciliationRunHistoryRow> rows = mapper.search(null, null);
+
+        assertThat(rows).extracting(ReconciliationRunHistoryRow::getReconciliationRunId).contains(runId);
+    }
+}

--- a/src/test/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImplTest.java
@@ -1,0 +1,108 @@
+package com.susukkang.fgc.reconciliation.service;
+
+import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryResponse;
+import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryRow;
+import com.susukkang.fgc.reconciliation.dto.ReconciliationRunSearchCriteria;
+import com.susukkang.fgc.reconciliation.mapper.ReconciliationRunHistoryMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * FGC-FUN-051 — 일치율 계산(대상 0건 처리 포함)과 라벨 변환을 순수 로직 단위로 검증한다.
+ * DB 없이 Mockito로 Mapper를 대체한다 — SQL 정합성은 ReconciliationRunHistoryMapperIntegrationTest가 맡는다.
+ */
+@ExtendWith(MockitoExtension.class)
+class ReconciliationRunHistoryServiceImplTest {
+
+    @Mock
+    private ReconciliationRunHistoryMapper reconciliationRunHistoryMapper;
+
+    private ReconciliationRunHistoryServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ReconciliationRunHistoryServiceImpl(reconciliationRunHistoryMapper);
+    }
+
+    private ReconciliationRunHistoryRow row(long targetCount, long matchedCount, long exceptionCount) {
+        ReconciliationRunHistoryRow row = new ReconciliationRunHistoryRow();
+        row.setReconciliationRunId(1L);
+        row.setValidationRunId(2L);
+        row.setSettlementMonth(LocalDate.of(2026, 7, 1));
+        row.setPaymentStage("GA_TO_FC");
+        row.setInsurerId(3L);
+        row.setInsurerName("테스트생명");
+        row.setStatus("COMPLETED");
+        row.setTargetCount(targetCount);
+        row.setMatchedCount(matchedCount);
+        row.setExceptionCount(exceptionCount);
+        row.setExpectedTotal(BigDecimal.valueOf(100000));
+        row.setActualTotal(BigDecimal.valueOf(90000));
+        row.setDifferenceTotal(BigDecimal.valueOf(10000));
+        return row;
+    }
+
+    @Test
+    void returnsNullMatchRateWhenTargetCountIsZero() {
+        given(reconciliationRunHistoryMapper.search(null, null)).willReturn(List.of(row(0, 0, 0)));
+
+        List<ReconciliationRunHistoryResponse> result = service.findHistory(new ReconciliationRunSearchCriteria(null, null));
+
+        assertThat(result).singleElement().satisfies(response ->
+                assertThat(response.matchRatePct()).isNull());
+    }
+
+    @Test
+    void calculatesMatchRatePctRoundedToOneDecimal() {
+        // 3건 중 2건 일치 = 66.6666...% → 소수점 첫째 자리 반올림으로 66.7
+        given(reconciliationRunHistoryMapper.search(null, null)).willReturn(List.of(row(3, 2, 1)));
+
+        List<ReconciliationRunHistoryResponse> result = service.findHistory(new ReconciliationRunSearchCriteria(null, null));
+
+        assertThat(result).singleElement().satisfies(response ->
+                assertThat(response.matchRatePct()).isEqualByComparingTo("66.7"));
+    }
+
+    @Test
+    void calculatesFullMatchRateAsHundred() {
+        given(reconciliationRunHistoryMapper.search(null, null)).willReturn(List.of(row(5, 5, 0)));
+
+        List<ReconciliationRunHistoryResponse> result = service.findHistory(new ReconciliationRunSearchCriteria(null, null));
+
+        assertThat(result).singleElement().satisfies(response ->
+                assertThat(response.matchRatePct()).isEqualByComparingTo("100.0"));
+    }
+
+    @Test
+    void mapsPaymentStageAndStatusLabels() {
+        given(reconciliationRunHistoryMapper.search(null, null)).willReturn(List.of(row(1, 1, 0)));
+
+        List<ReconciliationRunHistoryResponse> result = service.findHistory(new ReconciliationRunSearchCriteria(null, null));
+
+        assertThat(result).singleElement().satisfies(response -> {
+            assertThat(response.paymentStage()).isEqualTo("GA_TO_FC");
+            assertThat(response.paymentStageLabel()).isEqualTo("GA→설계사");
+            assertThat(response.status()).isEqualTo("COMPLETED");
+            assertThat(response.statusLabel()).isEqualTo("계산완료");
+        });
+    }
+
+    @Test
+    void returnsEmptyListWhenMapperFindsNothing() {
+        given(reconciliationRunHistoryMapper.search(null, null)).willReturn(List.of());
+
+        List<ReconciliationRunHistoryResponse> result = service.findHistory(new ReconciliationRunSearchCriteria(null, null));
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImplTest.java
@@ -74,6 +74,20 @@ class ReconciliationRunHistoryServiceImplTest {
     }
 
     @Test
+    void roundsOnceInsteadOfCompoundingIntermediateRounding() {
+        // 코드리뷰 반영 회귀 테스트 — matched=12449, target=100000의 정확한 비율은
+        // 12.449%다. 소수 넷째 자리에서 먼저 반올림한 뒤 다시 소수 첫째 자리로
+        // 반올림하면(두 번 반올림) 12.45 → 12.5로 틀어진다. 한 번에 반올림하면 12.4가
+        // 맞는 값이다.
+        given(reconciliationRunHistoryMapper.search(null, null)).willReturn(List.of(row(100000, 12449, 87551)));
+
+        List<ReconciliationRunHistoryResponse> result = service.findHistory(new ReconciliationRunSearchCriteria(null, null));
+
+        assertThat(result).singleElement().satisfies(response ->
+                assertThat(response.matchRatePct()).isEqualByComparingTo("12.4"));
+    }
+
+    @Test
     void calculatesFullMatchRateAsHundred() {
         given(reconciliationRunHistoryMapper.search(null, null)).willReturn(List.of(row(5, 5, 0)));
 

--- a/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunDetailMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunDetailMapperIntegrationTest.java
@@ -350,10 +350,12 @@ class ValidationRunDetailMapperIntegrationTest {
 
         List<AgentCapMonitoringRow> byAgent = mapper.summarizeCapByAgent(runId);
 
-        // 두 계약이 같은 설계사 소속이면 모니터링 집계는 하나로 묶인다(참고용 합계일 뿐).
+        // 두 계약이 같은 설계사 소속이면(같은 지급단계라는 전제 하에) 모니터링 집계는
+        // 하나로 묶인다(참고용 합계일 뿐).
         if (sameAgentId.equals(agentId(c2))) {
             assertThat(byAgent).singleElement().satisfies(row -> {
                 assertThat(row.getAgentId()).isEqualTo(sameAgentId);
+                assertThat(row.getPaymentStage()).isEqualTo("INSURER_TO_GA");
                 assertThat(row.getCheckedCount()).isEqualTo(2);
                 assertThat(row.getViolationCount()).isEqualTo(1);
                 assertThat(row.getWarningCount()).isEqualTo(1);
@@ -373,6 +375,35 @@ class ValidationRunDetailMapperIntegrationTest {
                 String.class, runId, c2);
         assertThat(c1Status).isEqualTo("VIOLATION");
         assertThat(c2Status).isEqualTo("WARNING");
+    }
+
+    @Test
+    void summarizeCapByAgentKeepsInsurerToGaAndGaToFcAsSeparateGauges() {
+        // 코드리뷰 반영 회귀 테스트 — REG-08 "1,200% 게이지 2개(원수사→GA / GA→설계사)는
+        // 절대 합치지 않는다"(docs/07_규제조문표_v0.2.1.md). 같은 계약(=같은 설계사)이
+        // 두 지급단계에 각각 cap_check를 가질 수 있는데, payment_stage로 나누지 않으면
+        // 이 두 행이 하나의 checkedCount/violationCount로 잘못 합쳐진다.
+        Long runId = insertValidationRun(LocalDate.of(2031, 12, 1), 1, "RUNNING");
+        Long c1 = contractId("FGC-FGL01-202607-0001");
+
+        insertCapCheck(runId, c1, "INSURER_TO_GA", "VIOLATION");
+        insertCapCheck(runId, c1, "GA_TO_FC", "NORMAL");
+
+        List<AgentCapMonitoringRow> byAgent = mapper.summarizeCapByAgent(runId);
+
+        assertThat(byAgent).hasSize(2);
+        assertThat(byAgent).filteredOn(row -> row.getPaymentStage().equals("INSURER_TO_GA"))
+                .singleElement()
+                .satisfies(row -> {
+                    assertThat(row.getCheckedCount()).isEqualTo(1);
+                    assertThat(row.getViolationCount()).isEqualTo(1);
+                });
+        assertThat(byAgent).filteredOn(row -> row.getPaymentStage().equals("GA_TO_FC"))
+                .singleElement()
+                .satisfies(row -> {
+                    assertThat(row.getCheckedCount()).isEqualTo(1);
+                    assertThat(row.getViolationCount()).isZero();
+                });
     }
 
     @Test


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* 대사 실행 이력 조회 읽기 전용 Service(FUN-051)를 구현

## 🔗 2. 관련 이슈

* Closes #199

## 🛠 3. 구현 내용

* `ReconciliationRunSearchCriteria`(정산월·지급단계), `ReconciliationRunHistoryRow`(Mapper row), `ReconciliationRunHistoryResponse`
* `ReconciliationRunHistoryMapper`(인터페이스+XML) : `reconciliation_run`을 `vw_reconciliation_summary`(INNER JOIN해도 결과 0건 실행이 안 빠짐)·`insurer`·`app_user`와 조인
* `ReconciliationRunHistoryServiceImpl` : 일치율 = 일치 건수/대상 건수×100(대상 0건이면 null), 상태 라벨은 `ValidationRunStatus`를 그대로 씀

## 🧪 4. 테스트 방법

1. `./gradlew test --tests "com.susukkang.fgc.reconciliation.mapper.ReconciliationRunHistoryMapperIntegrationTest"` — 결과 0건 실행 포함 여부, 정산월·지급단계 필터, 같은 정산월·지급단계라도 보험회사가 다르면 별도 이력으로 조회되는지 확인
2. `./gradlew test --tests "com.susukkang.fgc.reconciliation.service.ReconciliationRunHistoryServiceImplTest"` — 일치율 계산(0건→null, 소수점 반올림), 라벨 매핑

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음

## 📋 6. 리뷰 요구사항


## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음

## 💬 9. 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 정산·대사 실행 이력을 정산월과 결제 단계로 검색할 수 있습니다.
  * 실행 상태, 처리 건수, 금액 합계 및 일치율을 확인할 수 있습니다.
  * 검증 결과에 스케줄 생성 건수와 대사 결과별 집계를 제공합니다.
  * 설계사별 한도 점검 현황과 검토 필요 건수를 확인할 수 있습니다.
  * 생성된 스케줄이 해당 검증 실행과 자동으로 연결됩니다.

* **개선 사항**
  * 대사 실행 요약 조회 성능과 결과 범위 분리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->