### PR TITLE
[Feat] 차익거래 검증 카드 필터링 기능 추가

### DIFF
--- a/src/main/java/com/susukkang/fgc/arbitrage/mapper/ArbitrageMapper.java
+++ b/src/main/java/com/susukkang/fgc/arbitrage/mapper/ArbitrageMapper.java
@@ -27,6 +27,10 @@ public interface ArbitrageMapper {
     ArbitrageCheckSummary arbitrageCheckSummary(
             @Param("condition") ArbitrageCheckSearchCondition condition);
 
+    // 검색 조건에 해당하는 차익거래 검증 결과의 전체 건수를 조회한다.
+    long countByCondition(
+            @Param("condition") ArbitrageCheckSearchCondition condition);
+
     // 계약과 기준일에 해당하는 계약 정보 및 최신 금융 스냅샷을 조회한다
     ArbitrageCalculationSource selectCalculationSource(
             @Param("contractId") Long contractId,

--- a/src/main/java/com/susukkang/fgc/arbitrage/service/ArbitrageService.java
+++ b/src/main/java/com/susukkang/fgc/arbitrage/service/ArbitrageService.java
@@ -86,16 +86,20 @@ public class ArbitrageService {
         // 검색 조건에 해당하는 차익거래 검증 결과 목록 조회
         List<ArbitrageCheckView> arbitrageCheckList =
                 arbitrageMapper.selectByCondition(condition, offset, size);
-        // 검색 조건에 해당하는 판정별 요약 건수 조회
-        ArbitrageCheckSummary summary = arbitrageMapper.arbitrageCheckSummary(condition);
+        // 상태 필터와 무관하게 현재 조회 범위의 판정 분포를 카드에 유지한다.
+        ArbitrageCheckSearchCondition summaryCondition = new ArbitrageCheckSearchCondition(
+                condition.getMonth(), null, condition.getStage(),
+                condition.getInsurerId(), condition.getContractNo());
+        ArbitrageCheckSummary summary = arbitrageMapper.arbitrageCheckSummary(summaryCondition);
         if (summary == null) summary = new ArbitrageCheckSummary();
+        long totalElements = arbitrageMapper.countByCondition(condition);
 
         // 조회 목록을 페이지 응답으로 변환
         PageResponse<ArbitrageCheckView> items = PageResponse.of(
                 arbitrageCheckList,
                 page,
                 size,
-                summary.getTotalArbitrageChecks(),
+                totalElements,
                 "arbitrageCheckId,desc"
         );
 

--- a/src/main/resources/mapper/arbitrage/ArbitrageMapper.xml
+++ b/src/main/resources/mapper/arbitrage/ArbitrageMapper.xml
@@ -98,6 +98,15 @@
         <include refid="arbitrageSearchCondition"/>
     </select>
 
+    <!-- 검색 조건에 해당하는 목록 페이징용 전체 건수를 조회한다. -->
+    <select id="countByCondition" resultType="long">
+        SELECT COUNT(*)
+        FROM arbitrage_check ac
+        JOIN insurance_contract c
+          ON c.contract_id = ac.contract_id
+        <include refid="arbitrageSearchCondition"/>
+    </select>
+
     <!-- 계약과 기준일에 해당하는 계약 정보 및 최신 금융 스냅샷을 조회한다. -->
     <select id="selectCalculationSource"
             resultType="com.susukkang.fgc.arbitrage.dto.ArbitrageCalculationSource">

--- a/src/main/resources/static/js/features/arbitrage/arbitrage-list.js
+++ b/src/main/resources/static/js/features/arbitrage/arbitrage-list.js
@@ -77,6 +77,12 @@
     document.getElementById("summary-clear").textContent = number(summary.clearCount) + "건";
     document.getElementById("summary-candidate").textContent = number(summary.candidateCount) + "건";
     document.getElementById("summary-review").textContent = number(summary.reviewRequiredCount) + "건";
+    document.querySelectorAll("[data-arb-summary-status]").forEach(function (card) {
+      var selected = card.dataset.arbSummaryStatus === controls.status.value;
+      card.setAttribute("aria-pressed", String(selected));
+      card.style.outline = selected ? "2px solid var(--color-primary, #2563eb)" : "";
+      card.style.outlineOffset = selected ? "2px" : "";
+    });
   }
 
   function rowHtml(row) {
@@ -181,6 +187,14 @@
   [controls.month, controls.status, controls.stage, controls.insurerId].forEach(function (control) { control.addEventListener("change", function () { state.page = 1; state.selectedId = null; load(); }); });
   controls.contractNo.addEventListener("keydown", function (event) { if (event.key === "Enter") { event.preventDefault(); state.page = 1; state.selectedId = null; load(); } });
   document.getElementById("f-reset").addEventListener("click", function () { controls.month.value = root.dataset.initialMonth || ""; controls.status.value = ""; controls.stage.value = "GA_TO_FC"; controls.insurerId.value = ""; controls.contractNo.value = ""; state.page = 1; state.selectedId = null; load(); });
+  document.getElementById("summary-cards").addEventListener("click", function (event) {
+    var card = event.target.closest("[data-arb-summary-status]");
+    if (!card) return;
+    controls.status.value = card.dataset.arbSummaryStatus;
+    state.page = 1;
+    state.selectedId = null;
+    load();
+  });
   document.getElementById("list-body").addEventListener("click", function (event) { var row = event.target.closest("tr[data-arbitrage-id]"); if (!row) return; var id = row.dataset.arbitrageId; var current = state.rows.find(function (item) { return String(item.arbitrageCheckId) === id; }); if (current) renderDetail(current); });
   var recheckButton = document.getElementById("arb-recheck-button");
   if (recheckButton) recheckButton.addEventListener("click", function () {

--- a/src/main/resources/templates/arbitrage/list.html
+++ b/src/main/resources/templates/arbitrage/list.html
@@ -90,21 +90,21 @@
   <!-- ② 요약 카드 3장 — 차익거래 조회 API 응답으로 Ajax 렌더링 -->
   <section style="margin-top:16px;display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:10px"
            id="summary-cards">
-    <div class="fgc-kpi fgc-kpi--success">
+    <button type="button" class="fgc-kpi fgc-kpi--success" data-arb-summary-status="CLEAR" aria-pressed="false" style="text-align:left;cursor:pointer">
       <div class="fgc-kpi__label">이상없음</div>
       <div class="fgc-kpi__value" id="summary-clear">—</div>
       <div class="fgc-kpi__sub">초과액이 없습니다</div>
-    </div>
-    <div class="fgc-kpi fgc-kpi--warning">
+    </button>
+    <button type="button" class="fgc-kpi fgc-kpi--warning" data-arb-summary-status="CANDIDATE" aria-pressed="false" style="text-align:left;cursor:pointer">
       <div class="fgc-kpi__label">검토대상</div>
       <div class="fgc-kpi__value" id="summary-candidate">—</div>
       <div class="fgc-kpi__sub">사람의 사유 확인이 필요합니다</div>
-    </div>
-    <div class="fgc-kpi fgc-kpi--closed">
+    </button>
+    <button type="button" class="fgc-kpi fgc-kpi--closed" data-arb-summary-status="REVIEW_REQUIRED" aria-pressed="false" style="text-align:left;cursor:pointer">
       <div class="fgc-kpi__label">자료부족</div>
       <div class="fgc-kpi__value" id="summary-review">—</div>
       <div class="fgc-kpi__sub">자료 보완 후 재확인합니다</div>
-    </div>
+    </button>
   </section>
 
   <div class="fgc-responsive-split" style="margin-top:16px;display:grid;grid-template-columns:1.25fr 1fr;gap:16px" id="arb-grid">

--- a/src/test/java/com/susukkang/fgc/arbitrage/service/ArbitrageServiceTest.java
+++ b/src/test/java/com/susukkang/fgc/arbitrage/service/ArbitrageServiceTest.java
@@ -2,6 +2,8 @@ package com.susukkang.fgc.arbitrage.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.susukkang.fgc.arbitrage.dto.ArbitrageCalculationSource;
+import com.susukkang.fgc.arbitrage.dto.ArbitrageCheckSearchCondition;
+import com.susukkang.fgc.arbitrage.dto.ArbitrageCheckSummary;
 import com.susukkang.fgc.audit.service.AuditLogService;
 import com.susukkang.fgc.arbitrage.dto.ConfirmedCommissionSummary;
 import com.susukkang.fgc.arbitrage.dto.ReArbitrageCheckRequest;
@@ -21,6 +23,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -146,6 +150,30 @@ class ArbitrageServiceTest {
         @SuppressWarnings("unchecked")
         java.util.Map<String, Object> after = (java.util.Map<String, Object>) event.after();
         assertThat(after).containsKeys("validationRunId", "contractId", "resultStatus");
+    }
+
+    @Test
+    void keepsSummaryCountsAcrossStatusCardFiltering() {
+        ArbitrageCheckSearchCondition condition = new ArbitrageCheckSearchCondition(
+                YearMonth.of(2026, 8), ArbitrageCheckStatus.CANDIDATE,
+                PaymentStage.GA_TO_FC, 10L, "C001");
+        ArbitrageCheckSummary summary = new ArbitrageCheckSummary();
+        summary.setClearCount(3);
+        summary.setCandidateCount(2);
+        summary.setReviewRequiredCount(1);
+        given(arbitrageMapper.selectByCondition(condition, 0, 20)).willReturn(List.of());
+        given(arbitrageMapper.arbitrageCheckSummary(any())).willReturn(summary);
+        given(arbitrageMapper.countByCondition(condition)).willReturn(2L);
+
+        var response = arbitrageService.selectByCondition(condition, 1, 20);
+
+        assertThat(response.getSummary().getTotalArbitrageChecks()).isEqualTo(6);
+        assertThat(response.getItems().totalElements()).isEqualTo(2);
+        org.mockito.ArgumentCaptor<ArbitrageCheckSearchCondition> summaryCondition =
+                org.mockito.ArgumentCaptor.forClass(ArbitrageCheckSearchCondition.class);
+        verify(arbitrageMapper).arbitrageCheckSummary(summaryCondition.capture());
+        assertThat(summaryCondition.getValue().getStatus()).isNull();
+        assertThat(summaryCondition.getValue().getMonth()).isEqualTo(condition.getMonth());
     }
 
     /**


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- ARB-W01 차익거래 검증 현황의 상태별 요약 카드를 클릭하면 해당 판정 상태로 목록을 필터링하도록 개선했습니다.
- 카드 클릭 후에도 정상·후보·검토필요 카드의 전체 상태별 건수는 유지됩니다.

## 🔗 2. 관련 이슈

* Closes #

## 🛠 3. 구현 내용

- 정상 / 후보 / 검토필요 요약 카드를 클릭 가능한 버튼으로 변경했습니다.
- 카드 클릭 시 상태 필터, URL 쿼리, 목록 및 페이징을 갱신합니다.
- 선택된 카드를 시각적으로 표시합니다.
- 요약 건수 조회는 상태 필터를 제외하고 수행합니다.
    - 월, 지급단계, 보험회사, 계약번호 조건은 유지합니다.
- 목록 페이징 총건수는 선택한 상태 필터를 적용해 계산합니다.
- 상태 카드 필터 동작을 검증하는 서비스 테스트를 추가했습니다.

## 🧪 4. 테스트 방법

1. 차익거래 검증 현황(ARB-W01)에 접속합니다.
2. 정상 / 후보 / 검토필요 카드 중 하나를 클릭합니다.
3. 목록이 선택한 판정 상태만 표시하는지 확인합니다.
4. 카드의 상태별 전체 건수는 클릭 전과 동일하게 유지되는지 확인합니다.
5. 다른 조회 조건(정산월, 지급단계, 보험회사, 계약번호)을 적용한 뒤 카드 클릭 시 해당 조건 범위의 상태별 건수가 유지되는지 확인합니다.
6. 브라우저 새로고침 후 URL의 `status` 쿼리값에 따라 필터가 복원되는지 확인합니다.

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

- 상태 카드 건수는 상태 필터를 제외한 현재 검색 범위의 전체 분포를 표시합니다.
- 목록 및 페이징 건수만 상태 필터를 적용하는 UX가 적절한지 확인 부탁드립니다.

## ✅ 7. 체크리스트

* [ ] `develop` 최신 내용을 반영했습니다.
* [ ] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [ ] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [ ] 기존 기능에 영향이 없는지 확인했습니다.
* [ ] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 있음 — 차익거래 검증 현황의 상태별 요약 카드 클릭 필터 및 선택 상태 표시

## 💬 9. 참고 사항

- 카드 수치는 `status`를 제외한 동일 검색 조건의 전체 상태별 분포입니다.
- 카드 클릭으로 필터링된 목록의 총건수와 카드의 전체 건수는 의도적으로 다를 수 있습니다.