### PR TITLE
[Feat] 스케줄 조회 API 한글 라벨 필드 제공

### DIFF
--- a/docs/05_인터페이스정의서_v2_0.md
+++ b/docs/05_인터페이스정의서_v2_0.md
@@ -310,9 +310,9 @@ DB가 던진 제약 이름(`uq_contract_no` 등)을 오류코드로 바꾸는 �
 | IF-API-24 | TRAN-W02 | `POST /api/v1/transactions/{id}/precheck` | — | 저장 없이 계산만 → `capPreview[]`(게이지 2개), `blockers[]` | SETTLEMENT | **Ajax** | FUN-033 |
 | IF-API-25 | TRAN-W02 | `POST /api/v1/transactions/{id}/confirm` **(확정 전용)** | `Idempotency-Key` | `status:"CONFIRMED"`, `capCheckIds[]`, `journalHeaderId` / 실패 시 3장 오류 | SETTLEMENT | **Ajax** | FUN-065·031·033·034 |
 | IF-API-26 | TRAN-W02 | `POST /api/v1/transactions/{id}/cancel` | `reason`(필수) | `status:"CANCELLED"` | SETTLEMENT | Ajax | FUN-065 |
-| IF-API-27 | SCHE-W01 | `GET /api/v1/schedules?contractNo=&stage=&regime=&purpose=&status=` | 검색조건 | 헤더 목록 | 전체 | MPA | FUN-036·039·040 |
-| IF-API-28 | SCHE-W02 | `GET /api/v1/schedules/{id}` | — | 헤더 + 회차별 라인 + `ruleRef`(근거) | 전체 | MPA | FUN-036·039 |
-| IF-API-28A | SCHE-W02 | `GET /api/v1/schedules/{id}/versions` | — | 같은 계약·지급단계의 스케줄 버전 목록(최신순) | 전체 | Ajax | FUN-039 |
+| IF-API-27 | SCHE-W01 | `GET /api/v1/schedules?contractNo=&stage=&regime=&purpose=&status=` | 검색조건 | 헤더 목록(`paymentStage`, `scheduleRegime`, `schedulePurpose`, `status` 코드와 각 `*Label`) | 전체 | MPA | FUN-036·039·040 |
+| IF-API-28 | SCHE-W02 | `GET /api/v1/schedules/{id}` | — | 코드·`*Label`을 포함한 헤더 + 회차별 라인 + `ruleRef`(근거) | 전체 | MPA | FUN-036·039 |
+| IF-API-28A | SCHE-W02 | `GET /api/v1/schedules/{id}/versions` | — | 같은 계약·지급단계의 코드·`*Label` 포함 스케줄 버전 목록(최신순) | 전체 | Ajax | FUN-039 |
 | IF-API-29 | SCHE-W02 | `POST /api/v1/schedules/{id}/regenerate` | `reason`(필수) | 새 `scheduleHeaderId`, `versionNo` | SETTLEMENT | Ajax | FUN-039·040 |
 | IF-API-29A | SCHE-W02 | `POST /api/v1/schedules/{id}/confirm` | — | 확정된 헤더(`header.status:"CONFIRMED"`) + 회차별 라인(`lines[].lineStatus`는 실제 상태 유지) | SETTLEMENT | Ajax | FUN-039·040 |
 | IF-API-30 | CAP-W01 | `GET /api/v1/cap-checks?month=&stage=&status=&insurerId=&contractNo=&orgId=&page=1&size=20` | 검색조건 + `page`(1-base, 기본 1), `size`(기본 20·최대 100) | `summary{normal,warning,violation,reviewRequired}`(`stage` 적용·`status` 제외) + 전체 검색범위의 `stageSummary[2]`(`stage`·`status` 제외, `violationCount`, `warningCount`, `reviewRequiredCount`) + `agentSummary[]`(GA→설계사만, `stage`·`status` 제외, `violationCount`, `warningCount`, `reviewRequiredCount`, `worstContractNo`, `worstUsagePct`, 모니터링 전용) + 페이징 `content[]`, `page`, `size`, `totalElements`, `totalPages`, `sort` | 전체 | MPA(게이지만 Ajax) | FUN-030·032·034 |

--- a/src/main/java/com/susukkang/fgc/common/code/ScheduleHeaderStatus.java
+++ b/src/main/java/com/susukkang/fgc/common/code/ScheduleHeaderStatus.java
@@ -9,11 +9,21 @@ package com.susukkang.fgc.common.code;
  * @since 2026-08-10
  */
 public enum ScheduleHeaderStatus {
-    PLANNED,  //예정 계약이 생성되고 막 생성 된 상태
-    CONFIRMED,//확정 정산 담당자가 확정을 누를 경우
-    MATCHED,  //대사일치 실제 수수료 지급과 명세가 같은 경우
-    ADJUSTED, //조정완료 실제 수수료 지급과 명세가 다른 경우
-    HOLD,     //보류 계약이 미납된 경우
-    CANCELLED,//취소 계약이 해지된 경우
-    RESTARTED //재개 계약이 부활한 경우
+    PLANNED("예정"),
+    CONFIRMED("확정"),
+    MATCHED("대사일치"),
+    ADJUSTED("조정완료"),
+    HOLD("보류"),
+    CANCELLED("취소"),
+    RESTARTED("재개");
+
+    private final String label;
+
+    ScheduleHeaderStatus(String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
 }

--- a/src/main/java/com/susukkang/fgc/schedule/code/SchedulePurpose.java
+++ b/src/main/java/com/susukkang/fgc/schedule/code/SchedulePurpose.java
@@ -1,7 +1,28 @@
 package com.susukkang.fgc.schedule.code;
 
 public enum SchedulePurpose {
-    OPERATIONAL, // 운영
-    COMPARISON,  // 비교
-    SIMULATION   // 시뮬레이션
+    OPERATIONAL("운영"),
+    COMPARISON("비교"),
+    SIMULATION("시뮬레이션");
+
+    private final String label;
+
+    SchedulePurpose(String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public static String labelOf(String code) {
+        if (code == null || code.isBlank()) {
+            return null;
+        }
+        try {
+            return valueOf(code).label();
+        } catch (IllegalArgumentException exception) {
+            return code;
+        }
+    }
 }

--- a/src/main/java/com/susukkang/fgc/schedule/code/ScheduleRegime.java
+++ b/src/main/java/com/susukkang/fgc/schedule/code/ScheduleRegime.java
@@ -1,8 +1,29 @@
 package com.susukkang.fgc.schedule.code;
 
 public enum ScheduleRegime {
-    CURRENT,            //현행
-    FOUR_YEAR_2027,     //4년 분급
-    SEVEN_YEAR_2029,    //7년 분급
-    TM_SPECIAL          //TM 특례
+    CURRENT("현행"),
+    FOUR_YEAR_2027("4년 분급(2027)"),
+    SEVEN_YEAR_2029("7년 분급(2029)"),
+    TM_SPECIAL("TM 특례");
+
+    private final String label;
+
+    ScheduleRegime(String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public static String labelOf(String code) {
+        if (code == null || code.isBlank()) {
+            return null;
+        }
+        try {
+            return valueOf(code).label();
+        } catch (IllegalArgumentException exception) {
+            return code;
+        }
+    }
 }

--- a/src/main/java/com/susukkang/fgc/schedule/dto/ScheduleHeaderResponse.java
+++ b/src/main/java/com/susukkang/fgc/schedule/dto/ScheduleHeaderResponse.java
@@ -2,6 +2,8 @@ package com.susukkang.fgc.schedule.dto;
 
 import com.susukkang.fgc.common.code.PaymentStage;
 import com.susukkang.fgc.common.code.ScheduleHeaderStatus;
+import com.susukkang.fgc.schedule.code.SchedulePurpose;
+import com.susukkang.fgc.schedule.code.ScheduleRegime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,10 +27,30 @@ public class ScheduleHeaderResponse {
     private Long scheduleHeaderId; // 스케줄 헤더 ID
     private String contractNo; // 화면에 표시할 계약 번호
     private PaymentStage paymentStage; // 지급 단계
+
+    public String getPaymentStageLabel() {
+        return paymentStage == null ? null : paymentStage.label();
+    }
+
     private String scheduleRegime; // 적용 체계
+
+    public String getScheduleRegimeLabel() {
+        return ScheduleRegime.labelOf(scheduleRegime);
+    }
+
     private String schedulePurpose; // 스케줄 용도
+
+    public String getSchedulePurposeLabel() {
+        return SchedulePurpose.labelOf(schedulePurpose);
+    }
+
     private Integer scheduleVersionNo; // 스케줄 버전
     private ScheduleHeaderStatus status; // 스케줄 상태
+
+    public String getStatusLabel() {
+        return status == null ? null : status.label();
+    }
+
     private Boolean activeYn; // 현재 사용 여부
     private Integer lineCount; // 전체 회차 수
     private BigDecimal expectedTotal; // 예상 총액

--- a/src/main/resources/static/js/features/schedule/schedule-detail.js
+++ b/src/main/resources/static/js/features/schedule/schedule-detail.js
@@ -9,6 +9,27 @@
   var regenerateButton = document.getElementById("btn-regenerate");
   var regenerateReason = document.getElementById("regenerate-reason");
   var regenerateSubmit = document.getElementById("btn-regenerate-submit");
+  var PAYMENT_STAGE_LABELS = { INSURER_TO_GA: "원수사→GA", GA_TO_FC: "GA→설계사" };
+  var SCHEDULE_REGIME_LABELS = {
+    CURRENT: "현행",
+    FOUR_YEAR_2027: "4년 분급(2027)",
+    SEVEN_YEAR_2029: "7년 분급(2029)",
+    TM_SPECIAL: "TM 특례"
+  };
+  var SCHEDULE_PURPOSE_LABELS = {
+    OPERATIONAL: "운영",
+    COMPARISON: "비교",
+    SIMULATION: "시뮬레이션"
+  };
+  var SCHEDULE_STATUS_LABELS = {
+    PLANNED: "예정",
+    CONFIRMED: "확정",
+    MATCHED: "대사일치",
+    ADJUSTED: "조정완료",
+    HOLD: "보류",
+    CANCELLED: "취소",
+    RESTARTED: "재개"
+  };
 
   if (!main || !lineBody || !apiClient) return;
 
@@ -54,11 +75,11 @@
     setText("hdr-id", "schedule_header #" + value(header.scheduleHeaderId));
     setText("hdr-contract", header.contractNo);
     setText("hdr-product", "—");
-    setText("hdr-stage", label({ INSURER_TO_GA: "원수사→GA", GA_TO_FC: "GA→설계사" }, header.paymentStage));
-    setText("hdr-regime", label({ CURRENT: "현행", FOUR_YEAR: "4년 분급", SEVEN_YEAR: "7년 분급" }, header.scheduleRegime));
-    setText("hdr-purpose", label({ OPERATIONAL: "운영", SIMULATION: "비교·시뮬레이션" }, header.schedulePurpose));
+    setText("hdr-stage", responseLabel(header.paymentStageLabel, PAYMENT_STAGE_LABELS, header.paymentStage));
+    setText("hdr-regime", responseLabel(header.scheduleRegimeLabel, SCHEDULE_REGIME_LABELS, header.scheduleRegime));
+    setText("hdr-purpose", responseLabel(header.schedulePurposeLabel, SCHEDULE_PURPOSE_LABELS, header.schedulePurpose));
     setText("hdr-version", header.scheduleVersionNo == null ? "—" : "v" + header.scheduleVersionNo);
-    setText("hdr-status", label({ PLANNED: "예정", CONFIRMED: "확정", MATCHED: "대사일치", ADJUSTED: "조정" }, header.status));
+    setText("hdr-status", responseLabel(header.statusLabel, SCHEDULE_STATUS_LABELS, header.status));
     setText("hdr-active", header.activeYn === true ? "사용중" : "미사용");
     setText("hdr-policy", header.policyVersionLabel);
     setText("hdr-reason", join(header.generationReason, formatDateTime(header.generatedAt)));
@@ -208,10 +229,7 @@
       versionCell.appendChild(link);
       row.appendChild(versionCell);
 
-      appendCell(row, label({
-        PLANNED: "예정", CONFIRMED: "확정", MATCHED: "매칭", ADJUSTED: "조정",
-        HOLD: "보류", CANCELLED: "취소", RESTARTED: "재개"
-      }, version.status));
+      appendCell(row, responseLabel(version.statusLabel, SCHEDULE_STATUS_LABELS, version.status));
       appendCell(row, version.activeYn === true ? "사용중" : "미사용");
       appendCell(row, version.policyVersionLabel);
       appendCell(row, version.generationReason);
@@ -300,6 +318,12 @@
 
   function label(labels, code) {
     return labels[code] || value(code);
+  }
+
+  function responseLabel(serverLabel, labels, code) {
+    return typeof serverLabel === "string" && serverLabel.trim()
+      ? serverLabel
+      : label(labels, code);
   }
 
   function join(first, second) {

--- a/src/main/resources/static/js/features/schedule/schedule-list.js
+++ b/src/main/resources/static/js/features/schedule/schedule-list.js
@@ -15,8 +15,13 @@
     return Math.min(positivePage(requestedPage), lastPage);
   }
 
+  function responseLabel(serverLabel, labels, code) {
+    if (typeof serverLabel === "string" && serverLabel.trim()) return serverLabel;
+    return labels[code] || code || "-";
+  }
+
   if (typeof module === "object" && module.exports) {
-    module.exports = { normalizePage: normalizePage };
+    module.exports = { normalizePage: normalizePage, responseLabel: responseLabel };
     return;
   }
 
@@ -217,10 +222,6 @@
     makeStateRow(wrapper, "schedule-error-state");
   }
 
-  function label(group, value) {
-    return LABELS[group][value] || value || "-";
-  }
-
   function isTrue(value) {
     return value === true || value === "true";
   }
@@ -288,11 +289,11 @@
       }
 
       row.appendChild(contractCell);
-      row.appendChild(textCell(label("paymentStage", schedule.paymentStage)));
-      row.appendChild(badgeCell(label("scheduleRegime", schedule.scheduleRegime), "status-badge-neutral"));
-      row.appendChild(badgeCell(label("schedulePurpose", schedule.schedulePurpose), schedule.schedulePurpose === "OPERATIONAL" ? "status-badge-info" : "status-badge-neutral"));
+      row.appendChild(textCell(responseLabel(schedule.paymentStageLabel, LABELS.paymentStage, schedule.paymentStage)));
+      row.appendChild(badgeCell(responseLabel(schedule.scheduleRegimeLabel, LABELS.scheduleRegime, schedule.scheduleRegime), "status-badge-neutral"));
+      row.appendChild(badgeCell(responseLabel(schedule.schedulePurposeLabel, LABELS.schedulePurpose, schedule.schedulePurpose), schedule.schedulePurpose === "OPERATIONAL" ? "status-badge-info" : "status-badge-neutral"));
       row.appendChild(textCell(schedule.scheduleVersionNo === null || schedule.scheduleVersionNo === undefined ? "-" : "v" + schedule.scheduleVersionNo, "is-center tabular-nums"));
-      row.appendChild(badgeCell(label("scheduleStatus", schedule.status), STATUS_TONES[schedule.status] || "status-badge-neutral"));
+      row.appendChild(badgeCell(responseLabel(schedule.statusLabel, LABELS.scheduleStatus, schedule.status), STATUS_TONES[schedule.status] || "status-badge-neutral"));
       row.appendChild(badgeCell(isTrue(schedule.activeYn) ? "사용중" : "미사용", isTrue(schedule.activeYn) ? "status-badge-success" : "status-badge-neutral"));
       row.appendChild(textCell(formatInteger(schedule.lineCount), "is-number tabular-nums"));
       row.appendChild(textCell(formatWon(schedule.expectedTotal), "is-number tabular-nums"));

--- a/src/test/java/com/susukkang/fgc/schedule/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/schedule/controller/ScheduleControllerTest.java
@@ -1,9 +1,12 @@
 package com.susukkang.fgc.schedule.controller;
 
 import com.susukkang.fgc.common.config.SecurityConfig;
+import com.susukkang.fgc.common.code.PaymentStage;
+import com.susukkang.fgc.common.code.ScheduleHeaderStatus;
 import com.susukkang.fgc.common.exception.ConstraintErrorCodeResolver;
 import com.susukkang.fgc.common.exception.FgcMessageResolver;
 import com.susukkang.fgc.common.exception.GlobalExceptionHandler;
+import com.susukkang.fgc.common.web.PageResponse;
 import com.susukkang.fgc.schedule.dto.ScheduleRegenResponse;
 import com.susukkang.fgc.schedule.dto.ScheduleDetailResponse;
 import com.susukkang.fgc.schedule.dto.ScheduleHeaderResponse;
@@ -19,6 +22,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -37,11 +42,51 @@ class ScheduleControllerTest {
     private ScheduleService scheduleService;
 
     @Test
+    void returnsKoreanLabelsWithScheduleListCodes() throws Exception {
+        ScheduleHeaderResponse header = scheduleHeaderWithCodes();
+        when(scheduleService.selectByCondition(any(), eq(1), eq(20)))
+                .thenReturn(PageResponse.of(java.util.List.of(header), 1, 20, 1, "scheduleHeaderId,desc"));
+
+        mockMvc.perform(get("/api/v1/schedules")
+                        .with(user("viewer").roles("COMPLIANCE")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].paymentStage").value("GA_TO_FC"))
+                .andExpect(jsonPath("$.data.content[0].paymentStageLabel").value("GA→설계사"))
+                .andExpect(jsonPath("$.data.content[0].scheduleRegime").value("FOUR_YEAR_2027"))
+                .andExpect(jsonPath("$.data.content[0].scheduleRegimeLabel").value("4년 분급(2027)"))
+                .andExpect(jsonPath("$.data.content[0].schedulePurpose").value("COMPARISON"))
+                .andExpect(jsonPath("$.data.content[0].schedulePurposeLabel").value("비교"))
+                .andExpect(jsonPath("$.data.content[0].status").value("ADJUSTED"))
+                .andExpect(jsonPath("$.data.content[0].statusLabel").value("조정완료"));
+    }
+
+    @Test
+    void returnsKoreanLabelsWithScheduleDetailCodes() throws Exception {
+        when(scheduleService.selectScheduleDetailById(10L)).thenReturn(
+                ScheduleDetailResponse.builder()
+                        .header(scheduleHeaderWithCodes())
+                        .lines(java.util.List.of())
+                        .build());
+
+        mockMvc.perform(get("/api/v1/schedules/{id}", 10L)
+                        .with(user("viewer").roles("COMPLIANCE")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.header.paymentStageLabel").value("GA→설계사"))
+                .andExpect(jsonPath("$.data.header.scheduleRegimeLabel").value("4년 분급(2027)"))
+                .andExpect(jsonPath("$.data.header.schedulePurposeLabel").value("비교"))
+                .andExpect(jsonPath("$.data.header.statusLabel").value("조정완료"));
+    }
+
+    @Test
     void returnsScheduleVersionsForSameContractAndStage() throws Exception {
         when(scheduleService.selectScheduleVersions(10L)).thenReturn(java.util.List.of(
                 ScheduleHeaderResponse.builder()
                         .scheduleHeaderId(11L)
+                        .paymentStage(PaymentStage.INSURER_TO_GA)
+                        .scheduleRegime("SEVEN_YEAR_2029")
+                        .schedulePurpose("SIMULATION")
                         .scheduleVersionNo(2)
+                        .status(ScheduleHeaderStatus.RESTARTED)
                         .activeYn(true)
                         .build(),
                 ScheduleHeaderResponse.builder()
@@ -55,6 +100,10 @@ class ScheduleControllerTest {
                         .with(user("viewer").roles("COMPLIANCE")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].scheduleHeaderId").value(11))
+                .andExpect(jsonPath("$.data[0].paymentStageLabel").value("원수사→GA"))
+                .andExpect(jsonPath("$.data[0].scheduleRegimeLabel").value("7년 분급(2029)"))
+                .andExpect(jsonPath("$.data[0].schedulePurposeLabel").value("시뮬레이션"))
+                .andExpect(jsonPath("$.data[0].statusLabel").value("재개"))
                 .andExpect(jsonPath("$.data[1].scheduleVersionNo").value(1));
 
         verify(scheduleService).selectScheduleVersions(10L);
@@ -145,5 +194,15 @@ class ScheduleControllerTest {
 
         mockMvc.perform(post("/api/v1/schedules/{id}/regenerate", 10L).with(user("admin").roles("SYSTEM_ADMIN")).contentType(APPLICATION_JSON).content("{\"reason\":\"정책 변경 반영\"}"))
                 .andExpect(status().isOk());
+    }
+
+    private ScheduleHeaderResponse scheduleHeaderWithCodes() {
+        return ScheduleHeaderResponse.builder()
+                .scheduleHeaderId(10L)
+                .paymentStage(PaymentStage.GA_TO_FC)
+                .scheduleRegime("FOUR_YEAR_2027")
+                .schedulePurpose("COMPARISON")
+                .status(ScheduleHeaderStatus.ADJUSTED)
+                .build();
     }
 }

--- a/src/test/js/schedule-list.test.cjs
+++ b/src/test/js/schedule-list.test.cjs
@@ -1,7 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const { normalizePage } = require("../../main/resources/static/js/features/schedule/schedule-list.js");
+const { normalizePage, responseLabel } = require("../../main/resources/static/js/features/schedule/schedule-list.js");
 
 test("empty schedule result normalizes an out-of-range page to page 1", () => {
   const response = { content: [], page: 999, totalPages: 0, totalElements: 0 };
@@ -14,4 +14,12 @@ test("FGC-QUR-001 non-empty result preserves boundaries and rejects malformed pa
   assert.equal(normalizePage(2, 5), 2);
   assert.equal(normalizePage(999, 5), 5);
   assert.equal(normalizePage("2abc", 5), 1);
+});
+
+test("schedule labels prefer API values and keep code-map fallback", () => {
+  const labels = { PLANNED: "예정" };
+
+  assert.equal(responseLabel("서버 예정", labels, "PLANNED"), "서버 예정");
+  assert.equal(responseLabel("", labels, "PLANNED"), "예정");
+  assert.equal(responseLabel(null, labels, "UNKNOWN"), "UNKNOWN");
 });


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- 스케줄 조회 응답에 코드값과 함께 화면 표시용 한글 라벨을 제공합니다.
- SCHE-W01·W02 화면이 서버 라벨을 우선 사용하도록 연동했습니다.
- 기존 코드 필드와 프론트 fallback을 유지하여 하위 호환성을 보존했습니다.

## 🔗 2. 관련 이슈

- Closes #124

## 🛠 3. 구현 내용

- `ScheduleHeaderResponse`에 다음 계산형 한글 라벨 응답을 추가했습니다.
  - `paymentStageLabel`
  - `scheduleRegimeLabel`
  - `schedulePurposeLabel`
  - `statusLabel`
- 기존 `paymentStage`, `scheduleRegime`, `schedulePurpose`, `status` 코드값은 그대로 유지했습니다.
- 목록·상세·버전 조회 응답에 동일한 라벨 계약이 적용됩니다.
- SCHE-W01·W02는 서버 라벨을 우선 표시하고, 구버전 응답에서는 기존 코드 매핑을 fallback으로 사용합니다.
- 상세 화면의 누락되거나 오래된 코드 매핑을 현재 enum 기준으로 정리했습니다.
- 인터페이스 정의서에 코드·라벨 동봉 응답을 반영했습니다.
- Controller JSON 계약 테스트와 JavaScript fallback 테스트를 보강했습니다.

## 🧪 4. 테스트 방법

1. `./gradlew test`
2. `node --test src/test/js/schedule-list.test.cjs`
3. `node --check src/main/resources/static/js/features/schedule/schedule-list.js`
4. `node --check src/main/resources/static/js/features/schedule/schedule-detail.js`

### 테스트 결과

- 전체 Gradle 테스트 성공
- JavaScript 테스트 3건 성공
- JavaScript 문법 검사 성공
- `git diff --check` 성공

## 🗄️ 5. DB / Flyway 변경

- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

- 없음

## 📋 6. 리뷰 요구사항

- 계산형 라벨 getter가 기존 코드 응답을 변경하지 않고 추가 필드만 제공하는지 확인 부탁드립니다.
- SCHE-W01·W02의 서버 라벨 우선 표시와 기존 코드 매핑 fallback 구성이 적절한지 확인 부탁드립니다.
- 한글 라벨 문구가 업무 용어와 일치하는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

- [x] `develop` 최신 내용을 반영했습니다.
- [x] 로컬 빌드에 성공했습니다.
- [ ] 애플리케이션 수동 실행을 확인했습니다.
- [ ] 브라우저에서 관련 기능을 직접 테스트했습니다.
- [x] 테스트 코드를 작성했습니다.
- [x] 전체 테스트로 기존 기능에 영향이 없는지 확인했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

- SCHE-W01·W02의 한글 표시값을 API 라벨 우선 방식으로 전환했습니다.
- 화면 레이아웃과 디자인 변경은 없습니다.

## 💬 9. 참고 사항

- API 경로와 요청 파라미터는 변경하지 않았습니다.
- DB·Mapper SQL·Flyway 변경은 없습니다.
- 알 수 없는 코드가 응답되는 경우 원본 코드를 표시하여 표시값이 사라지지 않도록 했습니다.
- 구버전 API 응답에서도 기존 프론트 코드 매핑으로 한글 표시가 유지됩니다.