### PR TITLE
[Feat] FUN-044 VRUN-W02 확정 체크리스트 화면 연동

### DIFF
--- a/src/main/resources/static/js/features/vrun/vrun-detail.js
+++ b/src/main/resources/static/js/features/vrun/vrun-detail.js
@@ -1,7 +1,8 @@
 /**
- * FGC-UI-VRUN-W02 실행·진행률 (FUN-042·043)
+ * FGC-UI-VRUN-W02 실행·진행률·확정 체크리스트 (FUN-042·043·044)
  * POST /api/v1/validation-runs/{id}/execute  (IF-API-48, 202 · 배치 비동기)
  * GET  /api/v1/validation-runs/{id}/progress (IF-API-49, 2초 폴링)
+ * GET  /api/v1/validation-runs/{id}/finalize-checklist (IF-API-50)
  *
  * 헤더·스텝퍼·대상 선별·결과 요약은 서버 렌더링이다 — 이 스크립트는 실행 버튼과
  * 폴링 중 스텝퍼/상태 배지 갱신만 맡고, 종료 상태(COMPLETED/FAILED)는 전체
@@ -16,11 +17,15 @@
   var refreshButton = document.getElementById("btn-refresh");
   var stepper = document.getElementById("stepper");
   var statusBadge = document.getElementById("hdr-status");
+  var checklistSummary = document.getElementById("cond-summary");
+  var checklistBody = document.getElementById("cond-body");
+  var finalizeButton = document.getElementById("btn-finalize");
   if (!apiClient || !executeButton || !stepper) {
     return;
   }
 
   var runId = executeButton.dataset.runId;
+  var runStatus = executeButton.dataset.runStatus;
   var pollTimer = null;
 
   var STATUS_TONES = {
@@ -87,6 +92,86 @@
     pollTimer = window.setInterval(poll, 2000); // IF-API-49: 2초 폴링
   }
 
+  // 2026-08-19 yslee - FUN-044 확정 조건을 IF-API-50 응답으로 표시
+  // 기존 코드: 체크리스트 영역이 정적 "연동 대기" 문구와 비활성 버튼만 표시
+  // 문제: 사용자가 어떤 조건 때문에 확정할 수 없는지 화면에서 확인할 수 없음
+  // 개선: 서버가 판정한 6개 조건을 그대로 표시하고 통과 여부를 후속 확정 게이트에 전달
+  function safeInternalLink(linkUrl) {
+    if (!linkUrl || typeof linkUrl !== "string" || !linkUrl.startsWith("/") || linkUrl.startsWith("//")) {
+      return null;
+    }
+    try {
+      var url = new URL(linkUrl, window.location.origin);
+      return url.origin === window.location.origin ? url.pathname + url.search + url.hash : null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function setChecklistState(summary, message, tone) {
+    checklistSummary.textContent = summary;
+    checklistSummary.className = tone ? "fgc-badge " + tone : "fgc-muted";
+    checklistBody.replaceChildren();
+    var empty = document.createElement("div");
+    empty.className = "fgc-empty publishing-empty-state";
+    empty.textContent = message;
+    checklistBody.appendChild(empty);
+    finalizeButton.dataset.checklistPassed = "false";
+  }
+
+  function renderChecklist(checklist) {
+    checklistBody.replaceChildren();
+    checklist.conditions.forEach(function (condition) {
+      var row = document.createElement("div");
+      row.className = "publishing-result-placeholder";
+
+      var title = document.createElement("strong");
+      title.textContent = condition.no + ". " + condition.label;
+      row.appendChild(title);
+
+      var result = document.createElement(condition.passed ? "span" : "a");
+      result.className = "fgc-badge " + (condition.passed ? "fgc-badge--normal" : "fgc-badge--violation");
+      result.textContent = condition.passed ? "통과" : "미충족 " + condition.count + "건";
+      if (!condition.passed) {
+        var link = safeInternalLink(condition.linkUrl);
+        if (link) result.href = link;
+      }
+      row.appendChild(result);
+      checklistBody.appendChild(row);
+    });
+
+    checklistSummary.textContent = checklist.passed ? "6개 조건 모두 통과" : "미충족 조건 있음";
+    checklistSummary.className = "fgc-badge "
+      + (checklist.passed ? "fgc-badge--normal" : "fgc-badge--violation");
+    finalizeButton.dataset.checklistPassed = String(checklist.passed);
+  }
+
+  function loadFinalizeChecklist() {
+    if (!checklistSummary || !checklistBody || !finalizeButton) return;
+    if (runStatus === "FINALIZED") {
+      setChecklistState("확정 완료", "확정된 실행의 결과와 계산 근거가 잠겼습니다.", "fgc-badge--review");
+      return;
+    }
+    if (runStatus !== "COMPLETED") {
+      setChecklistState("확인 대기", "검증 실행이 완료되면 확정 조건을 확인할 수 있습니다.");
+      return;
+    }
+
+    checklistSummary.textContent = "확인 중";
+    apiClient.request("/api/v1/validation-runs/" + runId + "/finalize-checklist")
+      .then(function (envelope) {
+        var checklist = envelope.data;
+        if (!checklist || !Array.isArray(checklist.conditions) || checklist.conditions.length !== 6) {
+          throw new apiClient.ApiError({ message: "확정 조건 응답 형식이 올바르지 않습니다." }, envelope.requestId, 200);
+        }
+        renderChecklist(checklist);
+      })
+      .catch(function (error) {
+        setChecklistState("조회 실패", error && error.message
+          ? error.message : "확정 조건을 불러오지 못했습니다.", "fgc-badge--violation");
+      });
+  }
+
   executeButton.addEventListener("click", function () {
     executeButton.disabled = true;
     apiClient.request("/api/v1/validation-runs/" + runId + "/execute", { method: "POST" })
@@ -114,4 +199,5 @@
   if (executeButton.dataset.runStatus === "RUNNING") {
     startPolling();
   }
+  loadFinalizeChecklist();
 })();

--- a/src/main/resources/templates/vrun/detail.html
+++ b/src/main/resources/templates/vrun/detail.html
@@ -22,7 +22,7 @@
    · "확정 = 송금 마감"으로 읽히는 표현
 
   헤더·스텝퍼·③대상 선별·④결과 요약은 서버 렌더링(IF-API-47 과 같은 조회를 서비스 직주입으로).
-  ⑤확정 조건·⑥확정 버튼은 IF-API-50/51 연동(#172~#175) 전까지 placeholder 를 유지한다.
+  ⑤확정 조건은 IF-API-50으로 조회하고 ⑥확정 버튼은 IF-API-51 연동 전까지 비활성으로 유지한다.
 -->
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-VRUN-W02', '월 통합검증 상세·확정', '월 통합검증 실행 목록', '/validation-runs')}"
       xmlns:th="http://www.thymeleaf.org">
@@ -231,14 +231,14 @@
     </div>
   </section>
 
-  <!-- ⑤ 확정 조건 체크리스트 — finalize-checklist API(IF-API-50, #172~#175) 연동 시 채운다 -->
+  <!-- ⑤ 확정 조건 체크리스트 — IF-API-50 응답의 문서 순서·문구를 그대로 표시한다. -->
   <section class="fgc-card" style="margin-top:16px">
     <div class="fgc-card__head">
       <span class="fgc-card__title">⑤ 확정 조건 (운영정책서 제44조 · 6개 전부 통과해야 함)</span>
-      <span id="cond-summary" class="fgc-muted" style="font-size:12px">연동 대기</span>
+      <span id="cond-summary" class="fgc-muted" style="font-size:12px">확인 중</span>
     </div>
-    <div class="fgc-card__body" id="cond-body">
-      <div class="fgc-empty publishing-empty-state">확정 조건 API 연동 대기</div>
+    <div class="fgc-card__body" id="cond-body" aria-live="polite">
+      <div class="fgc-empty publishing-empty-state">확정 조건을 불러오는 중입니다.</div>
     </div>
   </section>
 
@@ -248,7 +248,7 @@
       <div style="max-width:640px">
         <div style="font-weight:700;font-size:14px">⑥ 확정 (FINALIZED)</div>
         <p class="fgc-help" id="finalize-actions-pending" style="margin-top:4px">
-          확정 조건 확인과 확정 작업은 API 연동 대기입니다.<br>
+          위 6개 조건이 모두 통과한 실행만 확정할 수 있습니다.<br>
           확정하면 이 실행의 검증 결과와 그때 쓰인 룰셋·계산근거가 <strong>잠깁니다</strong>.
           <strong>되돌릴 수 없습니다.</strong> 결과를 바꾸려면 새 실행을 만드세요.
           확정 권한은 <span class="fgc-mono">GA_ADMIN</span> · <span class="fgc-mono">SYSTEM_ADMIN</span> 에게만 있습니다.
@@ -258,11 +258,9 @@
           확정된 결과는 DB 트리거가 물리적으로 수정을 막습니다.
         -->
       </div>
-      <!-- 확정 버튼은 체크리스트 게이트(IF-API-50) 연동 전까지 항상 비활성.
-           th:disabled 를 걸면 정적 disabled 를 덮어써 활성화돼 버린다 —
-           연동 시 th:disabled="${(roleCode != 'GA_ADMIN' and roleCode != 'SYSTEM_ADMIN') or !checklistPassed}"
-           로 바꾼다. 확정 권한은 GA_ADMIN·SYSTEM_ADMIN (화면정의서 :1485, IF-API-51) — canProcess·readOnly 와 집합이 다르다. -->
+      <!-- IF-API-51 연결 전까지 비활성. IF-API-50 결과는 data-checklist-passed에만 보존한다. -->
       <button class="fgc-btn fgc-btn--primary" id="btn-finalize" type="button" data-fgc-action="finalize" disabled
+              data-checklist-passed="false"
               aria-describedby="finalize-actions-pending" style="padding:10px 20px">
         <span class="material-symbols-outlined" style="font-size:18px">lock</span> 확정
       </button>

--- a/src/test/java/com/susukkang/fgc/ui/PendingActionButtonStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PendingActionButtonStructureTest.java
@@ -24,16 +24,24 @@ class PendingActionButtonStructureTest {
      */
 
     /**
-     * FGC-FUN-044 — 확정(IF-API-51)만 아직 미연동이라 pending 을 유지한다.
+     * FGC-FUN-044 — IF-API-50은 연동되었고 확정(IF-API-51)만 아직 미연동이다.
      * 생성·새로고침·실행(IF-API-45·48·49)은 #188 에서 연동돼 pending 단언에서 뺐다 —
      * 해당 버튼들의 활성/비활성 규칙은 ValidationRunViewControllerTest 가 검증한다.
      */
+    // 2026-08-19 yslee - IF-API-50 체크리스트 연동 후 남은 IF-API-51 대기 상태 검증 적용
+    // 기존 코드: IF-API-50·51이 모두 미연동인 예전 안내 문구를 검사
+    // 문제: IF-API-50 연결로 문구가 제거되어 정상 기능이 CI 실패로 판정됨
+    // 개선: 체크리스트 API 호출과 확정 버튼의 초기 비활성 상태를 독립적으로 검증
     @Test
-    void validationRunFinalizeStaysDisabledUntilFrontendApiIntegration() throws IOException {
+    void validationRunChecklistLoadsWhileFinalizeStaysDisabled() throws IOException {
         String detailTemplate = resource("templates/vrun/detail.html");
+        String detailScript = resource("static/js/features/vrun/vrun-detail.js");
 
         assertPendingButton(detailTemplate, "btn-finalize", "finalize-actions-pending");
-        assertThat(detailTemplate).contains("확정 조건 확인과 확정 작업은 API 연동 대기입니다.");
+        assertThat(detailTemplate)
+                .contains("data-checklist-passed=\"false\"")
+                .doesNotContain("확정 조건 확인과 확정 작업은 API 연동 대기입니다.");
+        assertThat(detailScript).contains("/finalize-checklist");
     }
 
     private static void assertPendingButton(String template, String id, String descriptionId) {

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -72,12 +72,19 @@ class PublishingTemplateStructureTest {
                 .containsPattern("(?s)row\\.addEventListener\\(\"keydown\".*?if \\(event\\.target\\.closest\\(\"a\"\\)\\) return;.*?event\\.preventDefault\\(\\)")
                 .contains("apiClient.request")
                 .doesNotContain("fetch(");
-        // VRUN-W02 는 #188 에서 헤더·스텝퍼·실행(IF-API-48·49)이 연동됐다 — 아직 미연동인
-        // 확정 체크리스트(IF-API-50/51, #172~#175)만 대기 상태를 유지하고, 확정 버튼은
-        // 체크리스트 게이트 연동 전까지 정적 disabled 다.
+        // VRUN-W02 는 IF-API-50 체크리스트를 연동하고, IF-API-51 연결 전까지 확정 버튼을
+        // 정적 disabled 로 유지한다.
         assertThat(resource("templates/vrun/detail.html"))
-                .contains("확정 조건 API 연동 대기")
+                .contains("id=\"cond-body\" aria-live=\"polite\"")
+                .contains("data-checklist-passed=\"false\"")
+                .doesNotContain("확정 조건 API 연동 대기")
                 .containsPattern("(?s)<button[^>]*id=\"btn-finalize\"[^>]*\\bdisabled\\b[^>]*>");
+        assertThat(resource("static/js/features/vrun/vrun-detail.js"))
+                .contains("/finalize-checklist")
+                .contains("safeInternalLink")
+                .contains("checklist.conditions.length !== 6")
+                .contains("finalizeButton.dataset.checklistPassed = String(checklist.passed)")
+                .doesNotContain("fetch(");
     }
 
     @Test


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* VRUN-W02에서 FUN-044 확정 체크리스트 6개를 조회·표시하도록 연결했습니다.

## 🔗 2. 관련 이슈

* Closes #232

## 🛠 3. 구현 내용

* IF-API-50 응답의 번호·조건명·통과 여부·미충족 건수를 화면에 표시합니다.
* 실패 조건의 내부 이동 링크를 검증하고 조회 오류 시 확정 가능 상태를 차단합니다.

## 🧪 4. 테스트 방법

1. `gradlew.bat -g .gradle test --tests com.susukkang.fgc.ui.PublishingTemplateStructureTest --tests com.susukkang.fgc.validation.controller.ValidationRunViewControllerTest`
2. `gradlew.bat -g .gradle build`
3. COMPLETED 실행 상세에서 체크리스트 6개와 통과·미충족 상태를 확인합니다.

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* API가 반환한 `linkUrl`을 동일 출처 내부 경로로만 노출하는지 확인 부탁드립니다.
* 조회 실패나 응답 형식 오류에서 확정 게이트가 열리지 않는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* FGC-UI-VRUN-W02 확정 조건 영역을 IF-API-50 데이터로 표시합니다.

## 💬 9. 참고 사항

* IF-API-51 확정 버튼 동작은 후속 PR에서 연결합니다.