### PR TITLE
[Feat] FUN-051 #2 대사 실행 이력 조회 API

### DIFF
--- a/src/main/java/com/susukkang/fgc/reconciliation/controller/ReconciliationRunController.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/controller/ReconciliationRunController.java
@@ -7,14 +7,11 @@ import com.susukkang.fgc.common.exception.FgcErrorCode;
 import com.susukkang.fgc.common.security.Roles;
 import com.susukkang.fgc.common.util.DateUtil;
 import com.susukkang.fgc.common.web.ApiResponse;
-import com.susukkang.fgc.reconciliation.dto.CreateReconciliationRunCommand;
-import com.susukkang.fgc.reconciliation.dto.CreateReconciliationRunRequest;
-import com.susukkang.fgc.reconciliation.dto.CreateReconciliationRunResponse;
-import com.susukkang.fgc.reconciliation.dto.ReconciliationRunRow;
-import com.susukkang.fgc.reconciliation.dto.ReconciliationResultDetailResponse;
-import com.susukkang.fgc.reconciliation.dto.ReconciliationResultSearchResponse;
+import com.susukkang.fgc.common.web.PageResponse;
+import com.susukkang.fgc.reconciliation.dto.*;
 import com.susukkang.fgc.reconciliation.domain.ReconciliationResultType;
 import com.susukkang.fgc.reconciliation.service.ReconciliationResultQueryService;
+import com.susukkang.fgc.reconciliation.service.ReconciliationRunHistoryService;
 import com.susukkang.fgc.reconciliation.service.ReconciliationRunService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -51,6 +48,33 @@ public class ReconciliationRunController {
 
     private final ReconciliationRunService reconciliationRunService;
     private final ReconciliationResultQueryService reconciliationResultQueryService;
+    private final ReconciliationRunHistoryService reconciliationRunHistoryService;
+
+    @Operation(summary = "대사 실행 이력 조회 (IF-API-39)")
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public ApiResponse<ReconciliationRunSearchResponse> searchHistory(
+            @RequestParam(required = false) String month,
+            @RequestParam(required = false) String stage,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "createdAt,desc") String sort
+    ) {
+        LocalDate settlementMonth = null;
+        if (month != null) {
+            settlementMonth = parseSettlementMonth(month);
+        }
+
+        String paymentStage = null;
+        if (stage != null) {
+            paymentStage = parsePaymentStage(stage).name();
+        }
+
+        ReconciliationRunSearchCriteria criteria = new ReconciliationRunSearchCriteria(settlementMonth, paymentStage);
+        PageResponse<ReconciliationRunHistoryResponse> result = reconciliationRunHistoryService.findHistory(criteria, page, size, sort);
+
+        return ApiResponse.success(ReconciliationRunSearchResponse.from(result));
+    }
 
     @Operation(summary = "대사 실행 생성 (IF-API-38)")
     @PostMapping

--- a/src/main/java/com/susukkang/fgc/reconciliation/dto/ReconciliationRunSearchResponse.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/dto/ReconciliationRunSearchResponse.java
@@ -1,0 +1,20 @@
+package com.susukkang.fgc.reconciliation.dto;
+
+import com.susukkang.fgc.common.web.PageResponse;
+
+import java.util.List;
+
+/** IF-API-39 대사 실행 이력 조회 응답. ValidationRunSearchResponse/JournalSearchResponse와 같은 페이지 래핑 관례. */
+public record ReconciliationRunSearchResponse(
+        List<ReconciliationRunHistoryResponse> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        String sort
+) {
+    public static ReconciliationRunSearchResponse from(PageResponse<ReconciliationRunHistoryResponse> page) {
+        return new ReconciliationRunSearchResponse(
+                page.content(), page.page(), page.size(), page.totalElements(), page.totalPages(), page.sort());
+    }
+}

--- a/src/main/java/com/susukkang/fgc/reconciliation/mapper/ReconciliationRunHistoryMapper.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/mapper/ReconciliationRunHistoryMapper.java
@@ -16,10 +16,18 @@ public interface ReconciliationRunHistoryMapper {
 
     /**
      * settlementMonth/paymentStage가 null이면 그 조건은 걸지 않는다(전체).
-     * created_at 내림차순(최신 실행·재실행이 먼저) — 같은 정산월·지급단계라도 월 검증
+     * sortDirection은 "asc"/"desc"만 유효하고(그 외 값은 desc로 취급), created_at 기준
+     * 정렬 후 reconciliation_run_id로 동률을 깬다 — 같은 정산월·지급단계라도 월 검증
      * 실행/보험회사가 다르면 uq_reconciliation_run(V1:1444-1445) 덕분에 서로 다른 행으로
      * 자연히 분리돼 나온다.
      */
     List<ReconciliationRunHistoryRow> search(@Param("settlementMonth") LocalDate settlementMonth,
-                                              @Param("paymentStage") String paymentStage);
+                                              @Param("paymentStage") String paymentStage,
+                                              @Param("sortDirection") String sortDirection,
+                                              @Param("offset") int offset,
+                                              @Param("limit") int limit);
+
+    /** search와 같은 조건(settlementMonth/paymentStage)의 전체 건수 — 페이징 totalElements 계산용. */
+    long count(@Param("settlementMonth") LocalDate settlementMonth,
+               @Param("paymentStage") String paymentStage);
 }

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryService.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryService.java
@@ -1,15 +1,22 @@
 package com.susukkang.fgc.reconciliation.service;
 
+import com.susukkang.fgc.common.web.PageResponse;
 import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryResponse;
 import com.susukkang.fgc.reconciliation.dto.ReconciliationRunSearchCriteria;
 
-import java.util.List;
-
 /**
- * IF-API-39 대사 실행 이력 조회(RECO-W01 "④ 실행 이력"). 내부 Service 호출 전용
+ * IF-API-39 대사 실행 이력 조회(RECO-W01 "④ 실행 이력").
  */
 public interface ReconciliationRunHistoryService {
 
-    /** criteria로 대사 실행 이력을 검색한다. 결과가 없으면 빈 리스트(오류 아님). */
-    List<ReconciliationRunHistoryResponse> findHistory(ReconciliationRunSearchCriteria criteria);
+    /**
+     * criteria로 대사 실행 이력을 페이징 검색한다. 결과가 없으면 빈 페이지(오류 아님).
+     * sort는 ReconciliationResultQueryService와 같은 관례로 "createdAt,asc"/"createdAt,desc"만
+     * 지원한다(그 외 값은 COMMON_002).
+     *
+     * @throws com.susukkang.fgc.common.exception.FgcBusinessException
+     *         (COMMON_002) page&lt;1이거나 size가 1~100 범위를 벗어나거나 sort가 지원 목록에 없을 때
+     */
+    PageResponse<ReconciliationRunHistoryResponse> findHistory(
+            ReconciliationRunSearchCriteria criteria, int page, int size, String sort);
 }

--- a/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImpl.java
@@ -2,6 +2,9 @@ package com.susukkang.fgc.reconciliation.service;
 
 import com.susukkang.fgc.common.code.PaymentStage;
 import com.susukkang.fgc.common.code.ValidationRunStatus;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.web.PageResponse;
 import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryResponse;
 import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryRow;
 import com.susukkang.fgc.reconciliation.dto.ReconciliationRunSearchCriteria;
@@ -12,57 +15,87 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class ReconciliationRunHistoryServiceImpl implements ReconciliationRunHistoryService {
 
+    private static final int MIN_PAGE = 1;
+    private static final int MIN_SIZE = 1;
+    private static final int MAX_SIZE = 100;
+    private static final Set<String> SUPPORTED_SORTS = Set.of("createdAt,asc", "createdAt,desc");
+
     private final ReconciliationRunHistoryMapper reconciliationRunHistoryMapper;
 
     @Override
     @Transactional(readOnly = true)
-    public List<ReconciliationRunHistoryResponse> findHistory(ReconciliationRunSearchCriteria criteria) {
-        // 1. 목록 조회
-        List<ReconciliationRunHistoryRow> rows =
-                reconciliationRunHistoryMapper.search(criteria.settlementMonth(), criteria.paymentStage());
-
-        List<ReconciliationRunHistoryResponse> result = new ArrayList<>();
-        for (ReconciliationRunHistoryRow row : rows) {
-            PaymentStage paymentStage = PaymentStage.valueOf(row.getPaymentStage());
-            ValidationRunStatus status = ValidationRunStatus.valueOf(row.getStatus());
-
-            // 일치율 계산 — 반올림은 최종 결과 한 번만 한다(코드리뷰 반영). 먼저 소수
-            // 넷째 자리로 나눠서 반올림한 다음 100을 곱하고 다시 소수 첫째 자리로
-            // 반올림하면 두 번 반올림하는 셈이라 오차가 생긴다(예: matched=12449,
-            // target=100000 → 정확한 값은 12.449%라 첫째 자리 반올림 시 12.4가 맞는데,
-            // 넷째 자리에서 먼저 반올림하면 0.1245*100=12.45가 되고 그걸 다시 반올림해
-            // 12.5로 틀어진다). 그래서 100을 먼저 곱한 뒤 나눗셈에서 바로 소수 첫째
-            // 자리까지 한 번에 반올림한다.
-            BigDecimal matchRatePct;
-            if(row.getTargetCount()==0){
-                matchRatePct = null;
-            } else {
-                matchRatePct = BigDecimal.valueOf(row.getMatchedCount())
-                        .multiply(BigDecimal.valueOf(100))
-                        .divide(BigDecimal.valueOf(row.getTargetCount()), 1, RoundingMode.HALF_UP);
-            }
-
-            result.add(new ReconciliationRunHistoryResponse(
-                    row.getReconciliationRunId(), row.getValidationRunId(),
-                    row.getSettlementMonth(), row.getPaymentStage(), paymentStage.label(),
-                    row.getInsurerId(), row.getInsurerName(),
-                    row.getStatus(), status.label(),
-                    row.getTolerancePolicyVersionId(),
-                    row.getCreatedBy(), row.getCreatedAt(),
-                    row.getStartedAt(), row.getCompletedAt(),
-                    row.getFinalizedAt(), row.getFinalizedBy(),
-                    row.getTargetCount(), row.getMatchedCount(), row.getExceptionCount(),
-                    row.getExpectedTotal(), row.getActualTotal(), row.getDifferenceTotal(),
-                    matchRatePct
-            ));
+    public PageResponse<ReconciliationRunHistoryResponse> findHistory(
+            ReconciliationRunSearchCriteria criteria, int page, int size, String sort) {
+        if (page < MIN_PAGE) {
+            throw invalid("page");
         }
-        return result;
+        if (size < MIN_SIZE || size > MAX_SIZE) {
+            throw invalid("size");
+        }
+        if (!SUPPORTED_SORTS.contains(sort)) {
+            throw invalid("sort");
+        }
+
+        long offsetLong = (long) (page - 1) * size;
+        if (offsetLong > Integer.MAX_VALUE) {
+            throw invalid("page");
+        }
+        int offset = (int) offsetLong;
+
+        String direction = sort.endsWith(",asc") ? "asc" : "desc";
+
+        List<ReconciliationRunHistoryResponse> content = reconciliationRunHistoryMapper
+                .search(criteria.settlementMonth(), criteria.paymentStage(), direction, offset, size)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+        long total = reconciliationRunHistoryMapper.count(criteria.settlementMonth(), criteria.paymentStage());
+
+        return PageResponse.of(content, page, size, total, sort);
+    }
+
+    private static FgcBusinessException invalid(String field) {
+        return new FgcBusinessException(FgcErrorCode.COMMON_002, field, Map.of("field", field), null);
+    }
+
+    /**
+     * ReconciliationRunHistoryRow 1행을 응답 1건으로 바꾼다
+     */
+    private ReconciliationRunHistoryResponse toResponse(ReconciliationRunHistoryRow row) {
+        PaymentStage paymentStage = PaymentStage.valueOf(row.getPaymentStage());
+        ValidationRunStatus status = ValidationRunStatus.valueOf(row.getStatus());
+
+        // 일치율(%) = matched/target*100, 소수 첫째 자리까지 한 번만 반올림한다(중간에
+        // 반올림을 한 번 더 하면 오차가 생길 수 있어 100을 먼저 곱하고 나눗셈에서 바로
+        // 최종 자리수로 반올림한다). target이 0이면 분모가 없으므로 null로 둔다.
+        BigDecimal matchRatePct;
+        if (row.getTargetCount() == 0) {
+            matchRatePct = null;
+        } else {
+            matchRatePct = BigDecimal.valueOf(row.getMatchedCount())
+                    .multiply(BigDecimal.valueOf(100))
+                    .divide(BigDecimal.valueOf(row.getTargetCount()), 1, RoundingMode.HALF_UP);
+        }
+
+        return new ReconciliationRunHistoryResponse(
+                row.getReconciliationRunId(), row.getValidationRunId(),
+                row.getSettlementMonth(), row.getPaymentStage(), paymentStage.label(),
+                row.getInsurerId(), row.getInsurerName(),
+                row.getStatus(), status.label(),
+                row.getTolerancePolicyVersionId(),
+                row.getCreatedBy(), row.getCreatedAt(),
+                row.getStartedAt(), row.getCompletedAt(),
+                row.getFinalizedAt(), row.getFinalizedBy(),
+                row.getTargetCount(), row.getMatchedCount(), row.getExceptionCount(),
+                row.getExpectedTotal(), row.getActualTotal(), row.getDifferenceTotal(),
+                matchRatePct);
     }
 }

--- a/src/main/resources/mapper/reconciliation/ReconciliationRunHistoryMapper.xml
+++ b/src/main/resources/mapper/reconciliation/ReconciliationRunHistoryMapper.xml
@@ -8,6 +8,17 @@
       안전하게 INNER JOIN한다. insurer/app_user는 insurer_id·created_by가 nullable이라
       LEFT JOIN한다.
     -->
+    <sql id="searchWhere">
+        <where>
+            <if test="settlementMonth != null">
+                AND rr.settlement_month = #{settlementMonth}
+            </if>
+            <if test="paymentStage != null">
+                AND rr.payment_stage = #{paymentStage}
+            </if>
+        </where>
+    </sql>
+
     <select id="search" resultType="com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryRow">
         SELECT rr.reconciliation_run_id, rr.validation_run_id, rr.settlement_month, rr.payment_stage,
                rr.insurer_id, ins.insurer_name AS insurerName,
@@ -24,14 +35,23 @@
         LEFT JOIN fgc.insurer ins ON ins.insurer_id = rr.insurer_id
         LEFT JOIN fgc.app_user creator ON creator.user_id = rr.created_by
         LEFT JOIN fgc.app_user finalizer ON finalizer.user_id = rr.finalized_by
-        <where>
-            <if test="settlementMonth != null">
-                AND rr.settlement_month = #{settlementMonth}
-            </if>
-            <if test="paymentStage != null">
-                AND rr.payment_stage = #{paymentStage}
-            </if>
-        </where>
-        ORDER BY rr.created_at DESC, rr.reconciliation_run_id DESC
+        <include refid="searchWhere"/>
+        ORDER BY rr.created_at
+        <choose>
+            <when test="sortDirection == 'asc'">ASC</when>
+            <otherwise>DESC</otherwise>
+        </choose>,
+        rr.reconciliation_run_id
+        <choose>
+            <when test="sortDirection == 'asc'">ASC</when>
+            <otherwise>DESC</otherwise>
+        </choose>
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="count" resultType="long">
+        SELECT COUNT(*)
+        FROM fgc.reconciliation_run rr
+        <include refid="searchWhere"/>
     </select>
 </mapper>

--- a/src/test/java/com/susukkang/fgc/reconciliation/controller/ReconciliationRunControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/controller/ReconciliationRunControllerTest.java
@@ -7,8 +7,11 @@ import com.susukkang.fgc.common.config.SecurityConfig;
 import com.susukkang.fgc.common.exception.ConstraintErrorCodeResolver;
 import com.susukkang.fgc.common.exception.FgcMessageResolver;
 import com.susukkang.fgc.common.exception.GlobalExceptionHandler;
+import com.susukkang.fgc.common.web.PageResponse;
 import com.susukkang.fgc.reconciliation.dto.CreateReconciliationRunRequest;
+import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryResponse;
 import com.susukkang.fgc.reconciliation.dto.ReconciliationRunRow;
+import com.susukkang.fgc.reconciliation.service.ReconciliationRunHistoryService;
 import com.susukkang.fgc.reconciliation.service.ReconciliationRunService;
 import com.susukkang.fgc.reconciliation.service.ReconciliationResultQueryService;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +24,13 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -55,6 +64,67 @@ class ReconciliationRunControllerTest {
 
     @MockitoBean
     private ReconciliationResultQueryService reconciliationResultQueryService;
+
+    @MockitoBean
+    private ReconciliationRunHistoryService reconciliationRunHistoryService;
+
+    @Test
+    void 대사_실행_이력을_조건_없이_조회한다() throws Exception {
+        given(reconciliationRunHistoryService.findHistory(any(), eq(1), eq(20), eq("createdAt,desc")))
+                .willReturn(PageResponse.of(List.of(), 1, 20, 0, "createdAt,desc"));
+
+        mockMvc.perform(get("/api/v1/reconciliations")
+                        .with(user(principal("COMPLIANCE"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.page").value(1))
+                .andExpect(jsonPath("$.data.totalElements").value(0));
+    }
+
+    @Test
+    void 정산월과_지급단계로_대사_실행_이력을_필터링한다() throws Exception {
+        given(reconciliationRunHistoryService.findHistory(any(), eq(2), eq(10), eq("createdAt,asc")))
+                .willReturn(PageResponse.of(List.of(historyRow()), 2, 10, 1, "createdAt,asc"));
+
+        mockMvc.perform(get("/api/v1/reconciliations")
+                        .with(user(principal("COMPLIANCE")))
+                        .queryParam("month", "2026-07")
+                        .queryParam("stage", "GA_TO_FC")
+                        .queryParam("page", "2")
+                        .queryParam("size", "10")
+                        .queryParam("sort", "createdAt,asc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].reconciliationRunId").value(41))
+                .andExpect(jsonPath("$.data.content[0].paymentStageLabel").value("GA→설계사"));
+
+        verify(reconciliationRunHistoryService).findHistory(
+                argThat(criteria -> criteria.paymentStage().equals("GA_TO_FC")), eq(2), eq(10), eq("createdAt,asc"));
+    }
+
+    @Test
+    void 잘못된_기준월로_이력을_조회하면_400으로_거절한다() throws Exception {
+        mockMvc.perform(get("/api/v1/reconciliations")
+                        .with(user(principal("COMPLIANCE")))
+                        .queryParam("month", "2026/07"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.field").value("settlementMonth"));
+
+        verify(reconciliationRunHistoryService, never()).findHistory(any(), anyInt(), anyInt(), anyString());
+    }
+
+    @Test
+    void 정의되지_않은_지급단계로_이력을_조회하면_400으로_거절한다() throws Exception {
+        mockMvc.perform(get("/api/v1/reconciliations")
+                        .with(user(principal("COMPLIANCE")))
+                        .queryParam("stage", "UNKNOWN"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.field").value("paymentStage"));
+    }
+
+    @Test
+    void 로그인하지_않으면_대사_실행_이력을_조회할_수_없다() throws Exception {
+        mockMvc.perform(get("/api/v1/reconciliations"))
+                .andExpect(status().isUnauthorized());
+    }
 
     @Test
     void 유효한_요청은_RUNNING_대사실행을_생성한다() throws Exception {
@@ -162,6 +232,21 @@ class ReconciliationRunControllerTest {
         row.setReconciliationRunId(41L);
         row.setStatus("RUNNING");
         return row;
+    }
+
+    private static ReconciliationRunHistoryResponse historyRow() {
+        return new ReconciliationRunHistoryResponse(
+                41L, 7L,
+                java.time.LocalDate.of(2026, 7, 1), "GA_TO_FC", "GA→설계사",
+                1L, "테스트생명",
+                "COMPLETED", "계산완료",
+                null,
+                "settlement-user", null,
+                null, null,
+                null, null,
+                10L, 9L, 1L,
+                java.math.BigDecimal.valueOf(100000), java.math.BigDecimal.valueOf(90000), java.math.BigDecimal.valueOf(10000),
+                java.math.BigDecimal.valueOf(90.0));
     }
 
     private static FgcUserDetails principal(String roleCode) {

--- a/src/test/java/com/susukkang/fgc/reconciliation/mapper/ReconciliationRunHistoryMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/mapper/ReconciliationRunHistoryMapperIntegrationTest.java
@@ -134,6 +134,9 @@ class ReconciliationRunHistoryMapperIntegrationTest {
     void searchOrdersByCreatedAtWithDirectionAndAppliesLimitOffset() {
         // 같은 정산월·지급단계·보험회사·월 검증 실행 조합은 uq_reconciliation_run
         // UNIQUE 제약에 걸리므로(V1:1444-1445) 보험회사를 다르게 해서 두 행을 만든다.
+        // TEST_MONTH+GA_TO_FC 조합은 이 테스트 메서드 안에서 이 두 건뿐이다(클래스가
+        // @Transactional이라 메서드마다 별도 트랜잭션으로 롤백되므로 다른 테스트의
+        // 데이터가 섞이지 않는다) — 그래서 순서/페이지를 정확한 값으로 검증할 수 있다.
         Long insurerA = insertInsurer("FUN051-6A");
         Long insurerB = insertInsurer("FUN051-6B");
         Long runOlder = insertReconciliationRun("GA_TO_FC", insurerA, null);
@@ -143,16 +146,27 @@ class ReconciliationRunHistoryMapperIntegrationTest {
         List<ReconciliationRunHistoryRow> ascRows = mapper.search(TEST_MONTH, "GA_TO_FC", "asc", 0, 100);
 
         assertThat(descRows).extracting(ReconciliationRunHistoryRow::getReconciliationRunId)
-                .contains(runNewer, runOlder);
+                .containsExactly(runNewer, runOlder);
         assertThat(ascRows).extracting(ReconciliationRunHistoryRow::getReconciliationRunId)
-                .contains(runOlder, runNewer);
+                .containsExactly(runOlder, runNewer);
 
+        // offset=0,limit=1은 desc 정렬의 첫 번째 행(runNewer)만, offset=1,limit=1은
+        // 두 번째 행(runOlder)만 돌려줘야 한다 — 둘 다 확인해야 LIMIT/OFFSET이 실제로
+        // 적용되는지 검증된다.
         List<ReconciliationRunHistoryRow> firstPage = mapper.search(TEST_MONTH, "GA_TO_FC", "desc", 0, 1);
-        assertThat(firstPage).hasSize(1);
+        List<ReconciliationRunHistoryRow> secondPage = mapper.search(TEST_MONTH, "GA_TO_FC", "desc", 1, 1);
+        assertThat(firstPage).extracting(ReconciliationRunHistoryRow::getReconciliationRunId)
+                .containsExactly(runNewer);
+        assertThat(secondPage).extracting(ReconciliationRunHistoryRow::getReconciliationRunId)
+                .containsExactly(runOlder);
     }
 
     @Test
     void countMatchesSearchFilters() {
+        // TEST_MONTH+GA_TO_FC 조합은 이 테스트 메서드 안에서 1건, 전체(지급단계 무관)는
+        // 2건뿐이다(위 테스트와 같은 이유로 메서드 간 데이터가 섞이지 않는다) — 그래서
+        // ">="가 아니라 정확한 기대값으로 검증한다. ">="였다면 필터가 전혀 안 걸려도
+        // (예: WHERE 절이 통째로 빠져도) 통과했을 것이다.
         Long insurerId = insertInsurer("FUN051-7");
         insertReconciliationRun("GA_TO_FC", insurerId, null);
         insertReconciliationRun("INSURER_TO_GA", insurerId, null);
@@ -160,7 +174,7 @@ class ReconciliationRunHistoryMapperIntegrationTest {
         long gaToFcCount = mapper.count(TEST_MONTH, "GA_TO_FC");
         long allCount = mapper.count(TEST_MONTH, null);
 
-        assertThat(gaToFcCount).isGreaterThanOrEqualTo(1);
-        assertThat(allCount).isGreaterThanOrEqualTo(gaToFcCount);
+        assertThat(gaToFcCount).isEqualTo(1);
+        assertThat(allCount).isEqualTo(2);
     }
 }

--- a/src/test/java/com/susukkang/fgc/reconciliation/mapper/ReconciliationRunHistoryMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/mapper/ReconciliationRunHistoryMapperIntegrationTest.java
@@ -58,7 +58,7 @@ class ReconciliationRunHistoryMapperIntegrationTest {
         Long insurerId = insertInsurer("FUN051-1");
         Long runId = insertReconciliationRun("GA_TO_FC", insurerId, null);
 
-        List<ReconciliationRunHistoryRow> rows = mapper.search(TEST_MONTH, "GA_TO_FC");
+        List<ReconciliationRunHistoryRow> rows = mapper.search(TEST_MONTH, "GA_TO_FC", "desc", 0, 100);
 
         assertThat(rows).filteredOn(row -> row.getReconciliationRunId().equals(runId))
                 .singleElement()
@@ -78,7 +78,7 @@ class ReconciliationRunHistoryMapperIntegrationTest {
         insertReconciliationResult(runId, "FUN051-B", "MATCHED");
         insertReconciliationResult(runId, "FUN051-C", "AMOUNT_DIFFERENCE");
 
-        List<ReconciliationRunHistoryRow> rows = mapper.search(TEST_MONTH, "GA_TO_FC");
+        List<ReconciliationRunHistoryRow> rows = mapper.search(TEST_MONTH, "GA_TO_FC", "desc", 0, 100);
 
         assertThat(rows).filteredOn(row -> row.getReconciliationRunId().equals(runId))
                 .singleElement()
@@ -95,8 +95,8 @@ class ReconciliationRunHistoryMapperIntegrationTest {
         Long gaToFcId = insertReconciliationRun("GA_TO_FC", insurerId, null);
         Long insurerToGaId = insertReconciliationRun("INSURER_TO_GA", insurerId, null);
 
-        List<ReconciliationRunHistoryRow> gaToFcRows = mapper.search(TEST_MONTH, "GA_TO_FC");
-        List<ReconciliationRunHistoryRow> insurerToGaRows = mapper.search(TEST_MONTH, "INSURER_TO_GA");
+        List<ReconciliationRunHistoryRow> gaToFcRows = mapper.search(TEST_MONTH, "GA_TO_FC", "desc", 0, 100);
+        List<ReconciliationRunHistoryRow> insurerToGaRows = mapper.search(TEST_MONTH, "INSURER_TO_GA", "desc", 0, 100);
 
         assertThat(gaToFcRows).extracting(ReconciliationRunHistoryRow::getReconciliationRunId)
                 .contains(gaToFcId).doesNotContain(insurerToGaId);
@@ -114,7 +114,7 @@ class ReconciliationRunHistoryMapperIntegrationTest {
         Long runA = insertReconciliationRun("GA_TO_FC", insurerA, null);
         Long runB = insertReconciliationRun("GA_TO_FC", insurerB, null);
 
-        List<ReconciliationRunHistoryRow> rows = mapper.search(TEST_MONTH, "GA_TO_FC");
+        List<ReconciliationRunHistoryRow> rows = mapper.search(TEST_MONTH, "GA_TO_FC", "desc", 0, 100);
 
         assertThat(rows).extracting(ReconciliationRunHistoryRow::getReconciliationRunId)
                 .contains(runA, runB);
@@ -125,8 +125,42 @@ class ReconciliationRunHistoryMapperIntegrationTest {
         Long insurerId = insertInsurer("FUN051-5");
         Long runId = insertReconciliationRun("GA_TO_FC", insurerId, null);
 
-        List<ReconciliationRunHistoryRow> rows = mapper.search(null, null);
+        List<ReconciliationRunHistoryRow> rows = mapper.search(null, null, "desc", 0, 100);
 
         assertThat(rows).extracting(ReconciliationRunHistoryRow::getReconciliationRunId).contains(runId);
+    }
+
+    @Test
+    void searchOrdersByCreatedAtWithDirectionAndAppliesLimitOffset() {
+        // 같은 정산월·지급단계·보험회사·월 검증 실행 조합은 uq_reconciliation_run
+        // UNIQUE 제약에 걸리므로(V1:1444-1445) 보험회사를 다르게 해서 두 행을 만든다.
+        Long insurerA = insertInsurer("FUN051-6A");
+        Long insurerB = insertInsurer("FUN051-6B");
+        Long runOlder = insertReconciliationRun("GA_TO_FC", insurerA, null);
+        Long runNewer = insertReconciliationRun("GA_TO_FC", insurerB, null);
+
+        List<ReconciliationRunHistoryRow> descRows = mapper.search(TEST_MONTH, "GA_TO_FC", "desc", 0, 100);
+        List<ReconciliationRunHistoryRow> ascRows = mapper.search(TEST_MONTH, "GA_TO_FC", "asc", 0, 100);
+
+        assertThat(descRows).extracting(ReconciliationRunHistoryRow::getReconciliationRunId)
+                .contains(runNewer, runOlder);
+        assertThat(ascRows).extracting(ReconciliationRunHistoryRow::getReconciliationRunId)
+                .contains(runOlder, runNewer);
+
+        List<ReconciliationRunHistoryRow> firstPage = mapper.search(TEST_MONTH, "GA_TO_FC", "desc", 0, 1);
+        assertThat(firstPage).hasSize(1);
+    }
+
+    @Test
+    void countMatchesSearchFilters() {
+        Long insurerId = insertInsurer("FUN051-7");
+        insertReconciliationRun("GA_TO_FC", insurerId, null);
+        insertReconciliationRun("INSURER_TO_GA", insurerId, null);
+
+        long gaToFcCount = mapper.count(TEST_MONTH, "GA_TO_FC");
+        long allCount = mapper.count(TEST_MONTH, null);
+
+        assertThat(gaToFcCount).isGreaterThanOrEqualTo(1);
+        assertThat(allCount).isGreaterThanOrEqualTo(gaToFcCount);
     }
 }

--- a/src/test/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImplTest.java
@@ -1,5 +1,7 @@
 package com.susukkang.fgc.reconciliation.service;
 
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.web.PageResponse;
 import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryResponse;
 import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryRow;
 import com.susukkang.fgc.reconciliation.dto.ReconciliationRunSearchCriteria;
@@ -15,14 +17,22 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
- * FGC-FUN-051 — 일치율 계산(대상 0건 처리 포함)과 라벨 변환을 순수 로직 단위로 검증한다.
- * DB 없이 Mockito로 Mapper를 대체한다 — SQL 정합성은 ReconciliationRunHistoryMapperIntegrationTest가 맡는다.
+ * FGC-FUN-051 — 일치율 계산(대상 0건 처리 포함)과 라벨 변환, 페이징 파라미터 검증을
+ * 순수 로직 단위로 검증한다. DB 없이 Mockito로 Mapper를 대체한다 — SQL 정합성은
+ * ReconciliationRunHistoryMapperIntegrationTest가 맡는다.
  */
 @ExtendWith(MockitoExtension.class)
 class ReconciliationRunHistoryServiceImplTest {
+
+    private static final ReconciliationRunSearchCriteria NO_FILTER =
+            new ReconciliationRunSearchCriteria(null, null);
 
     @Mock
     private ReconciliationRunHistoryMapper reconciliationRunHistoryMapper;
@@ -54,22 +64,26 @@ class ReconciliationRunHistoryServiceImplTest {
 
     @Test
     void returnsNullMatchRateWhenTargetCountIsZero() {
-        given(reconciliationRunHistoryMapper.search(null, null)).willReturn(List.of(row(0, 0, 0)));
+        given(reconciliationRunHistoryMapper.search(null, null, "desc", 0, 20))
+                .willReturn(List.of(row(0, 0, 0)));
 
-        List<ReconciliationRunHistoryResponse> result = service.findHistory(new ReconciliationRunSearchCriteria(null, null));
+        PageResponse<ReconciliationRunHistoryResponse> result =
+                service.findHistory(NO_FILTER, 1, 20, "createdAt,desc");
 
-        assertThat(result).singleElement().satisfies(response ->
+        assertThat(result.content()).singleElement().satisfies(response ->
                 assertThat(response.matchRatePct()).isNull());
     }
 
     @Test
     void calculatesMatchRatePctRoundedToOneDecimal() {
         // 3건 중 2건 일치 = 66.6666...% → 소수점 첫째 자리 반올림으로 66.7
-        given(reconciliationRunHistoryMapper.search(null, null)).willReturn(List.of(row(3, 2, 1)));
+        given(reconciliationRunHistoryMapper.search(null, null, "desc", 0, 20))
+                .willReturn(List.of(row(3, 2, 1)));
 
-        List<ReconciliationRunHistoryResponse> result = service.findHistory(new ReconciliationRunSearchCriteria(null, null));
+        PageResponse<ReconciliationRunHistoryResponse> result =
+                service.findHistory(NO_FILTER, 1, 20, "createdAt,desc");
 
-        assertThat(result).singleElement().satisfies(response ->
+        assertThat(result.content()).singleElement().satisfies(response ->
                 assertThat(response.matchRatePct()).isEqualByComparingTo("66.7"));
     }
 
@@ -79,31 +93,37 @@ class ReconciliationRunHistoryServiceImplTest {
         // 12.449%다. 소수 넷째 자리에서 먼저 반올림한 뒤 다시 소수 첫째 자리로
         // 반올림하면(두 번 반올림) 12.45 → 12.5로 틀어진다. 한 번에 반올림하면 12.4가
         // 맞는 값이다.
-        given(reconciliationRunHistoryMapper.search(null, null)).willReturn(List.of(row(100000, 12449, 87551)));
+        given(reconciliationRunHistoryMapper.search(null, null, "desc", 0, 20))
+                .willReturn(List.of(row(100000, 12449, 87551)));
 
-        List<ReconciliationRunHistoryResponse> result = service.findHistory(new ReconciliationRunSearchCriteria(null, null));
+        PageResponse<ReconciliationRunHistoryResponse> result =
+                service.findHistory(NO_FILTER, 1, 20, "createdAt,desc");
 
-        assertThat(result).singleElement().satisfies(response ->
+        assertThat(result.content()).singleElement().satisfies(response ->
                 assertThat(response.matchRatePct()).isEqualByComparingTo("12.4"));
     }
 
     @Test
     void calculatesFullMatchRateAsHundred() {
-        given(reconciliationRunHistoryMapper.search(null, null)).willReturn(List.of(row(5, 5, 0)));
+        given(reconciliationRunHistoryMapper.search(null, null, "desc", 0, 20))
+                .willReturn(List.of(row(5, 5, 0)));
 
-        List<ReconciliationRunHistoryResponse> result = service.findHistory(new ReconciliationRunSearchCriteria(null, null));
+        PageResponse<ReconciliationRunHistoryResponse> result =
+                service.findHistory(NO_FILTER, 1, 20, "createdAt,desc");
 
-        assertThat(result).singleElement().satisfies(response ->
+        assertThat(result.content()).singleElement().satisfies(response ->
                 assertThat(response.matchRatePct()).isEqualByComparingTo("100.0"));
     }
 
     @Test
     void mapsPaymentStageAndStatusLabels() {
-        given(reconciliationRunHistoryMapper.search(null, null)).willReturn(List.of(row(1, 1, 0)));
+        given(reconciliationRunHistoryMapper.search(null, null, "desc", 0, 20))
+                .willReturn(List.of(row(1, 1, 0)));
 
-        List<ReconciliationRunHistoryResponse> result = service.findHistory(new ReconciliationRunSearchCriteria(null, null));
+        PageResponse<ReconciliationRunHistoryResponse> result =
+                service.findHistory(NO_FILTER, 1, 20, "createdAt,desc");
 
-        assertThat(result).singleElement().satisfies(response -> {
+        assertThat(result.content()).singleElement().satisfies(response -> {
             assertThat(response.paymentStage()).isEqualTo("GA_TO_FC");
             assertThat(response.paymentStageLabel()).isEqualTo("GA→설계사");
             assertThat(response.status()).isEqualTo("COMPLETED");
@@ -112,11 +132,81 @@ class ReconciliationRunHistoryServiceImplTest {
     }
 
     @Test
-    void returnsEmptyListWhenMapperFindsNothing() {
-        given(reconciliationRunHistoryMapper.search(null, null)).willReturn(List.of());
+    void returnsEmptyPageWhenMapperFindsNothing() {
+        given(reconciliationRunHistoryMapper.search(null, null, "desc", 0, 20))
+                .willReturn(List.of());
+        given(reconciliationRunHistoryMapper.count(null, null)).willReturn(0L);
 
-        List<ReconciliationRunHistoryResponse> result = service.findHistory(new ReconciliationRunSearchCriteria(null, null));
+        PageResponse<ReconciliationRunHistoryResponse> result =
+                service.findHistory(NO_FILTER, 1, 20, "createdAt,desc");
 
-        assertThat(result).isEmpty();
+        assertThat(result.content()).isEmpty();
+        assertThat(result.totalElements()).isZero();
+    }
+
+    @Test
+    void passesSettlementMonthAndPaymentStageFiltersThrough() {
+        ReconciliationRunSearchCriteria criteria =
+                new ReconciliationRunSearchCriteria(LocalDate.of(2026, 7, 1), "GA_TO_FC");
+        given(reconciliationRunHistoryMapper.search(
+                LocalDate.of(2026, 7, 1), "GA_TO_FC", "desc", 0, 20))
+                .willReturn(List.of());
+
+        service.findHistory(criteria, 1, 20, "createdAt,desc");
+
+        verify(reconciliationRunHistoryMapper)
+                .search(eq(LocalDate.of(2026, 7, 1)), eq("GA_TO_FC"), eq("desc"), eq(0), eq(20));
+        verify(reconciliationRunHistoryMapper)
+                .count(eq(LocalDate.of(2026, 7, 1)), eq("GA_TO_FC"));
+    }
+
+    @Test
+    void ascendingSortIsPassedThroughAsDirection() {
+        given(reconciliationRunHistoryMapper.search(null, null, "asc", 0, 20))
+                .willReturn(List.of());
+
+        service.findHistory(NO_FILTER, 1, 20, "createdAt,asc");
+
+        verify(reconciliationRunHistoryMapper).search(null, null, "asc", 0, 20);
+    }
+
+    @Test
+    void secondPageUsesOffsetOfSizeTimesPageMinusOne() {
+        given(reconciliationRunHistoryMapper.search(null, null, "desc", 40, 20))
+                .willReturn(List.of());
+
+        service.findHistory(NO_FILTER, 3, 20, "createdAt,desc");
+
+        verify(reconciliationRunHistoryMapper).search(null, null, "desc", 40, 20);
+    }
+
+    @Test
+    void throwsCommon002WhenPageIsLessThanOne() {
+        assertThatThrownBy(() -> service.findHistory(NO_FILTER, 0, 20, "createdAt,desc"))
+                .isInstanceOf(FgcBusinessException.class)
+                .satisfies(exception ->
+                        assertThat(((FgcBusinessException) exception).getField()).isEqualTo("page"));
+        verifyNoInteractions(reconciliationRunHistoryMapper);
+    }
+
+    @Test
+    void throwsCommon002WhenSizeIsOutOfRange() {
+        assertThatThrownBy(() -> service.findHistory(NO_FILTER, 1, 0, "createdAt,desc"))
+                .isInstanceOf(FgcBusinessException.class)
+                .satisfies(exception ->
+                        assertThat(((FgcBusinessException) exception).getField()).isEqualTo("size"));
+
+        assertThatThrownBy(() -> service.findHistory(NO_FILTER, 1, 101, "createdAt,desc"))
+                .isInstanceOf(FgcBusinessException.class)
+                .satisfies(exception ->
+                        assertThat(((FgcBusinessException) exception).getField()).isEqualTo("size"));
+    }
+
+    @Test
+    void throwsCommon002WhenSortIsNotSupported() {
+        assertThatThrownBy(() -> service.findHistory(NO_FILTER, 1, 20, "insurerName,asc"))
+                .isInstanceOf(FgcBusinessException.class)
+                .satisfies(exception ->
+                        assertThat(((FgcBusinessException) exception).getField()).isEqualTo("sort"));
     }
 }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* 대사 실행 이력 조회 API(IF-API-39, `GET /api/v1/reconciliations?month=&stage=&page=&size=`) 추가

## 🔗 2. 관련 이슈

* Closes #200

## 🛠 3. 구현 내용

* `ReconciliationRunHistoryMapper`/`.xml`에 페이징(`search`/`count`) 추가
* `ReconciliationRunSearchResponse` DTO 추가 — `ValidationRunSearchResponse`/`JournalSearchResponse`와 동일한 페이지 래핑 관례
* `ReconciliationRunHistoryService`/`Impl`을 단건 목록 조회에서 페이징 조회로 확장
* `ReconciliationRunController`에 `GET /api/v1/reconciliations` 추가

## 🧪 4. 테스트 방법

1. `ReconciliationRunHistoryMapperIntegrationTest` — 필터(정산월/지급단계), 정렬 방향, LIMIT/OFFSET, count 검증(DB 필요).
2. `ReconciliationRunHistoryServiceImplTest` — 일치율 계산(0건/반올림/100%), 라벨 변환, 필터 전달, 오프셋 계산, page/size/sort 검증(Mockito).
3. `ReconciliationRunControllerTest` — 정상 조회, 필터 적용, 잘못된 month/stage 400, 미인증 401.

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* `ReconciliationRunHistoryServiceImpl.findHistory()`의 page/size/sort 검증 및 offset 계산 로직

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음 (RECO-W01 "④ 실행 이력" 백엔드 API만)

## 💬 9. 참고 사항

*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 대사 실행 이력 조회 API를 추가했습니다.
  - 정산월과 지급 단계로 이력을 필터링할 수 있습니다.
  - 페이지 번호, 페이지 크기, 정렬 방향을 지원하며 전체 건수와 페이지 정보를 제공합니다.

- **개선**
  - 검색 결과가 없을 때도 일관된 빈 페이지 형식으로 표시됩니다.
  - 잘못된 정산월·지급 단계·페이지·정렬 조건을 검증하고 안내합니다.
  - 비로그인 사용자의 이력 조회 접근을 차단합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->