### PR TITLE
[Fix] VRUN-W02 실행 버튼이 계약수동 실행도 월 통합검증으로 잘못 기동하던 문제 수정

### DIFF
--- a/src/main/java/com/susukkang/fgc/validation/batch/daily/CreateDailyRunTasklet.java
+++ b/src/main/java/com/susukkang/fgc/validation/batch/daily/CreateDailyRunTasklet.java
@@ -1,6 +1,7 @@
 package com.susukkang.fgc.validation.batch.daily;
 
 import com.susukkang.fgc.common.code.ValidationRunStatus;
+import com.susukkang.fgc.common.code.ValidationRunType;
 import com.susukkang.fgc.common.util.DateUtil;
 import com.susukkang.fgc.validation.batch.ValidationRunBatchContext;
 import com.susukkang.fgc.validation.dto.BatchWatermarkRow;
@@ -44,13 +45,15 @@ public class CreateDailyRunTasklet implements Tasklet {
         // "오늘"을 Asia/Seoul 자정 기준으로 구한다 — 서버 타임존이 달라도 배치 기준시는
         // 항상 서울 자정이어야 "매일 02:00 KST"라는 운영 가정과 어긋나지 않는다.
         OffsetDateTime now = OffsetDateTime.now(DateUtil.SEOUL_ZONE);
-        OffsetDateTime dayStart = now.toLocalDate().atStartOfDay(DateUtil.SEOUL_ZONE).toOffsetDateTime();
-        OffsetDateTime dayEnd = dayStart.plusDays(1);
 
-        ValidationRunRow existing = validationRunMapper.findManualContractRunCreatedBetween(dayStart, dayEnd);
-        Long validationRunId = (existing == null)
-                ? createAndStart(params)
-                : reuseOrRecreate(existing, params);
+        // validationRunId가 지정돼 있으면(VRUN-W02의 [실행] 버튼 등 특정 행을 겨냥한 수동 재실행)
+        // "오늘 생성된 아무 MANUAL_CONTRACT 행"을 날짜창으로 다시 찾지 않고 그 행을 그대로 쓴다.
+        // 안 그러면 그 행이 오늘 생성분이 아닐 때 엉뚱한 새 행을 만들려다 전역 UNIQUE 제약에
+        // 걸려 조용히 실패하거나, 오늘 다른 MANUAL_CONTRACT 행이 있으면 그 행이 대신 진행된다.
+        Long requestedValidationRunId = jobParameters.getLong("validationRunId");
+        Long validationRunId = requestedValidationRunId != null
+                ? resumeRequestedRun(requestedValidationRunId, params)
+                : resolveOrCreateTodaysRun(params, now);
 
         // 이 Step 이후로는 changedContractStep을 포함한 모든 뒤 Step이 이 값을 읽는다.
         ValidationRunBatchContext.putValidationRunId(chunkContext, validationRunId);
@@ -70,6 +73,32 @@ public class CreateDailyRunTasklet implements Tasklet {
         DailyBatchContext.putRunStartedAt(chunkContext, now);
 
         return RepeatStatus.FINISHED;
+    }
+
+    private Long resolveOrCreateTodaysRun(MonthlyValidationJobParameters params, OffsetDateTime now) {
+        OffsetDateTime dayStart = now.toLocalDate().atStartOfDay(DateUtil.SEOUL_ZONE).toOffsetDateTime();
+        OffsetDateTime dayEnd = dayStart.plusDays(1);
+        ValidationRunRow existing = validationRunMapper.findManualContractRunCreatedBetween(dayStart, dayEnd);
+        return existing == null ? createAndStart(params) : reuseOrRecreate(existing, params);
+    }
+
+    /**
+     * VRUN-W02의 [실행] 버튼처럼 특정 행을 지정해 호출됐을 때, 그 행이 지금도 수동 재실행
+     * 대상(MANUAL_CONTRACT · CREATED)인지 다시 확인하고 그 행을 그대로 이어받는다. 호출부
+     * (ValidationRunExecuteServiceImpl)가 이미 CREATED를 확인했지만, 비동기 기동 사이의
+     * 경쟁을 여기서 한 번 더 막는다(MonthlyValidationJobTrigger.runOrWrap()과 같은 패턴).
+     */
+    private Long resumeRequestedRun(Long validationRunId, MonthlyValidationJobParameters params) {
+        ValidationRunRow requested = validationRunMapper.findById(validationRunId);
+        if (requested == null
+                || !ValidationRunType.MANUAL_CONTRACT.name().equals(requested.getRunType())
+                || !ValidationRunStatus.CREATED.name().equals(requested.getStatus())) {
+            throw new IllegalStateException("validation_run " + validationRunId
+                    + " 은 수동 재실행 대상이 아닙니다(runType=계약수동·status=CREATED 이어야 함, 실제 status="
+                    + (requested == null ? "삭제됨" : requested.getStatus()) + ")");
+        }
+        lifecycleService.start(requested.getValidationRunId(), params);
+        return requested.getValidationRunId();
     }
 
     private Long createAndStart(MonthlyValidationJobParameters params) {

--- a/src/main/java/com/susukkang/fgc/validation/batch/daily/DailyChangedContractJobTrigger.java
+++ b/src/main/java/com/susukkang/fgc/validation/batch/daily/DailyChangedContractJobTrigger.java
@@ -68,31 +68,38 @@ public class DailyChangedContractJobTrigger {
             return;
         }
         // 스케줄러 스레드는 결과를 기다리는 호출자가 없다 — launch() 안의 로깅으로 충분하다.
-        launch(scheduledTriggeredByUserId, RequestIdContext.generate());
+        // 특정 행을 지정하지 않는다 — CreateDailyRunTasklet이 "오늘" 기준으로 알아서 찾는다.
+        launch(null, scheduledTriggeredByUserId, RequestIdContext.generate());
     }
 
     /**
-     * 운영자가 화면/API에서 재실행을 요청했을 때 호출하는 진입점
+     * 운영자가 화면/API에서 특정 실행(validationRunId)의 재실행을 요청했을 때 호출하는 진입점.
+     * validationRunId를 넘겨야 CreateDailyRunTasklet이 "오늘 생성된 아무 행"이 아니라 요청받은
+     * 그 행을 정확히 이어받는다(코드리뷰 반영 — 이 값 없이 호출하면 오늘 생성분이 아닌 행이거나
+     * 오늘 다른 MANUAL_CONTRACT 행이 이미 있을 때 엉뚱한 행이 진행되거나 조용히 실패할 수 있다).
      */
-    public CompletableFuture<JobExecution> runManual(long triggeredBy, String requestId) {
-        return launch(triggeredBy, requestId);
+    public CompletableFuture<JobExecution> runManual(Long validationRunId, long triggeredBy, String requestId) {
+        return launch(validationRunId, triggeredBy, requestId);
     }
 
-    private CompletableFuture<JobExecution> launch(long triggeredBy, String requestId) {
+    private CompletableFuture<JobExecution> launch(Long validationRunId, long triggeredBy, String requestId) {
         String validationMonth = DateUtil.formatSettlementMonth(
                 DateUtil.nowSeoul().toLocalDate().withDayOfMonth(1));
 
         // runNo: MonthlyValidationJobParameters가 두 Job의 공통 계약이라 형식상 필요하지만,
-        // CreateDailyRunTasklet은 이 값을 쓰지 않는다(하루 1건 판정은 created_at 기준).
-        // 그래서 항상 고정값 1을 채운다 — 실제로 채번되는 run_no는 ValidationRunCreateService가
-        // (validationMonth, runType) 조합으로 별도로 매긴다.
-        JobParameters jobParameters = new JobParametersBuilder()
+        // CreateDailyRunTasklet은 이 값을 쓰지 않는다(하루 1건 판정은 created_at 기준 또는
+        // validationRunId 직접 지정). 그래서 항상 고정값 1을 채운다 — 실제로 채번되는 run_no는
+        // ValidationRunCreateService가 (validationMonth, runType) 조합으로 별도로 매긴다.
+        JobParametersBuilder jobParametersBuilder = new JobParametersBuilder()
                 .addString("validationMonth", validationMonth)
                 .addLong("runNo", 1L)
                 .addString("runType", ValidationRunType.MANUAL_CONTRACT.name())
                 .addLong("triggeredBy", triggeredBy)
-                .addString("requestId", requestId)
-                .toJobParameters();
+                .addString("requestId", requestId);
+        if (validationRunId != null) {
+            jobParametersBuilder.addLong("validationRunId", validationRunId);
+        }
+        JobParameters jobParameters = jobParametersBuilder.toJobParameters();
 
         // whenComplete는 exceptionally와 달리 예외를 다른 값으로 바꿔치기하지 않는다 — 로그만
         // 남기고, 반환된 CompletableFuture는 실패 상태를 그대로 유지해 호출자가 원하면 알 수 있다.

--- a/src/main/java/com/susukkang/fgc/validation/controller/ValidationRunController.java
+++ b/src/main/java/com/susukkang/fgc/validation/controller/ValidationRunController.java
@@ -194,7 +194,8 @@ public class ValidationRunController {
 
     @Operation(
             summary = "검증 실행 기동 (IF-API-48)",
-            description = "CREATED 상태의 실행을 MonthlyValidationJob(IF-BAT-01)으로 비동기 기동한다. "
+            description = "CREATED 상태의 실행을 runType에 따라 비동기로 기동한다 — MONTHLY·PRE_CONFIRM은 "
+                    + "MonthlyValidationJob(IF-BAT-01), MANUAL_CONTRACT는 DailyChangedContractJob(IF-BAT-02)으로 간다. "
                     + "202는 수락의 의미이며 실제 진행은 IF-API-49 폴링으로 본다. "
                     + "1차는 재기동을 지원하지 않는다 — FAILED면 새 실행을 만든다(FUN-045는 2차)."
     )

--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationRunExecuteServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationRunExecuteServiceImpl.java
@@ -46,12 +46,13 @@ public class ValidationRunExecuteServiceImpl implements ValidationRunExecuteServ
 
         // join하지 않는다 — IF-API-48은 202 즉시 반환, 진행은 IF-API-49 폴링이 본다.
         // runType별로 서로 다른 배치를 기동한다 — MANUAL_CONTRACT를 MonthlyValidationJob에
-        // 잘못 태우면 안 된다(#XXX 코드리뷰 반영). DailyChangedContractJobTrigger는 행을 직접
-        // 받지 않고 "오늘의 MANUAL_CONTRACT 실행"을 스스로 조회/재사용하므로(CreateDailyRunTasklet
-        // 이 created_at 기준으로 판정) row.getTriggeredBy()만 넘기면 이 행을 그대로 이어 탄다.
+        // 잘못 태우면 안 된다. validationRunId를 반드시 함께 넘겨야 CreateDailyRunTasklet이
+        // "오늘 생성된 아무 MANUAL_CONTRACT 행"이 아니라 지금 요청받은 이 행을 정확히 이어받는다
+        // (코드리뷰 반영 — 빠뜨리면 이 행이 오늘 생성분이 아닐 때 조용히 실패하거나, 오늘 다른
+        // MANUAL_CONTRACT 행이 있으면 그 행이 대신 진행될 수 있었다).
         try {
             if (ValidationRunType.MANUAL_CONTRACT.name().equals(row.getRunType())) {
-                dailyChangedContractJobTrigger.runManual(row.getTriggeredBy(), requestId);
+                dailyChangedContractJobTrigger.runManual(row.getValidationRunId(), row.getTriggeredBy(), requestId);
             } else {
                 monthlyValidationJobTrigger.launch(row, requestId);
             }

--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationRunExecuteServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationRunExecuteServiceImpl.java
@@ -1,9 +1,11 @@
 package com.susukkang.fgc.validation.service;
 
 import com.susukkang.fgc.common.code.ValidationRunStatus;
+import com.susukkang.fgc.common.code.ValidationRunType;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.common.exception.FgcErrorCode;
 import com.susukkang.fgc.validation.batch.MonthlyValidationJobTrigger;
+import com.susukkang.fgc.validation.batch.daily.DailyChangedContractJobTrigger;
 import com.susukkang.fgc.validation.dto.ValidationRunRow;
 import com.susukkang.fgc.validation.mapper.ValidationRunMapper;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ public class ValidationRunExecuteServiceImpl implements ValidationRunExecuteServ
 
     private final ValidationRunMapper validationRunMapper;
     private final MonthlyValidationJobTrigger monthlyValidationJobTrigger;
+    private final DailyChangedContractJobTrigger dailyChangedContractJobTrigger;
 
     @Override
     public ValidationRunRow execute(Long validationRunId, Long executedBy, String requestId) {
@@ -42,8 +45,16 @@ public class ValidationRunExecuteServiceImpl implements ValidationRunExecuteServ
                 validationRunId, executedBy, requestId);
 
         // join하지 않는다 — IF-API-48은 202 즉시 반환, 진행은 IF-API-49 폴링이 본다.
+        // runType별로 서로 다른 배치를 기동한다 — MANUAL_CONTRACT를 MonthlyValidationJob에
+        // 잘못 태우면 안 된다(#XXX 코드리뷰 반영). DailyChangedContractJobTrigger는 행을 직접
+        // 받지 않고 "오늘의 MANUAL_CONTRACT 실행"을 스스로 조회/재사용하므로(CreateDailyRunTasklet
+        // 이 created_at 기준으로 판정) row.getTriggeredBy()만 넘기면 이 행을 그대로 이어 탄다.
         try {
-            monthlyValidationJobTrigger.launch(row, requestId);
+            if (ValidationRunType.MANUAL_CONTRACT.name().equals(row.getRunType())) {
+                dailyChangedContractJobTrigger.runManual(row.getTriggeredBy(), requestId);
+            } else {
+                monthlyValidationJobTrigger.launch(row, requestId);
+            }
         } catch (java.util.concurrent.RejectedExecutionException e) {
             // 트리거 대기열 포화(AbortPolicy) — 500 대신 재시도 안내가 있는 409 로 돌려준다.
             // VRUN_005("다시 조회 후 시도하세요")가 기존 코드 중 재시도 의미에 가장 가깝다.

--- a/src/test/java/com/susukkang/fgc/validation/batch/daily/CreateDailyRunTaskletTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/batch/daily/CreateDailyRunTaskletTest.java
@@ -66,27 +66,41 @@ class CreateDailyRunTaskletTest {
         BatchWatermarkRow watermark = new BatchWatermarkRow();
         watermark.setJobName(DailyChangedContractJobNames.JOB_NAME);
         watermark.setLastProcessedAt(seededWatermark);
-        given(batchWatermarkMapper.findByJobNameAndStepName(
-                DailyChangedContractJobNames.JOB_NAME, DailyChangedContractJobNames.CHANGED_CONTRACT_STEP_NAME))
-                .willReturn(watermark);
+        // lenient — 요청된 validationRunId가 재실행 대상이 아니어서 조기 실패하는 테스트들은
+        // 이 지점까지 도달하지 않아 스텁이 안 쓰인다.
+        org.mockito.Mockito.lenient().when(batchWatermarkMapper.findByJobNameAndStepName(
+                        DailyChangedContractJobNames.JOB_NAME, DailyChangedContractJobNames.CHANGED_CONTRACT_STEP_NAME))
+                .thenReturn(watermark);
     }
 
     private ChunkContext newChunkContext() {
-        JobParameters parameters = new JobParametersBuilder()
+        return newChunkContext(null);
+    }
+
+    private ChunkContext newChunkContext(Long requestedValidationRunId) {
+        JobParametersBuilder builder = new JobParametersBuilder()
                 .addString("validationMonth", "2026-08")
                 .addLong("runNo", 1L)
                 .addString("runType", "MANUAL_CONTRACT")
                 .addLong("triggeredBy", 1L)
-                .addString("requestId", "req-1")
-                .toJobParameters();
-        JobExecution jobExecution = new JobExecution(new JobInstance(1L, DailyChangedContractJobNames.JOB_NAME), parameters);
+                .addString("requestId", "req-1");
+        if (requestedValidationRunId != null) {
+            builder.addLong("validationRunId", requestedValidationRunId);
+        }
+        JobExecution jobExecution = new JobExecution(
+                new JobInstance(1L, DailyChangedContractJobNames.JOB_NAME), builder.toJobParameters());
         StepExecution stepExecution = new StepExecution("createDailyRunStep", jobExecution);
         return new ChunkContext(new StepContext(stepExecution));
     }
 
     private ValidationRunRow runWithStatus(ValidationRunStatus status) {
+        return runWithStatus(status, "MANUAL_CONTRACT");
+    }
+
+    private ValidationRunRow runWithStatus(ValidationRunStatus status, String runType) {
         ValidationRunRow row = new ValidationRunRow();
         row.setValidationRunId(42L);
+        row.setRunType(runType);
         row.setStatus(status.name());
         return row;
     }
@@ -178,6 +192,56 @@ class CreateDailyRunTaskletTest {
         verify(lifecycleService, never()).start(eq(42L), any());
         verify(validationRunTransitionService, never()).transition(anyLong(), any());
         assertThat(ValidationRunBatchContext.getValidationRunId(chunkContext)).isEqualTo(77L);
+    }
+
+    /** validationRunId가 지정되면 날짜창 조회 없이 그 행을 바로 이어받는다(코드리뷰 반영). */
+    @Test
+    void requestedValidationRunIdResumesThatRowDirectly() {
+        given(validationRunMapper.findById(42L)).willReturn(runWithStatus(ValidationRunStatus.CREATED));
+
+        ChunkContext chunkContext = newChunkContext(42L);
+        RepeatStatus result = tasklet.execute(null, chunkContext);
+
+        assertThat(result).isEqualTo(RepeatStatus.FINISHED);
+        verify(lifecycleService).start(eq(42L), any());
+        verify(validationRunMapper, never()).findManualContractRunCreatedBetween(any(), any());
+        assertThat(ValidationRunBatchContext.getValidationRunId(chunkContext)).isEqualTo(42L);
+    }
+
+    /** 지정된 행이 오늘 생성분이 아니어도(=날짜창 조회로는 못 찾는 행이어도) 그대로 이어받는다. */
+    @Test
+    void requestedValidationRunIdResumesRowNotCreatedToday() {
+        given(validationRunMapper.findById(42L)).willReturn(runWithStatus(ValidationRunStatus.CREATED));
+        // 날짜창 조회는 아예 스텁하지 않는다 — 호출되면 Mockito가 null을 돌려주므로
+        // resolveOrCreateTodaysRun 경로로 잘못 빠지면 이 테스트가 실패한다(create 미스텁이라 NPE).
+
+        tasklet.execute(null, newChunkContext(42L));
+
+        verify(lifecycleService).start(eq(42L), any());
+        verify(validationRunCreateService, never()).create(any());
+    }
+
+    /** 지정된 행이 이미 다른 상태로 넘어갔으면(경쟁 등) 조용히 다른 행을 만들지 않고 명확히 실패한다. */
+    @Test
+    void requestedValidationRunIdThatIsNoLongerCreatedFailsLoudly() {
+        given(validationRunMapper.findById(42L)).willReturn(runWithStatus(ValidationRunStatus.RUNNING));
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> tasklet.execute(null, newChunkContext(42L)))
+                .isInstanceOf(IllegalStateException.class);
+
+        verify(lifecycleService, never()).start(anyLong(), any());
+        verify(validationRunCreateService, never()).create(any());
+    }
+
+    /** 지정된 행이 MANUAL_CONTRACT가 아니면(운영 실수로 잘못된 id가 넘어온 경우) 명확히 실패한다. */
+    @Test
+    void requestedValidationRunIdWithWrongRunTypeFailsLoudly() {
+        given(validationRunMapper.findById(42L)).willReturn(runWithStatus(ValidationRunStatus.CREATED, "MONTHLY"));
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> tasklet.execute(null, newChunkContext(42L)))
+                .isInstanceOf(IllegalStateException.class);
+
+        verify(lifecycleService, never()).start(anyLong(), any());
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/validation/service/ValidationRunExecuteServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ValidationRunExecuteServiceImplTest.java
@@ -106,7 +106,7 @@ class ValidationRunExecuteServiceImplTest {
         assertThat(result).isSameAs(created);
         // JobParameters는 트리거가 행 값으로 만든다 — 실행자(9L)가 아닌 행이 그대로 전달되는지
         verify(monthlyValidationJobTrigger).launch(created, "req-1");
-        verify(dailyChangedContractJobTrigger, never()).runManual(anyLong(), anyString());
+        verify(dailyChangedContractJobTrigger, never()).runManual(any(), anyLong(), anyString());
     }
 
     /** MANUAL_CONTRACT는 MonthlyValidationJob이 아니라 DailyChangedContractJob으로 가야 한다(코드리뷰 반영). */
@@ -118,9 +118,9 @@ class ValidationRunExecuteServiceImplTest {
         ValidationRunRow result = service.execute(100L, 9L, "req-1");
 
         assertThat(result).isSameAs(created);
-        // 행의 원래 생성자(triggeredBy=1L)를 그대로 넘겨야 오늘의 같은 행을 재사용한다 —
-        // 실행 버튼을 누른 사용자(9L)가 아니다.
-        verify(dailyChangedContractJobTrigger).runManual(1L, "req-1");
+        // validationRunId(100L)를 그대로 넘겨야 그 행을 정확히 이어받는다. triggeredBy도
+        // 행의 원래 생성자(1L)를 넘겨야 한다 — 실행 버튼을 누른 사용자(9L)가 아니다.
+        verify(dailyChangedContractJobTrigger).runManual(100L, 1L, "req-1");
         verify(monthlyValidationJobTrigger, never()).launch(any(), anyString());
     }
 

--- a/src/test/java/com/susukkang/fgc/validation/service/ValidationRunExecuteServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ValidationRunExecuteServiceImplTest.java
@@ -3,6 +3,7 @@ package com.susukkang.fgc.validation.service;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.common.exception.FgcErrorCode;
 import com.susukkang.fgc.validation.batch.MonthlyValidationJobTrigger;
+import com.susukkang.fgc.validation.batch.daily.DailyChangedContractJobTrigger;
 import com.susukkang.fgc.validation.dto.ValidationRunRow;
 import com.susukkang.fgc.validation.mapper.ValidationRunMapper;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ import java.time.LocalDate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -36,15 +38,22 @@ class ValidationRunExecuteServiceImplTest {
     @Mock
     private MonthlyValidationJobTrigger monthlyValidationJobTrigger;
 
+    @Mock
+    private DailyChangedContractJobTrigger dailyChangedContractJobTrigger;
+
     @InjectMocks
     private ValidationRunExecuteServiceImpl service;
 
     private ValidationRunRow row(String status) {
+        return row(status, "MONTHLY");
+    }
+
+    private ValidationRunRow row(String status, String runType) {
         ValidationRunRow row = new ValidationRunRow();
         row.setValidationRunId(100L);
         row.setValidationMonth(LocalDate.of(2026, 7, 1));
         row.setRunNo(1);
-        row.setRunType("MONTHLY");
+        row.setRunType(runType);
         row.setStatus(status);
         row.setCurrentStep(0);
         row.setTriggeredBy(1L);
@@ -97,6 +106,22 @@ class ValidationRunExecuteServiceImplTest {
         assertThat(result).isSameAs(created);
         // JobParameters는 트리거가 행 값으로 만든다 — 실행자(9L)가 아닌 행이 그대로 전달되는지
         verify(monthlyValidationJobTrigger).launch(created, "req-1");
+        verify(dailyChangedContractJobTrigger, never()).runManual(anyLong(), anyString());
+    }
+
+    /** MANUAL_CONTRACT는 MonthlyValidationJob이 아니라 DailyChangedContractJob으로 가야 한다(코드리뷰 반영). */
+    @Test
+    void launchesManualContractRunViaDailyTrigger() {
+        ValidationRunRow created = row("CREATED", "MANUAL_CONTRACT");
+        given(validationRunMapper.findById(100L)).willReturn(created);
+
+        ValidationRunRow result = service.execute(100L, 9L, "req-1");
+
+        assertThat(result).isSameAs(created);
+        // 행의 원래 생성자(triggeredBy=1L)를 그대로 넘겨야 오늘의 같은 행을 재사용한다 —
+        // 실행 버튼을 누른 사용자(9L)가 아니다.
+        verify(dailyChangedContractJobTrigger).runManual(1L, "req-1");
+        verify(monthlyValidationJobTrigger, never()).launch(any(), anyString());
     }
 
     /** 트리거 대기열 포화(AbortPolicy) — 500 이 아니라 재시도 안내가 있는 VRUN_005(409)로 매핑된다. */


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

VRUN-W02의 [실행] 버튼(IF-API-48)이 `validation_run.run_type`을 확인하지 않고 항상 `MonthlyValidationJob`만 기동하던 버그를 수정했습니다. `MANUAL_CONTRACT`(계약수동) 실행은 이제 `DailyChangedContractJob`으로 정상 기동됩니다.

## 🔗 2. 관련 이슈

* Closes #235

## 🛠 3. 구현 내용

* `ValidationRunExecuteServiceImpl`에 `DailyChangedContractJobTrigger`를 주입
* `execute()`에서 `row.getRunType()`이 `MANUAL_CONTRACT`면 `dailyChangedContractJobTrigger.runManual(row.getTriggeredBy(), requestId)`를 호출, 그 외(`MONTHLY`·`PRE_CONFIRM`)는 기존대로 `monthlyValidationJobTrigger.launch(row, requestId)` 호출
* `triggeredBy`는 실행 버튼을 누른 사용자가 아니라 **행의 원래 생성자**(`row.getTriggeredBy()`)를 그대로 전달

## 🧪 4. 테스트 방법

1. `ValidationRunExecuteServiceImplTest`에 `launchesManualContractRunViaDailyTrigger()` 케이스 추가 — `MANUAL_CONTRACT` 실행 시 `DailyChangedContractJobTrigger.runManual`이 정확히 호출되고 `MonthlyValidationJobTrigger`는 호출되지 않는지 검증
* 기존 `launchesCreatedRunAndReturnsRow()`에도 `dailyChangedContractJobTrigger`가 호출되지 않는지 단언 추가(회귀 방지)
2. `./gradlew test --tests "com.susukkang.fgc.validation.*"` 전체 통과 확인

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* `DailyChangedContractJobTrigger.runManual()`은 특정 `validationRunId`를 받지 않고 "오늘 생성된 MANUAL_CONTRACT 실행"을 자체적으로 재조회합니다(`CreateDailyRunTasklet`이 `created_at` 기준 판정). VRUN-W01에서 만든 행이 오늘 생성된 것이라면 정상적으로 같은 행을 이어받지만, 이 설계가 의도대로인지 재확인 부탁드립니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음(백엔드 라우팅 버그 수정)

## 💬 9. 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 수동 계약 검증 요청 시 지정한 검증 실행을 일일 변경 계약 배치로 재개할 수 있습니다.
  * 배치 실행에 검증 실행 ID, 요청자 정보, 요청 ID가 함께 전달됩니다.
  * 요청된 검증 실행의 유형과 상태를 확인한 후 안전하게 실행합니다.

* **버그 수정**
  * 날짜 범위와 관계없이 지정된 수동 검증 실행을 정확히 재개합니다.
  * 월간 및 사전 확인 검증은 기존 실행 방식대로 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->