### PR TITLE
[Feat] FUN-047 원장 역분개·재기표 Command·Service 및 API

### DIFF
--- a/src/main/java/com/susukkang/fgc/common/config/SecurityConfig.java
+++ b/src/main/java/com/susukkang/fgc/common/config/SecurityConfig.java
@@ -63,7 +63,8 @@ public class SecurityConfig {
                 // 기존 코드: 지급 API 경로만 CSRF 보호 체인에 포함
                 // 문제: 세션 쿠키를 사용하는 대사 실행 POST가 위조 요청에 노출
                 // 개선: IF-API-38 경로를 동일한 보호 체인에 추가
-                .securityMatcher("/api/v1/transactions/**", "/api/v1/reconciliations/**")
+                .securityMatcher("/api/v1/transactions/**", "/api/v1/reconciliations/**",
+                        "/api/v1/journals/**")
                 // 2026-08-11 yslee - 세션 쿠키 기반 지급 API의 CSRF 보호 활성화
                 // 기존 코드: /api/** 전체에서 CSRF 검증을 비활성화
                 // 문제: 로그인 세션을 악용한 외부 사이트가 지급 등록·수정·확정 요청을 위조할 수 있음

--- a/src/main/java/com/susukkang/fgc/common/exception/ConstraintErrorCodeResolver.java
+++ b/src/main/java/com/susukkang/fgc/common/exception/ConstraintErrorCodeResolver.java
@@ -125,6 +125,26 @@ public class ConstraintErrorCodeResolver {
                 "uq_validation_run",
                 FgcErrorCode.VRUN_001
         );
+        mappings.put(
+                "uq_journal_single_reversal",
+                FgcErrorCode.LEDG_002
+        );
+        mappings.put(
+                "uq_journal_correction_original",
+                FgcErrorCode.LEDG_002
+        );
+        mappings.put(
+                "uq_journal_correction_group_reversal",
+                FgcErrorCode.LEDG_002
+        );
+        mappings.put(
+                "uq_journal_correction_group_repost",
+                FgcErrorCode.LEDG_002
+        );
+        mappings.put(
+                "uq_journal_source_revision",
+                FgcErrorCode.LEDG_002
+        );
 
         return Map.copyOf(mappings);
     }

--- a/src/main/java/com/susukkang/fgc/common/exception/FgcErrorCode.java
+++ b/src/main/java/com/susukkang/fgc/common/exception/FgcErrorCode.java
@@ -137,7 +137,7 @@ public enum FgcErrorCode {
     //확인
     LEDG_003(
             "FGC-LEDG-003",
-            HttpStatus.CONFLICT,
+            HttpStatus.METHOD_NOT_ALLOWED,
             "error.ledger.reverseOnly"
     ),
 

--- a/src/main/java/com/susukkang/fgc/common/security/Roles.java
+++ b/src/main/java/com/susukkang/fgc/common/security/Roles.java
@@ -11,8 +11,8 @@ package com.susukkang.fgc.common.security;
  *  애노테이션 값은 컴파일타임 상수여야 한다. static final String 리터럴끼리의 "+" 결합은
  *  자바 컴파일러가 컴파일타임에 접어(constant fold) 상수로 취급하므로 애노테이션에 쓸 수 있다.
  *
- * 지금 실제로 쓰이는 역할 조합만 정의한다. 새 조합(예: EXCP-W01의 SETTLEMENT·GA_ADMIN, 아직
- * 미구현인 역분개·검증실행확정)은 그 엔드포인트가 실제로 생길 때 추가한다.
+     * 지금 실제로 쓰이는 역할 조합만 정의한다. 새 조합은 해당 엔드포인트가 실제로 생길 때
+     * 문서의 역할 계약과 함께 추가한다.
  */
 public final class Roles {
 
@@ -28,6 +28,10 @@ public final class Roles {
     /** AUDT-W01 감사로그 조회. 화면정의서 v2.0 :1503,:1530. */
     public static final String CAN_VIEW_AUDIT_LOG =
             "hasAnyRole('" + COMPLIANCE + "','" + SYSTEM_ADMIN + "')";
+
+    /** IF-API-36 원장 역분개. SYSTEM_ADMIN의 전 기능 권한을 함께 반영한다. */
+    public static final String CAN_REVERSE_JOURNAL =
+            "hasAnyRole('" + SETTLEMENT + "','" + GA_ADMIN + "','" + SYSTEM_ADMIN + "')";
 
     /**
      * "전체 조회" API용(기준정보 등). 사실상 authenticated()와 같지만, 역할 4종을 명시해

--- a/src/main/java/com/susukkang/fgc/journal/controller/JournalCorrectionController.java
+++ b/src/main/java/com/susukkang/fgc/journal/controller/JournalCorrectionController.java
@@ -1,0 +1,40 @@
+package com.susukkang.fgc.journal.controller;
+
+import com.susukkang.fgc.auth.dto.FgcUserDetails;
+import com.susukkang.fgc.common.security.Roles;
+import com.susukkang.fgc.common.web.ApiResponse;
+import com.susukkang.fgc.journal.dto.JournalCorrectionResult;
+import com.susukkang.fgc.journal.dto.ReverseJournalCommand;
+import com.susukkang.fgc.journal.dto.ReverseJournalRequest;
+import com.susukkang.fgc.journal.dto.ReverseJournalResponse;
+import com.susukkang.fgc.journal.service.JournalCorrectionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** IF-API-36 원장 역분개 API. */
+@RestController
+@RequestMapping("/api/v1/journals")
+@RequiredArgsConstructor
+public class JournalCorrectionController {
+
+    private final JournalCorrectionService journalCorrectionService;
+
+    @PreAuthorize(Roles.CAN_REVERSE_JOURNAL)
+    @PostMapping("/{journalId}/reverse")
+    public ApiResponse<ReverseJournalResponse> reverse(
+            @PathVariable Long journalId,
+            @Valid @RequestBody ReverseJournalRequest request,
+            @AuthenticationPrincipal FgcUserDetails principal) {
+        JournalCorrectionResult result = journalCorrectionService.reverse(
+                new ReverseJournalCommand(
+                        journalId, request.reason(), request.evidenceRef(), principal.getUserId()));
+        return ApiResponse.success(ReverseJournalResponse.from(result));
+    }
+}

--- a/src/main/java/com/susukkang/fgc/journal/dto/JournalCorrectionGroupInsertRow.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/JournalCorrectionGroupInsertRow.java
@@ -1,0 +1,14 @@
+package com.susukkang.fgc.journal.dto;
+
+import lombok.Builder;
+
+/** journal_correction_group INSERT 파라미터. */
+@Builder
+public record JournalCorrectionGroupInsertRow(
+        String correctionGroupKey,
+        Long originalJournalHeaderId,
+        String reason,
+        String evidenceRef,
+        Long createdBy
+) {
+}

--- a/src/main/java/com/susukkang/fgc/journal/dto/JournalCorrectionHeaderRow.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/JournalCorrectionHeaderRow.java
@@ -1,34 +1,24 @@
 package com.susukkang.fgc.journal.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
 
-/**
- * journal_header 1행 INSERT 파라미터
- */
+/** 정정 대상 원분개 잠금 조회 결과. */
 @Getter
 @Setter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class JournalHeaderInsertRow {
+public class JournalCorrectionHeaderRow {
     private Long journalHeaderId;
-    private String journalNo;
     private LocalDate journalDate;
     private String journalType;
     private String sourceEntityType;
     private String sourceEntityId;
     private Integer revisionNo;
     private Long validationRunId;
+    private String validationRunStatus;
     private Long contractId;
     private Long policyVersionId;
-    private Long reversalOfId;
-    private String correctionGroupKey;
+    private String status;
     private String description;
-    private Long createdBy;
 }

--- a/src/main/java/com/susukkang/fgc/journal/dto/JournalCorrectionLineRow.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/JournalCorrectionLineRow.java
@@ -1,0 +1,21 @@
+package com.susukkang.fgc.journal.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+/** 역분개 라인 생성을 위한 원분개 라인 조회 결과. */
+@Getter
+@Setter
+public class JournalCorrectionLineRow {
+    private Integer lineNo;
+    private Long journalAccountId;
+    private BigDecimal debitAmount;
+    private BigDecimal creditAmount;
+    private Long contractId;
+    private Long agentId;
+    private String paymentStage;
+    private Long commissionItemId;
+    private String memo;
+}

--- a/src/main/java/com/susukkang/fgc/journal/dto/JournalCorrectionResult.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/JournalCorrectionResult.java
@@ -1,0 +1,10 @@
+package com.susukkang.fgc.journal.dto;
+
+/** 역분개 또는 역분개+재기표 처리 결과. repostedJournalHeaderId는 기본 역분개에서 null이다. */
+public record JournalCorrectionResult(
+        Long journalHeaderId,
+        Long reversalOfId,
+        Long repostedJournalHeaderId,
+        String correctionGroupKey
+) {
+}

--- a/src/main/java/com/susukkang/fgc/journal/dto/ReverseAndRepostJournalCommand.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/ReverseAndRepostJournalCommand.java
@@ -1,0 +1,8 @@
+package com.susukkang.fgc.journal.dto;
+
+/** FUN-047 원분개 역분개와 정정 초안 재기표를 한 트랜잭션으로 처리하는 내부 명령. */
+public record ReverseAndRepostJournalCommand(
+        ReverseJournalCommand reversal,
+        JournalHeaderDraft correctedDraft
+) {
+}

--- a/src/main/java/com/susukkang/fgc/journal/dto/ReverseJournalCommand.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/ReverseJournalCommand.java
@@ -1,0 +1,10 @@
+package com.susukkang.fgc.journal.dto;
+
+/** FUN-047 역분개 명령. 처리자는 인증 principal에서 전달한다. */
+public record ReverseJournalCommand(
+        Long journalHeaderId,
+        String reason,
+        String evidenceRef,
+        Long requestedBy
+) {
+}

--- a/src/main/java/com/susukkang/fgc/journal/dto/ReverseJournalRequest.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/ReverseJournalRequest.java
@@ -1,0 +1,11 @@
+package com.susukkang.fgc.journal.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/** IF-API-36 역분개 요청. */
+public record ReverseJournalRequest(
+        @NotBlank @Size(max = 1000) String reason,
+        @Size(max = 500) String evidenceRef
+) {
+}

--- a/src/main/java/com/susukkang/fgc/journal/dto/ReverseJournalResponse.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/ReverseJournalResponse.java
@@ -1,0 +1,11 @@
+package com.susukkang.fgc.journal.dto;
+
+/** IF-API-36 역분개 응답. */
+public record ReverseJournalResponse(
+        Long journalHeaderId,
+        Long reversalOfId
+) {
+    public static ReverseJournalResponse from(JournalCorrectionResult result) {
+        return new ReverseJournalResponse(result.journalHeaderId(), result.reversalOfId());
+    }
+}

--- a/src/main/java/com/susukkang/fgc/journal/mapper/JournalCorrectionMapper.java
+++ b/src/main/java/com/susukkang/fgc/journal/mapper/JournalCorrectionMapper.java
@@ -1,0 +1,27 @@
+package com.susukkang.fgc.journal.mapper;
+
+import com.susukkang.fgc.journal.dto.JournalCorrectionGroupInsertRow;
+import com.susukkang.fgc.journal.dto.JournalCorrectionHeaderRow;
+import com.susukkang.fgc.journal.dto.JournalCorrectionLineRow;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface JournalCorrectionMapper {
+
+    JournalCorrectionHeaderRow findHeaderForUpdate(@Param("journalHeaderId") Long journalHeaderId);
+
+    List<JournalCorrectionLineRow> findLines(@Param("journalHeaderId") Long journalHeaderId);
+
+    int insertGroup(JournalCorrectionGroupInsertRow row);
+
+    /** 월별 journal_no 채번을 현재 트랜잭션 안에서 직렬화한다. */
+    int lockJournalNumbering(@Param("lockKey") String lockKey);
+
+    int markPosted(@Param("journalHeaderId") Long journalHeaderId,
+                   @Param("postedBy") Long postedBy);
+
+    int markReversed(@Param("journalHeaderId") Long journalHeaderId);
+}

--- a/src/main/java/com/susukkang/fgc/journal/service/JournalCorrectionService.java
+++ b/src/main/java/com/susukkang/fgc/journal/service/JournalCorrectionService.java
@@ -1,0 +1,14 @@
+package com.susukkang.fgc.journal.service;
+
+import com.susukkang.fgc.journal.dto.JournalCorrectionResult;
+import com.susukkang.fgc.journal.dto.ReverseAndRepostJournalCommand;
+import com.susukkang.fgc.journal.dto.ReverseJournalCommand;
+
+public interface JournalCorrectionService {
+
+    /** IF-API-36 기본 역분개. */
+    JournalCorrectionResult reverse(ReverseJournalCommand command);
+
+    /** FUN-047 내부 명령: 역분개와 정정 초안을 같은 트랜잭션에서 재기표한다. */
+    JournalCorrectionResult reverseAndRepost(ReverseAndRepostJournalCommand command);
+}

--- a/src/main/java/com/susukkang/fgc/journal/service/JournalCorrectionServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/journal/service/JournalCorrectionServiceImpl.java
@@ -1,0 +1,411 @@
+package com.susukkang.fgc.journal.service;
+
+import com.susukkang.fgc.audit.service.AuditLogService;
+import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.journal.domain.JournalType;
+import com.susukkang.fgc.journal.dto.JournalAccountRow;
+import com.susukkang.fgc.journal.dto.JournalCorrectionGroupInsertRow;
+import com.susukkang.fgc.journal.dto.JournalCorrectionHeaderRow;
+import com.susukkang.fgc.journal.dto.JournalCorrectionLineRow;
+import com.susukkang.fgc.journal.dto.JournalCorrectionResult;
+import com.susukkang.fgc.journal.dto.JournalHeaderDraft;
+import com.susukkang.fgc.journal.dto.JournalHeaderInsertRow;
+import com.susukkang.fgc.journal.dto.JournalLineDraft;
+import com.susukkang.fgc.journal.dto.JournalLineInsertRow;
+import com.susukkang.fgc.journal.dto.ReverseAndRepostJournalCommand;
+import com.susukkang.fgc.journal.dto.ReverseJournalCommand;
+import com.susukkang.fgc.journal.mapper.JournalAccountMapper;
+import com.susukkang.fgc.journal.mapper.JournalCorrectionMapper;
+import com.susukkang.fgc.journal.mapper.JournalMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class JournalCorrectionServiceImpl implements JournalCorrectionService {
+
+    private static final int REASON_MAX_LENGTH = 1000;
+    private static final int EVIDENCE_MAX_LENGTH = 500;
+    private static final int DESCRIPTION_MAX_LENGTH = 1000;
+    private static final int MAX_MONTHLY_SEQ = 9999;
+
+    private final JournalCorrectionMapper correctionMapper;
+    private final JournalMapper journalMapper;
+    private final JournalAccountMapper journalAccountMapper;
+    private final AuditLogService auditLogService;
+
+    @Override
+    @Transactional
+    public JournalCorrectionResult reverse(ReverseJournalCommand command) {
+        return correct(command, null);
+    }
+
+    @Override
+    @Transactional
+    public JournalCorrectionResult reverseAndRepost(ReverseAndRepostJournalCommand command) {
+        if (command == null || command.correctedDraft() == null) {
+            throw validationFailure("correctedDraft");
+        }
+        return correct(command.reversal(), command.correctedDraft());
+    }
+
+    private JournalCorrectionResult correct(ReverseJournalCommand command,
+                                              JournalHeaderDraft correctedDraft) {
+        ValidatedRequest request = validateRequest(command);
+        JournalCorrectionHeaderRow original = correctionMapper.findHeaderForUpdate(
+                command.journalHeaderId());
+        validateOriginal(original, command.journalHeaderId());
+
+        List<JournalCorrectionLineRow> originalLines = correctionMapper.findLines(
+                original.getJournalHeaderId());
+        assertBalanced(originalLines);
+
+        List<Long> correctedAccountIds = correctedDraft == null
+                ? List.of()
+                : validateCorrectedDraft(original, correctedDraft);
+
+        lockNumberingMonths(original.getJournalDate(),
+                correctedDraft == null ? null : correctedDraft.getJournalDate());
+
+        String correctionGroupKey = newCorrectionGroupKey(original.getJournalHeaderId());
+        correctionMapper.insertGroup(JournalCorrectionGroupInsertRow.builder()
+                .correctionGroupKey(correctionGroupKey)
+                .originalJournalHeaderId(original.getJournalHeaderId())
+                .reason(request.reason())
+                .evidenceRef(request.evidenceRef())
+                .createdBy(command.requestedBy())
+                .build());
+
+        Long reversalId = insertReversal(
+                original, originalLines, correctionGroupKey, request.reason(), command.requestedBy());
+        if (correctionMapper.markPosted(reversalId, command.requestedBy()) != 1) {
+            throw conflict(original.getJournalHeaderId());
+        }
+        if (correctionMapper.markReversed(original.getJournalHeaderId()) != 1) {
+            throw conflict(original.getJournalHeaderId());
+        }
+
+        Long repostedId = null;
+        if (correctedDraft != null) {
+            repostedId = insertRepost(
+                    correctedDraft, correctedAccountIds, correctionGroupKey, command.requestedBy());
+            if (correctionMapper.markPosted(repostedId, command.requestedBy()) != 1) {
+                throw conflict(original.getJournalHeaderId());
+            }
+        }
+
+        recordAudit(original, reversalId, repostedId, correctionGroupKey,
+                request, command.requestedBy(), originalLines, correctedDraft);
+
+        return new JournalCorrectionResult(
+                reversalId, original.getJournalHeaderId(), repostedId, correctionGroupKey);
+    }
+
+    private ValidatedRequest validateRequest(ReverseJournalCommand command) {
+        if (command == null || command.journalHeaderId() == null) {
+            throw validationFailure("journalHeaderId");
+        }
+        if (command.requestedBy() == null) {
+            throw validationFailure("requestedBy");
+        }
+        String reason = normalizeRequired(command.reason(), REASON_MAX_LENGTH, "reason");
+        String evidenceRef = normalizeOptional(
+                command.evidenceRef(), EVIDENCE_MAX_LENGTH, "evidenceRef");
+        return new ValidatedRequest(reason, evidenceRef);
+    }
+
+    private void validateOriginal(JournalCorrectionHeaderRow original, Long journalHeaderId) {
+        if (original == null) {
+            throw new FgcBusinessException(FgcErrorCode.COMMON_004,
+                    Map.of("resource", "journal", "id", journalHeaderId));
+        }
+        if ("FINALIZED".equals(original.getValidationRunStatus())) {
+            throw new FgcBusinessException(FgcErrorCode.VRUN_003,
+                    Map.of("validationRunId", original.getValidationRunId()));
+        }
+        if (!"POSTED".equals(original.getStatus())
+                || JournalType.REVERSAL.name().equals(original.getJournalType())) {
+            throw conflict(journalHeaderId);
+        }
+    }
+
+    private List<Long> validateCorrectedDraft(JournalCorrectionHeaderRow original,
+                                               JournalHeaderDraft correctedDraft) {
+        if (correctedDraft.getJournalType() == null
+                || !correctedDraft.getJournalType().name().equals(original.getJournalType())
+                || !Objects.equals(correctedDraft.getSourceEntityType(), original.getSourceEntityType())
+                || !Objects.equals(correctedDraft.getSourceEntityId(), original.getSourceEntityId())
+                || correctedDraft.getRevisionNo() != original.getRevisionNo() + 1
+                || !Objects.equals(correctedDraft.getValidationRunId(), original.getValidationRunId())
+                || !Objects.equals(correctedDraft.getContractId(), original.getContractId())
+                || !Objects.equals(correctedDraft.getPolicyVersionId(), original.getPolicyVersionId())) {
+            throw validationFailure("correctedDraft");
+        }
+        if (correctedDraft.getJournalDate() == null
+                || correctedDraft.getLines() == null
+                || correctedDraft.getLines().isEmpty()) {
+            throw validationFailure("correctedDraft");
+        }
+        if (correctedDraft.getDescription() != null
+                && correctedDraft.getDescription().length() > DESCRIPTION_MAX_LENGTH) {
+            throw validationFailure("correctedDraft.description");
+        }
+
+        BigDecimal debitTotal = BigDecimal.ZERO;
+        BigDecimal creditTotal = BigDecimal.ZERO;
+        List<Long> accountIds = new ArrayList<>();
+        for (JournalLineDraft line : correctedDraft.getLines()) {
+            validateCorrectedLine(line);
+            JournalAccountRow account = journalAccountMapper.findActiveByCode(
+                    line.getAccountCode().name());
+            if (account == null) {
+                throw new FgcBusinessException(FgcErrorCode.JOURNAL_001,
+                        Map.of("accountCode", line.getAccountCode()));
+            }
+            accountIds.add(account.getJournalAccountId());
+            debitTotal = debitTotal.add(line.getDebitAmount());
+            creditTotal = creditTotal.add(line.getCreditAmount());
+        }
+        assertBalanced(debitTotal, creditTotal);
+        return accountIds;
+    }
+
+    private void validateCorrectedLine(JournalLineDraft line) {
+        if (line == null || line.getLineNo() <= 0 || line.getAccountCode() == null
+                || line.getDebitAmount() == null || line.getCreditAmount() == null
+                || line.getDebitAmount().signum() < 0 || line.getCreditAmount().signum() < 0
+                || (line.getDebitAmount().signum() > 0) == (line.getCreditAmount().signum() > 0)) {
+            throw validationFailure("correctedDraft.lines");
+        }
+    }
+
+    private void assertBalanced(List<JournalCorrectionLineRow> lines) {
+        BigDecimal debitTotal = lines.stream()
+                .map(JournalCorrectionLineRow::getDebitAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal creditTotal = lines.stream()
+                .map(JournalCorrectionLineRow::getCreditAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertBalanced(debitTotal, creditTotal);
+    }
+
+    private void assertBalanced(BigDecimal debitTotal, BigDecimal creditTotal) {
+        if (debitTotal.signum() <= 0 || debitTotal.compareTo(creditTotal) != 0) {
+            throw new FgcBusinessException(FgcErrorCode.LEDG_001,
+                    Map.of("c", debitTotal.subtract(creditTotal).abs()));
+        }
+    }
+
+    private Long insertReversal(JournalCorrectionHeaderRow original,
+                                List<JournalCorrectionLineRow> originalLines,
+                                String correctionGroupKey,
+                                String reason,
+                                Long requestedBy) {
+        JournalHeaderInsertRow header = JournalHeaderInsertRow.builder()
+                .journalNo(nextJournalNo(original.getJournalDate()))
+                .journalDate(original.getJournalDate())
+                .journalType(JournalType.REVERSAL.name())
+                .sourceEntityType("JOURNAL_HEADER")
+                .sourceEntityId(String.valueOf(original.getJournalHeaderId()))
+                .revisionNo(1)
+                .validationRunId(original.getValidationRunId())
+                .contractId(original.getContractId())
+                .policyVersionId(original.getPolicyVersionId())
+                .reversalOfId(original.getJournalHeaderId())
+                .correctionGroupKey(correctionGroupKey)
+                .description(reason)
+                .createdBy(requestedBy)
+                .build();
+        journalMapper.insert(header);
+
+        for (JournalCorrectionLineRow line : originalLines) {
+            journalMapper.insertLine(JournalLineInsertRow.builder()
+                    .journalHeaderId(header.getJournalHeaderId())
+                    .lineNo(line.getLineNo())
+                    .journalAccountId(line.getJournalAccountId())
+                    .debitAmount(line.getCreditAmount())
+                    .creditAmount(line.getDebitAmount())
+                    .contractId(line.getContractId())
+                    .agentId(line.getAgentId())
+                    .paymentStage(line.getPaymentStage())
+                    .commissionItemId(line.getCommissionItemId())
+                    .memo(line.getMemo())
+                    .build());
+        }
+        return header.getJournalHeaderId();
+    }
+
+    private Long insertRepost(JournalHeaderDraft draft,
+                              List<Long> accountIds,
+                              String correctionGroupKey,
+                              Long requestedBy) {
+        JournalHeaderInsertRow header = JournalHeaderInsertRow.builder()
+                .journalNo(nextJournalNo(draft.getJournalDate()))
+                .journalDate(draft.getJournalDate())
+                .journalType(draft.getJournalType().name())
+                .sourceEntityType(draft.getSourceEntityType())
+                .sourceEntityId(draft.getSourceEntityId())
+                .revisionNo(draft.getRevisionNo())
+                .validationRunId(draft.getValidationRunId())
+                .contractId(draft.getContractId())
+                .policyVersionId(draft.getPolicyVersionId())
+                .correctionGroupKey(correctionGroupKey)
+                .description(draft.getDescription())
+                .createdBy(requestedBy)
+                .build();
+        journalMapper.insert(header);
+
+        for (int i = 0; i < draft.getLines().size(); i++) {
+            JournalLineDraft line = draft.getLines().get(i);
+            PaymentStage paymentStage = line.getPaymentStage();
+            journalMapper.insertLine(JournalLineInsertRow.builder()
+                    .journalHeaderId(header.getJournalHeaderId())
+                    .lineNo(line.getLineNo())
+                    .journalAccountId(accountIds.get(i))
+                    .debitAmount(line.getDebitAmount())
+                    .creditAmount(line.getCreditAmount())
+                    .contractId(line.getContractId())
+                    .agentId(line.getAgentId())
+                    .paymentStage(paymentStage == null ? null : paymentStage.name())
+                    .commissionItemId(line.getCommissionItemId())
+                    .memo(line.getMemo())
+                    .build());
+        }
+        return header.getJournalHeaderId();
+    }
+
+    private void lockNumberingMonths(LocalDate first, LocalDate second) {
+        LinkedHashSet<String> keys = new LinkedHashSet<>();
+        Stream.of(first, second)
+                .filter(Objects::nonNull)
+                .map(date -> "journal-no:" + YearMonth.from(date))
+                .sorted(Comparator.naturalOrder())
+                .forEach(keys::add);
+        keys.forEach(correctionMapper::lockJournalNumbering);
+    }
+
+    private String nextJournalNo(LocalDate journalDate) {
+        String year = String.valueOf(journalDate.getYear());
+        String month = String.format("%02d", journalDate.getMonthValue());
+        int seq = journalMapper.findNextJournalSeq(year, month);
+        if (seq > MAX_MONTHLY_SEQ) {
+            throw new IllegalStateException("journal_no 월간 일련번호 상한 초과");
+        }
+        return String.format("JV-%s-%s-%04d", year, month, seq);
+    }
+
+    private void recordAudit(JournalCorrectionHeaderRow original,
+                             Long reversalId,
+                             Long repostedId,
+                             String correctionGroupKey,
+                             ValidatedRequest request,
+                             Long requestedBy,
+                             List<JournalCorrectionLineRow> originalLines,
+                             JournalHeaderDraft correctedDraft) {
+        AmountTotals beforeTotals = totalsOfOriginal(originalLines);
+        AmountTotals afterTotals = correctedDraft == null
+                ? null
+                : totalsOfCorrected(correctedDraft.getLines());
+        auditLogService.record(AuditLogService.AuditEvent.builder()
+                .actionCode(repostedId == null
+                        ? "JOURNAL_REVERSED"
+                        : "JOURNAL_REVERSED_AND_REPOSTED")
+                .entityType("JOURNAL_HEADER")
+                .entityId(String.valueOf(original.getJournalHeaderId()))
+                .userId(requestedBy)
+                .before(new CorrectionBeforeSnapshot(
+                        original.getJournalHeaderId(), original.getStatus(), original.getRevisionNo(),
+                        beforeTotals.debitTotal(), beforeTotals.creditTotal()))
+                .after(new CorrectionAfterSnapshot(
+                        reversalId, repostedId, correctionGroupKey, request.evidenceRef(),
+                        afterTotals == null ? null : afterTotals.debitTotal(),
+                        afterTotals == null ? null : afterTotals.creditTotal()))
+                .reason(request.reason())
+                .policyVersionId(original.getPolicyVersionId())
+                .build());
+    }
+
+    private static AmountTotals totalsOfOriginal(List<JournalCorrectionLineRow> lines) {
+        return new AmountTotals(
+                lines.stream().map(JournalCorrectionLineRow::getDebitAmount)
+                        .reduce(BigDecimal.ZERO, BigDecimal::add),
+                lines.stream().map(JournalCorrectionLineRow::getCreditAmount)
+                        .reduce(BigDecimal.ZERO, BigDecimal::add));
+    }
+
+    private static AmountTotals totalsOfCorrected(List<JournalLineDraft> lines) {
+        return new AmountTotals(
+                lines.stream().map(JournalLineDraft::getDebitAmount)
+                        .reduce(BigDecimal.ZERO, BigDecimal::add),
+                lines.stream().map(JournalLineDraft::getCreditAmount)
+                        .reduce(BigDecimal.ZERO, BigDecimal::add));
+    }
+
+    private static String newCorrectionGroupKey(Long originalJournalHeaderId) {
+        return "JCG-" + originalJournalHeaderId + "-"
+                + UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private static String normalizeRequired(String value, int maxLength, String field) {
+        if (value == null || value.isBlank() || value.length() > maxLength) {
+            throw validationFailure(field);
+        }
+        return value.trim();
+    }
+
+    private static String normalizeOptional(String value, int maxLength, String field) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        if (value.length() > maxLength) {
+            throw validationFailure(field);
+        }
+        return value.trim();
+    }
+
+    private static FgcBusinessException validationFailure(String field) {
+        return new FgcBusinessException(
+                FgcErrorCode.COMMON_002, field, Map.of("field", field), null);
+    }
+
+    private static FgcBusinessException conflict(Long journalHeaderId) {
+        return new FgcBusinessException(FgcErrorCode.LEDG_002,
+                Map.of("journalHeaderId", journalHeaderId));
+    }
+
+    private record ValidatedRequest(String reason, String evidenceRef) {
+    }
+
+    private record AmountTotals(BigDecimal debitTotal, BigDecimal creditTotal) {
+    }
+
+    private record CorrectionBeforeSnapshot(Long journalHeaderId,
+                                            String status,
+                                            Integer revisionNo,
+                                            BigDecimal debitTotal,
+                                            BigDecimal creditTotal) {
+    }
+
+    private record CorrectionAfterSnapshot(Long reversalJournalHeaderId,
+                                           Long repostedJournalHeaderId,
+                                           String correctionGroupKey,
+                                           String evidenceRef,
+                                           BigDecimal debitTotal,
+                                           BigDecimal creditTotal) {
+    }
+}

--- a/src/main/resources/db/migration/V28__journal_correction_group.sql
+++ b/src/main/resources/db/migration/V28__journal_correction_group.sql
@@ -1,0 +1,164 @@
+-- FUN-047 원장 정정그룹 및 역분개/재기표 무결성
+-- 기존 V1 journal_header 스키마는 수정하지 않고 정정 메타데이터와 관계 제약만 확장한다.
+
+SET search_path TO fgc, public;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM fgc.journal_header WHERE correction_group_key IS NOT NULL) THEN
+    RAISE EXCEPTION
+      'V28 cannot infer correction metadata for pre-existing correction_group_key values';
+  END IF;
+END;
+$$;
+
+CREATE TABLE journal_correction_group (
+  correction_group_key       varchar(80) PRIMARY KEY,
+  original_journal_header_id bigint       NOT NULL
+      REFERENCES journal_header(journal_header_id),
+  reason                     varchar(1000) NOT NULL,
+  evidence_ref               varchar(500),
+  created_by                 bigint REFERENCES app_user(user_id),
+  created_at                 timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT uq_journal_correction_original UNIQUE (original_journal_header_id),
+  CONSTRAINT ck_journal_correction_group_key_not_blank
+      CHECK (btrim(correction_group_key) <> ''),
+  CONSTRAINT ck_journal_correction_reason_not_blank
+      CHECK (btrim(reason) <> '')
+);
+COMMENT ON TABLE journal_correction_group IS
+  '원분개를 변경하지 않고 역분개와 선택적 재기표를 연결하는 불변 정정그룹';
+
+ALTER TABLE journal_header
+  ADD CONSTRAINT fk_journal_header_correction_group
+  FOREIGN KEY (correction_group_key)
+  REFERENCES journal_correction_group(correction_group_key);
+
+ALTER TABLE journal_header
+  ADD CONSTRAINT ck_journal_reversal_group
+  CHECK (journal_type <> 'REVERSAL' OR correction_group_key IS NOT NULL);
+
+CREATE UNIQUE INDEX uq_journal_correction_group_reversal
+  ON journal_header(correction_group_key)
+  WHERE journal_type = 'REVERSAL';
+
+CREATE UNIQUE INDEX uq_journal_correction_group_repost
+  ON journal_header(correction_group_key)
+  WHERE journal_type <> 'REVERSAL' AND correction_group_key IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION fgc.guard_journal_correction_group_write()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_status varchar(15);
+  v_type varchar(35);
+BEGIN
+  IF TG_OP <> 'INSERT' THEN
+    RAISE EXCEPTION 'Journal correction group % is immutable', OLD.correction_group_key;
+  END IF;
+
+  SELECT status, journal_type
+    INTO v_status, v_type
+    FROM journal_header
+   WHERE journal_header_id = NEW.original_journal_header_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Original journal % does not exist', NEW.original_journal_header_id;
+  END IF;
+  IF v_status <> 'POSTED' THEN
+    RAISE EXCEPTION 'Only a POSTED journal may be corrected: % is %',
+      NEW.original_journal_header_id, v_status;
+  END IF;
+  IF v_type = 'REVERSAL' THEN
+    RAISE EXCEPTION 'A reversal journal cannot be corrected again: %',
+      NEW.original_journal_header_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_journal_correction_group_guard
+BEFORE INSERT OR UPDATE OR DELETE ON journal_correction_group
+FOR EACH ROW EXECUTE FUNCTION fgc.guard_journal_correction_group_write();
+
+CREATE OR REPLACE FUNCTION fgc.guard_journal_correction_membership()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_original_id bigint;
+  v_original_type varchar(35);
+  v_original_source_type varchar(60);
+  v_original_source_id varchar(100);
+  v_original_revision integer;
+  v_original_status varchar(15);
+BEGIN
+  IF NEW.correction_group_key IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT g.original_journal_header_id,
+         o.journal_type,
+         o.source_entity_type,
+         o.source_entity_id,
+         o.revision_no,
+         o.status
+    INTO v_original_id,
+         v_original_type,
+         v_original_source_type,
+         v_original_source_id,
+         v_original_revision,
+         v_original_status
+    FROM journal_correction_group g
+    JOIN journal_header o
+      ON o.journal_header_id = g.original_journal_header_id
+   WHERE g.correction_group_key = NEW.correction_group_key
+   FOR SHARE OF g, o;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Unknown journal correction group %', NEW.correction_group_key;
+  END IF;
+
+  IF NEW.journal_type = 'REVERSAL' THEN
+    IF NEW.reversal_of_id IS DISTINCT FROM v_original_id
+       OR NEW.source_entity_type <> 'JOURNAL_HEADER'
+       OR NEW.source_entity_id <> v_original_id::text
+       OR NEW.revision_no <> 1 THEN
+      RAISE EXCEPTION 'Reversal journal does not match correction group %',
+        NEW.correction_group_key;
+    END IF;
+    IF v_original_status <> 'POSTED' THEN
+      RAISE EXCEPTION 'Original journal % is no longer POSTED', v_original_id;
+    END IF;
+  ELSE
+    IF NEW.reversal_of_id IS NOT NULL
+       OR NEW.journal_type <> v_original_type
+       OR NEW.source_entity_type <> v_original_source_type
+       OR NEW.source_entity_id <> v_original_source_id
+       OR NEW.revision_no <> v_original_revision + 1 THEN
+      RAISE EXCEPTION 'Reposted journal does not match correction group %',
+        NEW.correction_group_key;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1
+        FROM journal_header r
+       WHERE r.correction_group_key = NEW.correction_group_key
+         AND r.journal_type = 'REVERSAL'
+         AND r.reversal_of_id = v_original_id
+         AND r.status = 'POSTED'
+    ) THEN
+      RAISE EXCEPTION 'Reposted journal requires a POSTED reversal in correction group %',
+        NEW.correction_group_key;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_journal_correction_membership
+BEFORE INSERT OR UPDATE ON journal_header
+FOR EACH ROW EXECUTE FUNCTION fgc.guard_journal_correction_membership();

--- a/src/main/resources/mapper/journal/JournalCorrectionMapper.xml
+++ b/src/main/resources/mapper/journal/JournalCorrectionMapper.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.susukkang.fgc.journal.mapper.JournalCorrectionMapper">
+    <select id="findHeaderForUpdate"
+            resultType="com.susukkang.fgc.journal.dto.JournalCorrectionHeaderRow">
+        SELECT h.journal_header_id, h.journal_date, h.journal_type,
+               h.source_entity_type, h.source_entity_id, h.revision_no,
+               h.validation_run_id, vr.status AS validationRunStatus,
+               h.contract_id, h.policy_version_id, h.status, h.description
+        FROM fgc.journal_header h
+        LEFT JOIN fgc.validation_run vr ON vr.validation_run_id = h.validation_run_id
+        WHERE h.journal_header_id = #{journalHeaderId}
+        FOR UPDATE OF h
+    </select>
+
+    <select id="findLines"
+            resultType="com.susukkang.fgc.journal.dto.JournalCorrectionLineRow">
+        SELECT line_no, journal_account_id, debit_amount, credit_amount,
+               contract_id, agent_id, payment_stage, commission_item_id, memo
+        FROM fgc.journal_line
+        WHERE journal_header_id = #{journalHeaderId}
+        ORDER BY line_no
+    </select>
+
+    <insert id="insertGroup"
+            parameterType="com.susukkang.fgc.journal.dto.JournalCorrectionGroupInsertRow">
+        INSERT INTO fgc.journal_correction_group
+            (correction_group_key, original_journal_header_id, reason,
+             evidence_ref, created_by)
+        VALUES
+            (#{correctionGroupKey}, #{originalJournalHeaderId}, #{reason},
+             #{evidenceRef}, #{createdBy})
+    </insert>
+
+    <select id="lockJournalNumbering" resultType="int">
+        SELECT 1
+        FROM pg_advisory_xact_lock(hashtextextended(#{lockKey}, 0))
+    </select>
+
+    <update id="markPosted">
+        UPDATE fgc.journal_header
+        SET status = 'POSTED', posted_by = #{postedBy}
+        WHERE journal_header_id = #{journalHeaderId} AND status = 'DRAFT'
+    </update>
+
+    <update id="markReversed">
+        UPDATE fgc.journal_header
+        SET status = 'REVERSED'
+        WHERE journal_header_id = #{journalHeaderId} AND status = 'POSTED'
+    </update>
+</mapper>

--- a/src/main/resources/mapper/journal/JournalMapper.xml
+++ b/src/main/resources/mapper/journal/JournalMapper.xml
@@ -11,11 +11,11 @@
         INSERT INTO fgc.journal_header
             (journal_no, journal_date, journal_type, source_entity_type, source_entity_id,
              revision_no, validation_run_id, contract_id, policy_version_id,
-             correction_group_key, description, created_by)
+             reversal_of_id, correction_group_key, description, created_by)
         VALUES
             (#{journalNo}, #{journalDate}, #{journalType}, #{sourceEntityType}, #{sourceEntityId},
              #{revisionNo}, #{validationRunId}, #{contractId}, #{policyVersionId},
-             #{correctionGroupKey}, #{description}, #{createdBy})
+             #{reversalOfId}, #{correctionGroupKey}, #{description}, #{createdBy})
     </insert>
 
     <insert id="insertLine" parameterType="com.susukkang.fgc.journal.dto.JournalLineInsertRow"

--- a/src/test/java/com/susukkang/fgc/journal/controller/JournalCorrectionControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/journal/controller/JournalCorrectionControllerTest.java
@@ -1,0 +1,153 @@
+package com.susukkang.fgc.journal.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.susukkang.fgc.auth.dto.AppUserView;
+import com.susukkang.fgc.auth.dto.FgcUserDetails;
+import com.susukkang.fgc.common.config.SecurityConfig;
+import com.susukkang.fgc.common.exception.ConstraintErrorCodeResolver;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.exception.FgcMessageResolver;
+import com.susukkang.fgc.common.exception.GlobalExceptionHandler;
+import com.susukkang.fgc.journal.dto.JournalCorrectionResult;
+import com.susukkang.fgc.journal.dto.ReverseJournalCommand;
+import com.susukkang.fgc.journal.dto.ReverseJournalRequest;
+import com.susukkang.fgc.journal.service.JournalCorrectionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/** IF-API-36 요청 검증, CSRF, 역할 및 공통 오류 봉투를 검증한다. */
+@WebMvcTest(JournalCorrectionController.class)
+@Import({JournalCorrectionController.class, GlobalExceptionHandler.class, FgcMessageResolver.class,
+        ConstraintErrorCodeResolver.class, MessageSourceAutoConfiguration.class, SecurityConfig.class})
+class JournalCorrectionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private JournalCorrectionService journalCorrectionService;
+
+    @Test
+    void reversesPostedJournalForSettlementRole() throws Exception {
+        given(journalCorrectionService.reverse(any(ReverseJournalCommand.class)))
+                .willReturn(new JournalCorrectionResult(20L, 10L, null, "JCG-10-test"));
+
+        ReverseJournalRequest request = new ReverseJournalRequest("금액 정정", "DOC-10");
+        mockMvc.perform(post("/api/v1/journals/10/reverse")
+                        .with(user(principal(1L, "settle01", "SETTLEMENT")))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.journalHeaderId").value(20L))
+                .andExpect(jsonPath("$.data.reversalOfId").value(10L));
+
+        verify(journalCorrectionService).reverse(new ReverseJournalCommand(
+                10L, "금액 정정", "DOC-10", 1L));
+    }
+
+    @Test
+    void allowsGaAdminRole() throws Exception {
+        given(journalCorrectionService.reverse(any(ReverseJournalCommand.class)))
+                .willReturn(new JournalCorrectionResult(20L, 10L, null, "JCG-10-test"));
+
+        mockMvc.perform(post("/api/v1/journals/10/reverse")
+                        .with(user(principal(2L, "gaadmin01", "GA_ADMIN")))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"정정\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void rejectsReadOnlyComplianceRole() throws Exception {
+        mockMvc.perform(post("/api/v1/journals/10/reverse")
+                        .with(user(principal(3L, "audit01", "COMPLIANCE")))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"정정\"}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("FGC-AUTH-003"));
+
+        verify(journalCorrectionService, never()).reverse(any());
+    }
+
+    @Test
+    void requiresCsrfToken() throws Exception {
+        mockMvc.perform(post("/api/v1/journals/10/reverse")
+                        .with(user(principal(1L, "settle01", "SETTLEMENT")))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"정정\"}"))
+                .andExpect(status().isForbidden());
+
+        verify(journalCorrectionService, never()).reverse(any());
+    }
+
+    @Test
+    void rejectsBlankReasonWithCommonValidationError() throws Exception {
+        mockMvc.perform(post("/api/v1/journals/10/reverse")
+                        .with(user(principal(1L, "settle01", "SETTLEMENT")))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\" \"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("FGC-COMMON-002"))
+                .andExpect(jsonPath("$.error.field").value("reason"));
+
+        verify(journalCorrectionService, never()).reverse(any());
+    }
+
+    @Test
+    void returnsConflictForDuplicateReversal() throws Exception {
+        willThrow(new FgcBusinessException(FgcErrorCode.LEDG_002))
+                .given(journalCorrectionService).reverse(any(ReverseJournalCommand.class));
+
+        mockMvc.perform(post("/api/v1/journals/10/reverse")
+                        .with(user(principal(1L, "settle01", "SETTLEMENT")))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"중복 요청\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("FGC-LEDG-002"));
+    }
+
+    @Test
+    void returnsUnauthorizedWhenUnauthenticated() throws Exception {
+        mockMvc.perform(post("/api/v1/journals/10/reverse")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\":\"정정\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private FgcUserDetails principal(Long userId, String loginId, String roleCode) {
+        AppUserView view = new AppUserView();
+        view.setUserId(userId);
+        view.setLoginId(loginId);
+        view.setPasswordHash("{bcrypt}dummy");
+        view.setUserName(loginId);
+        view.setRoleCode(roleCode);
+        return new FgcUserDetails(view, true, true);
+    }
+}

--- a/src/test/java/com/susukkang/fgc/journal/service/JournalCorrectionServiceIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/journal/service/JournalCorrectionServiceIntegrationTest.java
@@ -1,0 +1,308 @@
+package com.susukkang.fgc.journal.service;
+
+import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.common.exception.FgcBusinessException;
+import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.web.RequestIdContext;
+import com.susukkang.fgc.journal.domain.JournalAccountCode;
+import com.susukkang.fgc.journal.domain.JournalType;
+import com.susukkang.fgc.journal.dto.JournalCorrectionResult;
+import com.susukkang.fgc.journal.dto.JournalHeaderDraft;
+import com.susukkang.fgc.journal.dto.JournalLineDraft;
+import com.susukkang.fgc.journal.dto.ReverseAndRepostJournalCommand;
+import com.susukkang.fgc.journal.dto.ReverseJournalCommand;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** FUN-047 차대 역전, 원본 불변, 정정그룹, 중복 방지와 실패 롤백 통합 검증. */
+@SpringBootTest
+class JournalCorrectionServiceIntegrationTest {
+
+    private static final long ACTOR_ID = 1L;
+    private static final LocalDate JOURNAL_DATE = LocalDate.of(2026, 8, 1);
+
+    @Autowired
+    private JournalCorrectionService journalCorrectionService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @AfterEach
+    void clearRequestId() {
+        RequestIdContext.clear();
+    }
+
+    @Test
+    @Transactional
+    void reverseSwapsDebitAndCreditAndKeepsOriginalImmutable() {
+        String sourceId = newSourceId();
+        Long originalId = insertPostedOriginal(sourceId, BigDecimal.valueOf(650_000));
+        RequestIdContext.set("req-fun047-reverse");
+
+        JournalCorrectionResult result = journalCorrectionService.reverse(
+                new ReverseJournalCommand(originalId, "원장 금액 정정", "DOC-047", ACTOR_ID));
+
+        assertThat(result.reversalOfId()).isEqualTo(originalId);
+        assertThat(result.repostedJournalHeaderId()).isNull();
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT status FROM fgc.journal_header WHERE journal_header_id = ?",
+                String.class, originalId)).isEqualTo("REVERSED");
+
+        Map<String, Object> reversal = jdbcTemplate.queryForMap("""
+                SELECT journal_type, reversal_of_id, correction_group_key, status
+                FROM fgc.journal_header
+                WHERE journal_header_id = ?
+                """, result.journalHeaderId());
+        assertThat(reversal.get("journal_type")).isEqualTo("REVERSAL");
+        assertThat(((Number) reversal.get("reversal_of_id")).longValue()).isEqualTo(originalId);
+        assertThat(reversal.get("correction_group_key")).isEqualTo(result.correctionGroupKey());
+        assertThat(reversal.get("status")).isEqualTo("POSTED");
+
+        List<Map<String, Object>> lines = jdbcTemplate.queryForList("""
+                SELECT line_no, debit_amount, credit_amount
+                FROM fgc.journal_line
+                WHERE journal_header_id = ?
+                ORDER BY line_no
+                """, result.journalHeaderId());
+        assertThat((BigDecimal) lines.get(0).get("debit_amount")).isEqualByComparingTo("0");
+        assertThat((BigDecimal) lines.get(0).get("credit_amount")).isEqualByComparingTo("650000");
+        assertThat((BigDecimal) lines.get(1).get("debit_amount")).isEqualByComparingTo("650000");
+        assertThat((BigDecimal) lines.get(1).get("credit_amount")).isEqualByComparingTo("0");
+
+        Map<String, Object> group = jdbcTemplate.queryForMap("""
+                SELECT original_journal_header_id, reason, evidence_ref
+                FROM fgc.journal_correction_group
+                WHERE correction_group_key = ?
+                """, result.correctionGroupKey());
+        assertThat(((Number) group.get("original_journal_header_id")).longValue())
+                .isEqualTo(originalId);
+        assertThat(group.get("reason")).isEqualTo("원장 금액 정정");
+        assertThat(group.get("evidence_ref")).isEqualTo("DOC-047");
+
+        assertThat(jdbcTemplate.queryForObject("""
+                SELECT action_code FROM fgc.audit_log
+                WHERE entity_type = 'JOURNAL_HEADER' AND entity_id = ? AND request_id = ?
+                """, String.class, String.valueOf(originalId), "req-fun047-reverse"))
+                .isEqualTo("JOURNAL_REVERSED");
+
+        assertThatThrownBy(() -> jdbcTemplate.update("""
+                UPDATE fgc.journal_header SET description = '원본 변경 시도'
+                WHERE journal_header_id = ?
+                """, originalId)).isInstanceOf(DataAccessException.class);
+    }
+
+    @Test
+    @Transactional
+    void reverseAndRepostCreatesThreeMemberCorrectionGroupWithRevisionTwo() {
+        String sourceId = newSourceId();
+        Long originalId = insertPostedOriginal(sourceId, BigDecimal.valueOf(650_000));
+        Long contractId = contractId();
+        JournalHeaderDraft correctedDraft = correctedDraft(
+                sourceId, contractId, BigDecimal.valueOf(600_000), 1, 2);
+        RequestIdContext.set("req-fun047-repost");
+
+        JournalCorrectionResult result = journalCorrectionService.reverseAndRepost(
+                new ReverseAndRepostJournalCommand(
+                        new ReverseJournalCommand(
+                                originalId, "기대 금액 재산정", "CALC-047", ACTOR_ID),
+                        correctedDraft));
+
+        assertThat(result.repostedJournalHeaderId()).isNotNull();
+        Map<String, Object> repost = jdbcTemplate.queryForMap("""
+                SELECT journal_type, source_entity_type, source_entity_id, revision_no,
+                       correction_group_key, status
+                FROM fgc.journal_header
+                WHERE journal_header_id = ?
+                """, result.repostedJournalHeaderId());
+        assertThat(repost.get("journal_type")).isEqualTo(JournalType.EXPECTED_INSURER_INCOME.name());
+        assertThat(repost.get("source_entity_type")).isEqualTo("SCHEDULE_LINE");
+        assertThat(repost.get("source_entity_id")).isEqualTo(sourceId);
+        assertThat(((Number) repost.get("revision_no")).intValue()).isEqualTo(2);
+        assertThat(repost.get("correction_group_key")).isEqualTo(result.correctionGroupKey());
+        assertThat(repost.get("status")).isEqualTo("POSTED");
+
+        Integer memberCount = jdbcTemplate.queryForObject("""
+                SELECT COUNT(*)
+                FROM fgc.journal_correction_group g
+                JOIN fgc.journal_header h
+                  ON h.journal_header_id = g.original_journal_header_id
+                  OR h.correction_group_key = g.correction_group_key
+                WHERE g.correction_group_key = ?
+                """, Integer.class, result.correctionGroupKey());
+        assertThat(memberCount).isEqualTo(3);
+
+        Map<String, BigDecimal> netByAccount = jdbcTemplate.query("""
+                SELECT a.account_code,
+                       SUM(l.debit_amount - l.credit_amount) AS net_amount
+                FROM fgc.journal_line l
+                JOIN fgc.journal_account a ON a.journal_account_id = l.journal_account_id
+                WHERE l.journal_header_id IN (?, ?, ?)
+                GROUP BY a.account_code
+                """, rs -> {
+            java.util.HashMap<String, BigDecimal> values = new java.util.HashMap<>();
+            while (rs.next()) {
+                values.put(rs.getString("account_code"), rs.getBigDecimal("net_amount"));
+            }
+            return values;
+        }, originalId, result.journalHeaderId(), result.repostedJournalHeaderId());
+        assertThat(netByAccount.get(JournalAccountCode.EXPECTED_RECEIVABLE.name()))
+                .isEqualByComparingTo("600000");
+        assertThat(netByAccount.get(JournalAccountCode.EXPECTED_INCOME.name()))
+                .isEqualByComparingTo("-600000");
+
+        assertThat(jdbcTemplate.queryForObject("""
+                SELECT action_code FROM fgc.audit_log
+                WHERE entity_type = 'JOURNAL_HEADER' AND entity_id = ? AND request_id = ?
+                """, String.class, String.valueOf(originalId), "req-fun047-repost"))
+                .isEqualTo("JOURNAL_REVERSED_AND_REPOSTED");
+        Map<String, Object> auditAmounts = jdbcTemplate.queryForMap("""
+                SELECT before_value ->> 'debitTotal' AS before_debit,
+                       after_value ->> 'debitTotal' AS after_debit
+                FROM fgc.audit_log
+                WHERE entity_type = 'JOURNAL_HEADER' AND entity_id = ? AND request_id = ?
+                """, String.valueOf(originalId), "req-fun047-repost");
+        assertThat(new BigDecimal((String) auditAmounts.get("before_debit")))
+                .isEqualByComparingTo("650000");
+        assertThat(new BigDecimal((String) auditAmounts.get("after_debit")))
+                .isEqualByComparingTo("600000");
+    }
+
+    @Test
+    @Transactional
+    void duplicateRequestDoesNotCreateAnotherReversal() {
+        Long originalId = insertPostedOriginal(newSourceId(), BigDecimal.valueOf(100_000));
+        ReverseJournalCommand command = new ReverseJournalCommand(
+                originalId, "중복 요청 검증", null, ACTOR_ID);
+
+        journalCorrectionService.reverse(command);
+
+        assertThatThrownBy(() -> journalCorrectionService.reverse(command))
+                .isInstanceOf(FgcBusinessException.class)
+                .satisfies(ex -> assertThat(((FgcBusinessException) ex).getErrorCode())
+                        .isEqualTo(FgcErrorCode.LEDG_002));
+
+        Integer reversalCount = jdbcTemplate.queryForObject("""
+                SELECT COUNT(*) FROM fgc.journal_header WHERE reversal_of_id = ?
+                """, Integer.class, originalId);
+        assertThat(reversalCount).isEqualTo(1);
+    }
+
+    @Test
+    void repostLineFailureRollsBackOriginalReversalAndCorrectionGroup() {
+        String sourceId = newSourceId();
+        assertThatThrownBy(() -> transactionTemplate.executeWithoutResult(status -> {
+            Long originalId = insertPostedOriginal(sourceId, BigDecimal.valueOf(200_000));
+            Long contractId = contractId();
+            JournalHeaderDraft brokenDraft = correctedDraft(
+                    sourceId, contractId, BigDecimal.valueOf(190_000), 1, 1);
+
+            journalCorrectionService.reverseAndRepost(new ReverseAndRepostJournalCommand(
+                    new ReverseJournalCommand(originalId, "롤백 검증", null, ACTOR_ID),
+                    brokenDraft));
+        })).isInstanceOf(DataAccessException.class);
+
+        assertThat(jdbcTemplate.queryForObject("""
+                SELECT COUNT(*) FROM fgc.journal_header
+                WHERE source_entity_type = 'SCHEDULE_LINE' AND source_entity_id = ?
+                """, Integer.class, sourceId)).isZero();
+        assertThat(jdbcTemplate.queryForObject("""
+                SELECT COUNT(*) FROM fgc.journal_correction_group WHERE reason = '롤백 검증'
+                """, Integer.class)).isZero();
+    }
+
+    private Long insertPostedOriginal(String sourceId, BigDecimal amount) {
+        Long contractId = contractId();
+        String journalNo = "TEST-CORR-" + UUID.randomUUID();
+        Long headerId = jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.journal_header
+                    (journal_no, journal_date, journal_type, source_entity_type,
+                     source_entity_id, revision_no, contract_id, description, created_by)
+                VALUES (?, ?, 'EXPECTED_INSURER_INCOME', 'SCHEDULE_LINE', ?, 1, ?, ?, ?)
+                RETURNING journal_header_id
+                """, Long.class, journalNo, JOURNAL_DATE, sourceId, contractId,
+                "FUN-047 통합테스트", ACTOR_ID);
+
+        Long debitAccountId = accountId(JournalAccountCode.EXPECTED_RECEIVABLE);
+        Long creditAccountId = accountId(JournalAccountCode.EXPECTED_INCOME);
+        jdbcTemplate.update("""
+                INSERT INTO fgc.journal_line
+                    (journal_header_id, line_no, journal_account_id, debit_amount,
+                     credit_amount, contract_id, payment_stage)
+                VALUES (?, 1, ?, ?, 0, ?, 'INSURER_TO_GA'),
+                       (?, 2, ?, 0, ?, ?, 'INSURER_TO_GA')
+                """, headerId, debitAccountId, amount, contractId,
+                headerId, creditAccountId, amount, contractId);
+        assertThat(jdbcTemplate.update("""
+                UPDATE fgc.journal_header SET status = 'POSTED', posted_by = ?
+                WHERE journal_header_id = ?
+                """, ACTOR_ID, headerId)).isEqualTo(1);
+        return headerId;
+    }
+
+    private JournalHeaderDraft correctedDraft(String sourceId,
+                                               Long contractId,
+                                               BigDecimal amount,
+                                               int firstLineNo,
+                                               int secondLineNo) {
+        return JournalHeaderDraft.builder()
+                .journalType(JournalType.EXPECTED_INSURER_INCOME)
+                .journalDate(JOURNAL_DATE)
+                .sourceEntityType("SCHEDULE_LINE")
+                .sourceEntityId(sourceId)
+                .revisionNo(2)
+                .contractId(contractId)
+                .description("FUN-047 정정 분개")
+                .lines(List.of(
+                        JournalLineDraft.builder()
+                                .lineNo(firstLineNo)
+                                .accountCode(JournalAccountCode.EXPECTED_RECEIVABLE)
+                                .debitAmount(amount)
+                                .creditAmount(BigDecimal.ZERO)
+                                .contractId(contractId)
+                                .paymentStage(PaymentStage.INSURER_TO_GA)
+                                .build(),
+                        JournalLineDraft.builder()
+                                .lineNo(secondLineNo)
+                                .accountCode(JournalAccountCode.EXPECTED_INCOME)
+                                .debitAmount(BigDecimal.ZERO)
+                                .creditAmount(amount)
+                                .contractId(contractId)
+                                .paymentStage(PaymentStage.INSURER_TO_GA)
+                                .build()))
+                .build();
+    }
+
+    private Long contractId() {
+        return jdbcTemplate.queryForObject("""
+                SELECT contract_id FROM fgc.insurance_contract ORDER BY contract_id LIMIT 1
+                """, Long.class);
+    }
+
+    private Long accountId(JournalAccountCode code) {
+        return jdbcTemplate.queryForObject("""
+                SELECT journal_account_id FROM fgc.journal_account WHERE account_code = ?
+                """, Long.class, code.name());
+    }
+
+    private static String newSourceId() {
+        return "FUN047-" + UUID.randomUUID();
+    }
+}

--- a/src/test/java/com/susukkang/fgc/journal/service/JournalDetailServiceImplIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/journal/service/JournalDetailServiceImplIntegrationTest.java
@@ -50,6 +50,23 @@ class JournalDetailServiceImplIntegrationTest {
                 contractId, reversalOfId);
     }
 
+    private Long insertReversalHeader(String journalNo, Long contractId, Long originalId) {
+        String correctionGroupKey = "TEST-CORRECTION-" + originalId;
+        jdbcTemplate.update("""
+                INSERT INTO fgc.journal_correction_group
+                    (correction_group_key, original_journal_header_id, reason)
+                VALUES (?, ?, 'detail service integration test')
+                """, correctionGroupKey, originalId);
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.journal_header
+                    (journal_no, journal_date, journal_type, source_entity_type, source_entity_id,
+                     contract_id, reversal_of_id, correction_group_key, description)
+                VALUES (?, ?, 'REVERSAL', 'JOURNAL_HEADER', ?, ?, ?, ?, '역분개 조회 테스트')
+                RETURNING journal_header_id
+                """, Long.class, journalNo, LocalDate.of(2026, 8, 1), originalId.toString(),
+                contractId, originalId, correctionGroupKey);
+    }
+
     private void insertLine(Long headerId, int lineNo, String accountCode,
                              BigDecimal debit, BigDecimal credit) {
         jdbcTemplate.update("""
@@ -118,7 +135,10 @@ class JournalDetailServiceImplIntegrationTest {
     void reversalLinkIsExposedBidirectionally() {
         Long contractId = anyContractId();
         Long originalId = insertHeader("TEST-DETAIL-0003", "ADJUSTMENT", contractId, null);
-        Long reversalId = insertHeader("TEST-DETAIL-0004", "REVERSAL", contractId, originalId);
+        insertLine(originalId, 1, "EXPECTED_RECEIVABLE", new BigDecimal("10000.00"), BigDecimal.ZERO);
+        insertLine(originalId, 2, "EXPECTED_INCOME", BigDecimal.ZERO, new BigDecimal("10000.00"));
+        postJournal(originalId);
+        Long reversalId = insertReversalHeader("TEST-DETAIL-0004", contractId, originalId);
 
         JournalDetailResponse original = journalDetailService.findByJournalHeaderId(originalId);
         JournalDetailResponse reversal = journalDetailService.findByJournalHeaderId(reversalId);
@@ -154,7 +174,7 @@ class JournalDetailServiceImplIntegrationTest {
         insertLine(originalId, 2, "EXPECTED_INCOME", BigDecimal.ZERO, new BigDecimal("10000.00"));
         postJournal(originalId);
 
-        Long reversalId = insertHeader("TEST-DETAIL-0007", "REVERSAL", contractId, originalId);
+        Long reversalId = insertReversalHeader("TEST-DETAIL-0007", contractId, originalId);
         insertLine(reversalId, 1, "EXPECTED_RECEIVABLE", BigDecimal.ZERO, new BigDecimal("10000.00"));
         insertLine(reversalId, 2, "EXPECTED_INCOME", new BigDecimal("10000.00"), BigDecimal.ZERO);
         postJournal(reversalId);


### PR DESCRIPTION
# Pull Request

## 1. 변경 사항 요약

* FUN-047 원장 역분개·재기표 처리와 IF-API-36을 구현했습니다.

## 2. 관련 이슈

* Closes #215

## 3. 구현 내용

* 원분개를 보존하고 역분개와 선택적 정정 분개를 하나의 정정그룹·트랜잭션으로 생성합니다.
* 정정그룹 참조, 원본 불변, 단일 역분개, 재기표 revision 무결성을 DB 제약으로 보강했습니다.
* 역할 권한, CSRF, 감사로그, 문서 정의 오류 응답을 적용했습니다.

## 4. 테스트 방법

1. `gradlew clean build` 성공 — 1,016 tests, 0 failures
2. 역분개·재기표 통합 테스트로 차대변 역전, 원자성, 중복 방지, 실패 롤백 검증
3. 컨트롤러 및 기존 원장·공통 예외 회귀 테스트 통과

## 5. DB / Flyway 변경

* [ ] DB 변경 없음
* [x] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [x] 기존 데이터에 영향이 있을 수 있음

### 추가한 마이그레이션 파일

* `V28__journal_correction_group.sql`

기존 원장 행은 변경하지 않습니다. 이미 정정그룹 값이 있는 환경은 추론 이관 대신 마이그레이션을 중단하도록 보호했습니다.

## 6. 리뷰 요구사항

* 정정 트랜잭션의 원자성과 DB 제약 조합
* 역분개 API 권한·CSRF·오류 매핑
* 감사로그의 변경 전후 금액 기록

## 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드를 작성했습니다.
* [x] 기존 기능 회귀 테스트를 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 포함하지 않았습니다.
* [x] 기존 Flyway 파일을 수정하지 않았습니다.
* [x] 불필요한 로그와 디버깅 코드를 제거했습니다.

## 8. 화면 변경

* 없음

## 9. 참고 사항

* API는 역분개만 노출하며 재기표는 내부 Service 계약으로 제공합니다.
