### PR TITLE
[Feat] FUN-044 VRUN-W02 검증 실행 확정 화면 연동

### DIFF
--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationRunFinalizationServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationRunFinalizationServiceImpl.java
@@ -54,12 +54,14 @@ public class ValidationRunFinalizationServiceImpl implements ValidationRunFinali
         }
         String normalizedKey = normalizeIdempotencyKey(idempotencyKey);
 
-        // 선택 멱등키는 실행 간 재사용을 금지한다. UNIQUE 인덱스가 최후 방어선이며,
-        // 이 사전 조회는 제약 위반보다 명확한 VRUN_005 응답을 주기 위한 것이다.
+        // 2026-08-19 yslee - 다른 검증 실행에 귀속된 확정 멱등키 사전 검사 오류코드 정합성 수정
+        // 기존 코드: 멱등키 소유자가 다른 실행이면 상태 경합 코드 FGC-VRUN-005를 반환
+        // 문제: IF-API-51 명세는 앱 사전검사와 DB UNIQUE 제약 모두 FGC-VRUN-006을 반환하도록 규정함
+        // 개선: 사전 조회 충돌도 FGC-VRUN-006으로 통일해 클라이언트가 새 키로 재시도하게 함
         if (normalizedKey != null) {
             Long keyOwner = validationRunMapper.findValidationRunIdByFinalizeIdempotencyKey(normalizedKey);
             if (keyOwner != null && !keyOwner.equals(validationRunId)) {
-                throw new FgcBusinessException(FgcErrorCode.VRUN_005,
+                throw new FgcBusinessException(FgcErrorCode.VRUN_006,
                         Map.of("id", validationRunId, "idempotencyKey", normalizedKey));
             }
         }

--- a/src/main/resources/static/js/features/vrun/vrun-detail.js
+++ b/src/main/resources/static/js/features/vrun/vrun-detail.js
@@ -1,7 +1,8 @@
 /**
- * FGC-UI-VRUN-W02 실행·진행률 (FUN-042·043)
+ * FGC-UI-VRUN-W02 실행·진행률·확정 체크리스트 (FUN-042·043·044)
  * POST /api/v1/validation-runs/{id}/execute  (IF-API-48, 202 · 배치 비동기)
  * GET  /api/v1/validation-runs/{id}/progress (IF-API-49, 2초 폴링)
+ * GET  /api/v1/validation-runs/{id}/finalize-checklist (IF-API-50)
  *
  * 헤더·스텝퍼·대상 선별·결과 요약은 서버 렌더링이다 — 이 스크립트는 실행 버튼과
  * 폴링 중 스텝퍼/상태 배지 갱신만 맡고, 종료 상태(COMPLETED/FAILED)는 전체
@@ -16,11 +17,15 @@
   var refreshButton = document.getElementById("btn-refresh");
   var stepper = document.getElementById("stepper");
   var statusBadge = document.getElementById("hdr-status");
+  var checklistSummary = document.getElementById("cond-summary");
+  var checklistBody = document.getElementById("cond-body");
+  var finalizeButton = document.getElementById("btn-finalize");
   if (!apiClient || !executeButton || !stepper) {
     return;
   }
 
   var runId = executeButton.dataset.runId;
+  var runStatus = executeButton.dataset.runStatus;
   var pollTimer = null;
 
   var STATUS_TONES = {
@@ -87,6 +92,86 @@
     pollTimer = window.setInterval(poll, 2000); // IF-API-49: 2초 폴링
   }
 
+  // 2026-08-19 yslee - FUN-044 확정 조건을 IF-API-50 응답으로 표시
+  // 기존 코드: 체크리스트 영역이 정적 "연동 대기" 문구와 비활성 버튼만 표시
+  // 문제: 사용자가 어떤 조건 때문에 확정할 수 없는지 화면에서 확인할 수 없음
+  // 개선: 서버가 판정한 6개 조건을 그대로 표시하고 통과 여부를 후속 확정 게이트에 전달
+  function safeInternalLink(linkUrl) {
+    if (!linkUrl || typeof linkUrl !== "string" || !linkUrl.startsWith("/") || linkUrl.startsWith("//")) {
+      return null;
+    }
+    try {
+      var url = new URL(linkUrl, window.location.origin);
+      return url.origin === window.location.origin ? url.pathname + url.search + url.hash : null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function setChecklistState(summary, message, tone) {
+    checklistSummary.textContent = summary;
+    checklistSummary.className = tone ? "fgc-badge " + tone : "fgc-muted";
+    checklistBody.replaceChildren();
+    var empty = document.createElement("div");
+    empty.className = "fgc-empty publishing-empty-state";
+    empty.textContent = message;
+    checklistBody.appendChild(empty);
+    finalizeButton.dataset.checklistPassed = "false";
+  }
+
+  function renderChecklist(checklist) {
+    checklistBody.replaceChildren();
+    checklist.conditions.forEach(function (condition) {
+      var row = document.createElement("div");
+      row.className = "publishing-result-placeholder";
+
+      var title = document.createElement("strong");
+      title.textContent = condition.no + ". " + condition.label;
+      row.appendChild(title);
+
+      var result = document.createElement(condition.passed ? "span" : "a");
+      result.className = "fgc-badge " + (condition.passed ? "fgc-badge--normal" : "fgc-badge--violation");
+      result.textContent = condition.passed ? "통과" : "미충족 " + condition.count + "건";
+      if (!condition.passed) {
+        var link = safeInternalLink(condition.linkUrl);
+        if (link) result.href = link;
+      }
+      row.appendChild(result);
+      checklistBody.appendChild(row);
+    });
+
+    checklistSummary.textContent = checklist.passed ? "6개 조건 모두 통과" : "미충족 조건 있음";
+    checklistSummary.className = "fgc-badge "
+      + (checklist.passed ? "fgc-badge--normal" : "fgc-badge--violation");
+    finalizeButton.dataset.checklistPassed = String(checklist.passed);
+  }
+
+  function loadFinalizeChecklist() {
+    if (!checklistSummary || !checklistBody || !finalizeButton) return;
+    if (runStatus === "FINALIZED") {
+      setChecklistState("확정 완료", "확정된 실행의 결과와 계산 근거가 잠겼습니다.", "fgc-badge--review");
+      return;
+    }
+    if (runStatus !== "COMPLETED") {
+      setChecklistState("확인 대기", "검증 실행이 완료되면 확정 조건을 확인할 수 있습니다.");
+      return;
+    }
+
+    checklistSummary.textContent = "확인 중";
+    apiClient.request("/api/v1/validation-runs/" + runId + "/finalize-checklist")
+      .then(function (envelope) {
+        var checklist = envelope.data;
+        if (!checklist || !Array.isArray(checklist.conditions) || checklist.conditions.length !== 6) {
+          throw new apiClient.ApiError({ message: "확정 조건 응답 형식이 올바르지 않습니다." }, envelope.requestId, 200);
+        }
+        renderChecklist(checklist);
+      })
+      .catch(function (error) {
+        setChecklistState("조회 실패", error && error.message
+          ? error.message : "확정 조건을 불러오지 못했습니다.", "fgc-badge--violation");
+      });
+  }
+
   executeButton.addEventListener("click", function () {
     executeButton.disabled = true;
     apiClient.request("/api/v1/validation-runs/" + runId + "/execute", { method: "POST" })
@@ -114,4 +199,5 @@
   if (executeButton.dataset.runStatus === "RUNNING") {
     startPolling();
   }
+  loadFinalizeChecklist();
 })();

--- a/src/main/resources/static/js/features/vrun/vrun-detail.js
+++ b/src/main/resources/static/js/features/vrun/vrun-detail.js
@@ -223,6 +223,13 @@
     }).catch(function (error) {
       finalizeRequestPending = false;
       finalizeButton.removeAttribute("aria-busy");
+      // 2026-08-19 yslee - FGC-VRUN-006 멱등키 충돌 시 다음 재시도에서 새 키를 발급하도록 수정
+      // 기존 코드: 모든 실패 후 최초 멱등키를 계속 재사용
+      // 문제: 다른 검증 실행에 귀속된 키 충돌 시 새로고침 전까지 같은 409 오류가 반복됨
+      // 개선: 문서에서 새 키 재시도를 요구하는 FGC-VRUN-006에서만 저장된 키를 초기화
+      if (error && error.code === "FGC-VRUN-006") {
+        finalizeIdempotencyKey = null;
+      }
       if (toast) toast(error && error.message ? error.message : "검증 실행 확정에 실패했습니다.", "error");
       loadFinalizeChecklist();
     });

--- a/src/main/resources/static/js/features/vrun/vrun-detail.js
+++ b/src/main/resources/static/js/features/vrun/vrun-detail.js
@@ -3,6 +3,7 @@
  * POST /api/v1/validation-runs/{id}/execute  (IF-API-48, 202 · 배치 비동기)
  * GET  /api/v1/validation-runs/{id}/progress (IF-API-49, 2초 폴링)
  * GET  /api/v1/validation-runs/{id}/finalize-checklist (IF-API-50)
+ * POST /api/v1/validation-runs/{id}/finalize (IF-API-51)
  *
  * 헤더·스텝퍼·대상 선별·결과 요약은 서버 렌더링이다 — 이 스크립트는 실행 버튼과
  * 폴링 중 스텝퍼/상태 배지 갱신만 맡고, 종료 상태(COMPLETED/FAILED)는 전체
@@ -27,6 +28,8 @@
   var runId = executeButton.dataset.runId;
   var runStatus = executeButton.dataset.runStatus;
   var pollTimer = null;
+  var finalizeRequestPending = false;
+  var finalizeIdempotencyKey = null;
 
   var STATUS_TONES = {
     FAILED: "fgc-badge--violation",
@@ -117,6 +120,21 @@
     empty.textContent = message;
     checklistBody.appendChild(empty);
     finalizeButton.dataset.checklistPassed = "false";
+    updateFinalizeButtonState();
+  }
+
+  function updateFinalizeButtonState() {
+    if (!finalizeButton) return;
+    var canFinalize = finalizeButton.dataset.canFinalize === "true";
+    var checklistPassed = finalizeButton.dataset.checklistPassed === "true";
+    finalizeButton.disabled = finalizeRequestPending || runStatus !== "COMPLETED" || !canFinalize || !checklistPassed;
+    if (!canFinalize) {
+      finalizeButton.title = "확정 권한은 GA_ADMIN 또는 SYSTEM_ADMIN에게만 있습니다.";
+    } else if (!checklistPassed) {
+      finalizeButton.title = "확정 조건 6개를 모두 통과해야 합니다.";
+    } else {
+      finalizeButton.removeAttribute("title");
+    }
   }
 
   function renderChecklist(checklist) {
@@ -144,6 +162,7 @@
     checklistSummary.className = "fgc-badge "
       + (checklist.passed ? "fgc-badge--normal" : "fgc-badge--violation");
     finalizeButton.dataset.checklistPassed = String(checklist.passed);
+    updateFinalizeButtonState();
   }
 
   function loadFinalizeChecklist() {
@@ -172,6 +191,43 @@
       });
   }
 
+  // 2026-08-19 yslee - FUN-044 검증 실행 확정 API를 화면 버튼에 연결
+  // 기존 코드: 확정 버튼이 항상 비활성이고 IF-API-51을 호출하는 사용자 동작이 없음
+  // 문제: 서버 확정 기능이 구현돼도 VRUN-W02에서 사람이 검토 후 확정할 수 없음
+  // 개선: 권한·완료 상태·체크리스트를 모두 확인하고 멱등키로 한 번만 확정 요청
+  function createFinalizeIdempotencyKey() {
+    if (window.crypto && typeof window.crypto.randomUUID === "function") {
+      return "vrun-finalize-" + runId + "-" + window.crypto.randomUUID();
+    }
+    return "vrun-finalize-" + runId + "-" + Date.now();
+  }
+
+  function finalizeRun() {
+    updateFinalizeButtonState();
+    if (finalizeButton.disabled || finalizeRequestPending) return;
+    if (!window.confirm("이 검증 실행을 확정하면 결과와 계산 근거를 고칠 수 없습니다. 확정하시겠습니까?")) {
+      return;
+    }
+
+    finalizeRequestPending = true;
+    finalizeIdempotencyKey = finalizeIdempotencyKey || createFinalizeIdempotencyKey();
+    updateFinalizeButtonState();
+    finalizeButton.setAttribute("aria-busy", "true");
+
+    apiClient.request("/api/v1/validation-runs/" + runId + "/finalize", {
+      method: "POST",
+      idempotencyKey: finalizeIdempotencyKey
+    }).then(function () {
+      if (toast) toast("검증 실행을 확정했습니다.", "success");
+      window.location.reload();
+    }).catch(function (error) {
+      finalizeRequestPending = false;
+      finalizeButton.removeAttribute("aria-busy");
+      if (toast) toast(error && error.message ? error.message : "검증 실행 확정에 실패했습니다.", "error");
+      loadFinalizeChecklist();
+    });
+  }
+
   executeButton.addEventListener("click", function () {
     executeButton.disabled = true;
     apiClient.request("/api/v1/validation-runs/" + runId + "/execute", { method: "POST" })
@@ -198,6 +254,10 @@
   // 새로고침으로 진입했는데 이미 실행 중이면 폴링을 이어 붙인다
   if (executeButton.dataset.runStatus === "RUNNING") {
     startPolling();
+  }
+  if (finalizeButton) {
+    finalizeButton.addEventListener("click", finalizeRun);
+    updateFinalizeButtonState();
   }
   loadFinalizeChecklist();
 })();

--- a/src/main/resources/templates/vrun/detail.html
+++ b/src/main/resources/templates/vrun/detail.html
@@ -22,7 +22,7 @@
    · "확정 = 송금 마감"으로 읽히는 표현
 
   헤더·스텝퍼·③대상 선별·④결과 요약은 서버 렌더링(IF-API-47 과 같은 조회를 서비스 직주입으로).
-  ⑤확정 조건은 IF-API-50으로 조회하고 ⑥확정 버튼은 IF-API-51 연동 전까지 비활성으로 유지한다.
+  ⑤확정 조건은 IF-API-50으로 조회하고 ⑥확정 버튼은 IF-API-51로 사람이 확정한다.
 -->
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-VRUN-W02', '월 통합검증 상세·확정', '월 통합검증 실행 목록', '/validation-runs')}"
       xmlns:th="http://www.thymeleaf.org">
@@ -247,7 +247,7 @@
     <div class="fgc-card__body" style="display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap">
       <div style="max-width:640px">
         <div style="font-weight:700;font-size:14px">⑥ 확정 (FINALIZED)</div>
-        <p class="fgc-help" id="finalize-actions-pending" style="margin-top:4px">
+        <p class="fgc-help" id="finalize-action-guide" style="margin-top:4px">
           위 6개 조건이 모두 통과한 실행만 확정할 수 있습니다.<br>
           확정하면 이 실행의 검증 결과와 그때 쓰인 룰셋·계산근거가 <strong>잠깁니다</strong>.
           <strong>되돌릴 수 없습니다.</strong> 결과를 바꾸려면 새 실행을 만드세요.
@@ -258,10 +258,11 @@
           확정된 결과는 DB 트리거가 물리적으로 수정을 막습니다.
         -->
       </div>
-      <!-- IF-API-51 연결 전까지 비활성. IF-API-50 결과는 data-checklist-passed에만 보존한다. -->
+      <!-- 서버 권한과 IF-API-50 체크리스트가 모두 통과해야 스크립트가 활성화한다. -->
       <button class="fgc-btn fgc-btn--primary" id="btn-finalize" type="button" data-fgc-action="finalize" disabled
               data-checklist-passed="false"
-              aria-describedby="finalize-actions-pending" style="padding:10px 20px">
+              th:attr="data-can-finalize=${roleCode == 'GA_ADMIN' or roleCode == 'SYSTEM_ADMIN'}"
+              aria-describedby="finalize-action-guide" style="padding:10px 20px">
         <span class="material-symbols-outlined" style="font-size:18px">lock</span> 확정
       </button>
     </div>

--- a/src/main/resources/templates/vrun/detail.html
+++ b/src/main/resources/templates/vrun/detail.html
@@ -23,7 +23,6 @@
 
   헤더·스텝퍼·③대상 선별·④결과 요약은 서버 렌더링(IF-API-47 과 같은 조회를 서비스 직주입으로).
   ⑤확정 조건은 IF-API-50으로 조회하고 ⑥확정 버튼은 IF-API-51로 사람이 확정한다.
-  ⑤확정 조건은 IF-API-50으로 조회하고 ⑥확정 버튼은 IF-API-51 연동 전까지 비활성으로 유지한다.
 -->
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-VRUN-W02', '월 통합검증 상세·확정', '월 통합검증 실행 목록', '/validation-runs')}"
       xmlns:th="http://www.thymeleaf.org">

--- a/src/main/resources/templates/vrun/detail.html
+++ b/src/main/resources/templates/vrun/detail.html
@@ -248,10 +248,14 @@
     <div class="fgc-card__body" style="display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap">
       <div style="max-width:640px">
         <div style="font-weight:700;font-size:14px">⑥ 확정 (FINALIZED)</div>
+        <!-- 2026-08-19 yslee - #238 병합 잔재를 제거하고 VRUN-W02 확정 안내 고정 문구 적용 -->
+        <!-- 기존 코드: 신·구 안내 p 요소가 중첩되고 송금·회계 마감 아님 안내가 누락됨 -->
+        <!-- 문제: aria-describedby가 빈 p를 가리켜 접근성 안내가 제공되지 않고 확정을 송금 마감으로 오인할 수 있음 -->
+        <!-- 개선: 단일 안내 요소에 검증 결과 잠금이며 실제 송금·회계 마감이 아니라는 고정 문구를 표시 -->
         <p class="fgc-help" id="finalize-action-guide" style="margin-top:4px">
-        <p class="fgc-help" id="finalize-actions-pending" style="margin-top:4px">
           위 6개 조건이 모두 통과한 실행만 확정할 수 있습니다.<br>
           확정하면 이 실행의 검증 결과와 그때 쓰인 룰셋·계산근거가 <strong>잠깁니다</strong>.
+          <strong>검증 결과 잠금이며 실제 송금·회계 마감이 아닙니다.</strong><br>
           <strong>되돌릴 수 없습니다.</strong> 결과를 바꾸려면 새 실행을 만드세요.
           확정 권한은 <span class="fgc-mono">GA_ADMIN</span> · <span class="fgc-mono">SYSTEM_ADMIN</span> 에게만 있습니다.
         </p>
@@ -265,10 +269,6 @@
               data-checklist-passed="false"
               th:attr="data-can-finalize=${roleCode == 'GA_ADMIN' or roleCode == 'SYSTEM_ADMIN'}"
               aria-describedby="finalize-action-guide" style="padding:10px 20px">
-      <!-- IF-API-51 연결 전까지 비활성. IF-API-50 결과는 data-checklist-passed에만 보존한다. -->
-      <button class="fgc-btn fgc-btn--primary" id="btn-finalize" type="button" data-fgc-action="finalize" disabled
-              data-checklist-passed="false"
-              aria-describedby="finalize-actions-pending" style="padding:10px 20px">
         <span class="material-symbols-outlined" style="font-size:18px">lock</span> 확정
       </button>
     </div>

--- a/src/main/resources/templates/vrun/detail.html
+++ b/src/main/resources/templates/vrun/detail.html
@@ -22,7 +22,7 @@
    · "확정 = 송금 마감"으로 읽히는 표현
 
   헤더·스텝퍼·③대상 선별·④결과 요약은 서버 렌더링(IF-API-47 과 같은 조회를 서비스 직주입으로).
-  ⑤확정 조건·⑥확정 버튼은 IF-API-50/51 연동(#172~#175) 전까지 placeholder 를 유지한다.
+  ⑤확정 조건은 IF-API-50으로 조회하고 ⑥확정 버튼은 IF-API-51 연동 전까지 비활성으로 유지한다.
 -->
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-VRUN-W02', '월 통합검증 상세·확정', '월 통합검증 실행 목록', '/validation-runs')}"
       xmlns:th="http://www.thymeleaf.org">
@@ -231,14 +231,14 @@
     </div>
   </section>
 
-  <!-- ⑤ 확정 조건 체크리스트 — finalize-checklist API(IF-API-50, #172~#175) 연동 시 채운다 -->
+  <!-- ⑤ 확정 조건 체크리스트 — IF-API-50 응답의 문서 순서·문구를 그대로 표시한다. -->
   <section class="fgc-card" style="margin-top:16px">
     <div class="fgc-card__head">
       <span class="fgc-card__title">⑤ 확정 조건 (운영정책서 제44조 · 6개 전부 통과해야 함)</span>
-      <span id="cond-summary" class="fgc-muted" style="font-size:12px">연동 대기</span>
+      <span id="cond-summary" class="fgc-muted" style="font-size:12px">확인 중</span>
     </div>
-    <div class="fgc-card__body" id="cond-body">
-      <div class="fgc-empty publishing-empty-state">확정 조건 API 연동 대기</div>
+    <div class="fgc-card__body" id="cond-body" aria-live="polite">
+      <div class="fgc-empty publishing-empty-state">확정 조건을 불러오는 중입니다.</div>
     </div>
   </section>
 
@@ -248,7 +248,7 @@
       <div style="max-width:640px">
         <div style="font-weight:700;font-size:14px">⑥ 확정 (FINALIZED)</div>
         <p class="fgc-help" id="finalize-actions-pending" style="margin-top:4px">
-          확정 조건 확인과 확정 작업은 API 연동 대기입니다.<br>
+          위 6개 조건이 모두 통과한 실행만 확정할 수 있습니다.<br>
           확정하면 이 실행의 검증 결과와 그때 쓰인 룰셋·계산근거가 <strong>잠깁니다</strong>.
           <strong>되돌릴 수 없습니다.</strong> 결과를 바꾸려면 새 실행을 만드세요.
           확정 권한은 <span class="fgc-mono">GA_ADMIN</span> · <span class="fgc-mono">SYSTEM_ADMIN</span> 에게만 있습니다.
@@ -258,11 +258,9 @@
           확정된 결과는 DB 트리거가 물리적으로 수정을 막습니다.
         -->
       </div>
-      <!-- 확정 버튼은 체크리스트 게이트(IF-API-50) 연동 전까지 항상 비활성.
-           th:disabled 를 걸면 정적 disabled 를 덮어써 활성화돼 버린다 —
-           연동 시 th:disabled="${(roleCode != 'GA_ADMIN' and roleCode != 'SYSTEM_ADMIN') or !checklistPassed}"
-           로 바꾼다. 확정 권한은 GA_ADMIN·SYSTEM_ADMIN (화면정의서 :1485, IF-API-51) — canProcess·readOnly 와 집합이 다르다. -->
+      <!-- IF-API-51 연결 전까지 비활성. IF-API-50 결과는 data-checklist-passed에만 보존한다. -->
       <button class="fgc-btn fgc-btn--primary" id="btn-finalize" type="button" data-fgc-action="finalize" disabled
+              data-checklist-passed="false"
               aria-describedby="finalize-actions-pending" style="padding:10px 20px">
         <span class="material-symbols-outlined" style="font-size:18px">lock</span> 확정
       </button>

--- a/src/test/java/com/susukkang/fgc/ui/PendingActionButtonStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PendingActionButtonStructureTest.java
@@ -23,7 +23,10 @@ class PendingActionButtonStructureTest {
      * 버튼의 활성/비활성 규칙(SETTLEMENT만 활성)은 ReconciliationViewControllerTest가 검증한다.
      */
 
-    /** FGC-FUN-044 — IF-API-50/51 연결 후 초기 disabled를 권한·상태·체크리스트가 모두 통과할 때만 해제한다. */
+    // 2026-08-19 yslee - #238 병합 후에도 IF-API-50·51 연동 완료 기준을 단일 테스트로 유지
+    // 기존 코드: IF-API-50 전용 테스트와 IF-API-50·51 통합 테스트가 병합 과정에서 중복됨
+    // 문제: 메서드 닫는 괄호가 유실되어 테스트 소스가 컴파일되지 않음
+    // 개선: 확정 버튼의 초기 비활성·권한 게이트·IF-API-50·51 연동을 하나의 테스트로 검증
     @Test
     void validationRunFinalizeUsesFrontendChecklistAndRoleGate() throws IOException {
         String detailTemplate = resource("templates/vrun/detail.html");
@@ -40,25 +43,6 @@ class PendingActionButtonStructureTest {
                 .contains("/finalize-checklist")
                 .contains("/finalize\"")
                 .contains("idempotencyKey: finalizeIdempotencyKey");
-    /**
-     * FGC-FUN-044 — IF-API-50은 연동되었고 확정(IF-API-51)만 아직 미연동이다.
-     * 생성·새로고침·실행(IF-API-45·48·49)은 #188 에서 연동돼 pending 단언에서 뺐다 —
-     * 해당 버튼들의 활성/비활성 규칙은 ValidationRunViewControllerTest 가 검증한다.
-     */
-    // 2026-08-19 yslee - IF-API-50 체크리스트 연동 후 남은 IF-API-51 대기 상태 검증 적용
-    // 기존 코드: IF-API-50·51이 모두 미연동인 예전 안내 문구를 검사
-    // 문제: IF-API-50 연결로 문구가 제거되어 정상 기능이 CI 실패로 판정됨
-    // 개선: 체크리스트 API 호출과 확정 버튼의 초기 비활성 상태를 독립적으로 검증
-    @Test
-    void validationRunChecklistLoadsWhileFinalizeStaysDisabled() throws IOException {
-        String detailTemplate = resource("templates/vrun/detail.html");
-        String detailScript = resource("static/js/features/vrun/vrun-detail.js");
-
-        assertPendingButton(detailTemplate, "btn-finalize", "finalize-actions-pending");
-        assertThat(detailTemplate)
-                .contains("data-checklist-passed=\"false\"")
-                .doesNotContain("확정 조건 확인과 확정 작업은 API 연동 대기입니다.");
-        assertThat(detailScript).contains("/finalize-checklist");
     }
 
     private static void assertPendingButton(String template, String id, String descriptionId) {

--- a/src/test/java/com/susukkang/fgc/ui/PendingActionButtonStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PendingActionButtonStructureTest.java
@@ -23,17 +23,23 @@ class PendingActionButtonStructureTest {
      * 버튼의 활성/비활성 규칙(SETTLEMENT만 활성)은 ReconciliationViewControllerTest가 검증한다.
      */
 
-    /**
-     * FGC-FUN-044 — 확정(IF-API-51)만 아직 미연동이라 pending 을 유지한다.
-     * 생성·새로고침·실행(IF-API-45·48·49)은 #188 에서 연동돼 pending 단언에서 뺐다 —
-     * 해당 버튼들의 활성/비활성 규칙은 ValidationRunViewControllerTest 가 검증한다.
-     */
+    /** FGC-FUN-044 — IF-API-50/51 연결 후 초기 disabled를 권한·상태·체크리스트가 모두 통과할 때만 해제한다. */
     @Test
-    void validationRunFinalizeStaysDisabledUntilFrontendApiIntegration() throws IOException {
+    void validationRunFinalizeUsesFrontendChecklistAndRoleGate() throws IOException {
         String detailTemplate = resource("templates/vrun/detail.html");
+        String detailScript = resource("static/js/features/vrun/vrun-detail.js");
 
-        assertPendingButton(detailTemplate, "btn-finalize", "finalize-actions-pending");
-        assertThat(detailTemplate).contains("확정 조건 확인과 확정 작업은 API 연동 대기입니다.");
+        assertThat(detailTemplate)
+                .containsPattern("(?s)<button(?=[^>]*\\bid=\"btn-finalize\")"
+                        + "(?=[^>]*\\btype=\"button\")(?=[^>]*\\sdisabled\\b)"
+                        + "(?=[^>]*data-checklist-passed=\"false\")"
+                        + "(?=[^>]*data-can-finalize=)[^>]*>")
+                .contains("id=\"finalize-action-guide\"")
+                .doesNotContain("확정 조건 확인과 확정 작업은 API 연동 대기입니다.");
+        assertThat(detailScript)
+                .contains("/finalize-checklist")
+                .contains("/finalize\"")
+                .contains("idempotencyKey: finalizeIdempotencyKey");
     }
 
     private static void assertPendingButton(String template, String id, String descriptionId) {

--- a/src/test/java/com/susukkang/fgc/ui/PendingActionButtonStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PendingActionButtonStructureTest.java
@@ -38,10 +38,16 @@ class PendingActionButtonStructureTest {
                         + "(?=[^>]*data-checklist-passed=\"false\")"
                         + "(?=[^>]*data-can-finalize=)[^>]*>")
                 .contains("id=\"finalize-action-guide\"")
+                .contains("검증 결과 잠금이며 실제 송금·회계 마감이 아닙니다.")
+                .containsOnlyOnce("id=\"finalize-action-guide\"")
+                .containsOnlyOnce("id=\"btn-finalize\"")
+                .doesNotContain("id=\"finalize-actions-pending\"")
                 .doesNotContain("확정 조건 확인과 확정 작업은 API 연동 대기입니다.");
         assertThat(detailScript)
                 .contains("/finalize-checklist")
                 .contains("/finalize\"")
+                .contains("error.code === \"FGC-VRUN-006\"")
+                .contains("finalizeIdempotencyKey = null")
                 .contains("idempotencyKey: finalizeIdempotencyKey");
     }
 

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -72,12 +72,19 @@ class PublishingTemplateStructureTest {
                 .containsPattern("(?s)row\\.addEventListener\\(\"keydown\".*?if \\(event\\.target\\.closest\\(\"a\"\\)\\) return;.*?event\\.preventDefault\\(\\)")
                 .contains("apiClient.request")
                 .doesNotContain("fetch(");
-        // VRUN-W02 는 #188 에서 헤더·스텝퍼·실행(IF-API-48·49)이 연동됐다 — 아직 미연동인
-        // 확정 체크리스트(IF-API-50/51, #172~#175)만 대기 상태를 유지하고, 확정 버튼은
-        // 체크리스트 게이트 연동 전까지 정적 disabled 다.
+        // VRUN-W02 는 IF-API-50 체크리스트를 연동하고, IF-API-51 연결 전까지 확정 버튼을
+        // 정적 disabled 로 유지한다.
         assertThat(resource("templates/vrun/detail.html"))
-                .contains("확정 조건 API 연동 대기")
+                .contains("id=\"cond-body\" aria-live=\"polite\"")
+                .contains("data-checklist-passed=\"false\"")
+                .doesNotContain("확정 조건 API 연동 대기")
                 .containsPattern("(?s)<button[^>]*id=\"btn-finalize\"[^>]*\\bdisabled\\b[^>]*>");
+        assertThat(resource("static/js/features/vrun/vrun-detail.js"))
+                .contains("/finalize-checklist")
+                .contains("safeInternalLink")
+                .contains("checklist.conditions.length !== 6")
+                .contains("finalizeButton.dataset.checklistPassed = String(checklist.passed)")
+                .doesNotContain("fetch(");
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -80,6 +80,10 @@ class PublishingTemplateStructureTest {
                 .contains("id=\"cond-body\" aria-live=\"polite\"")
                 .contains("data-checklist-passed=\"false\"")
                 .contains("data-can-finalize=${roleCode == 'GA_ADMIN' or roleCode == 'SYSTEM_ADMIN'}")
+                .contains("검증 결과 잠금이며 실제 송금·회계 마감이 아닙니다.")
+                .containsOnlyOnce("id=\"finalize-action-guide\"")
+                .containsOnlyOnce("id=\"btn-finalize\"")
+                .doesNotContain("id=\"finalize-actions-pending\"")
                 .doesNotContain("확정 조건 API 연동 대기")
                 .containsPattern("(?s)<button[^>]*id=\"btn-finalize\"[^>]*\\bdisabled\\b[^>]*>");
         assertThat(resource("static/js/features/vrun/vrun-detail.js"))
@@ -89,6 +93,8 @@ class PublishingTemplateStructureTest {
                 .contains("checklist.conditions.length !== 6")
                 .contains("finalizeButton.dataset.checklistPassed = String(checklist.passed)")
                 .contains("idempotencyKey: finalizeIdempotencyKey")
+                .contains("error.code === \"FGC-VRUN-006\"")
+                .contains("finalizeIdempotencyKey = null")
                 .contains("runStatus !== \"COMPLETED\"")
                 .contains("window.confirm")
                 .doesNotContain("fetch(");

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -72,18 +72,23 @@ class PublishingTemplateStructureTest {
                 .containsPattern("(?s)row\\.addEventListener\\(\"keydown\".*?if \\(event\\.target\\.closest\\(\"a\"\\)\\) return;.*?event\\.preventDefault\\(\\)")
                 .contains("apiClient.request")
                 .doesNotContain("fetch(");
-        // VRUN-W02 는 IF-API-50 체크리스트를 연동하고, IF-API-51 연결 전까지 확정 버튼을
-        // 정적 disabled 로 유지한다.
+        // VRUN-W02 는 IF-API-50 체크리스트와 IF-API-51 확정을 연결한다. 버튼은 초기에는
+        // 정적 disabled 이고 권한·COMPLETED·6개 조건 통과를 확인한 뒤에만 스크립트가 푼다.
         assertThat(resource("templates/vrun/detail.html"))
                 .contains("id=\"cond-body\" aria-live=\"polite\"")
                 .contains("data-checklist-passed=\"false\"")
+                .contains("data-can-finalize=${roleCode == 'GA_ADMIN' or roleCode == 'SYSTEM_ADMIN'}")
                 .doesNotContain("확정 조건 API 연동 대기")
                 .containsPattern("(?s)<button[^>]*id=\"btn-finalize\"[^>]*\\bdisabled\\b[^>]*>");
         assertThat(resource("static/js/features/vrun/vrun-detail.js"))
                 .contains("/finalize-checklist")
+                .contains("/finalize\"")
                 .contains("safeInternalLink")
                 .contains("checklist.conditions.length !== 6")
                 .contains("finalizeButton.dataset.checklistPassed = String(checklist.passed)")
+                .contains("idempotencyKey: finalizeIdempotencyKey")
+                .contains("runStatus !== \"COMPLETED\"")
+                .contains("window.confirm")
                 .doesNotContain("fetch(");
     }
 

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -72,17 +72,14 @@ class PublishingTemplateStructureTest {
                 .containsPattern("(?s)row\\.addEventListener\\(\"keydown\".*?if \\(event\\.target\\.closest\\(\"a\"\\)\\) return;.*?event\\.preventDefault\\(\\)")
                 .contains("apiClient.request")
                 .doesNotContain("fetch(");
-        // VRUN-W02 는 IF-API-50 체크리스트와 IF-API-51 확정을 연결한다. 버튼은 초기에는
-        // 정적 disabled 이고 권한·COMPLETED·6개 조건 통과를 확인한 뒤에만 스크립트가 푼다.
+        // 2026-08-19 yslee - #238 병합 후 VRUN-W02 템플릿·스크립트 검증 체인 정리
+        // 기존 코드: IF-API-50 전용 검증과 IF-API-50·51 통합 검증이 병합 과정에서 중복됨
+        // 문제: 첫 번째 AssertJ 체인의 종결 문자가 유실되어 테스트 소스 컴파일이 실패함
+        // 개선: IF-API-50·51 연동 완료 상태를 중복 없는 하나의 템플릿·스크립트 체인으로 검증
         assertThat(resource("templates/vrun/detail.html"))
                 .contains("id=\"cond-body\" aria-live=\"polite\"")
                 .contains("data-checklist-passed=\"false\"")
                 .contains("data-can-finalize=${roleCode == 'GA_ADMIN' or roleCode == 'SYSTEM_ADMIN'}")
-        // VRUN-W02 는 IF-API-50 체크리스트를 연동하고, IF-API-51 연결 전까지 확정 버튼을
-        // 정적 disabled 로 유지한다.
-        assertThat(resource("templates/vrun/detail.html"))
-                .contains("id=\"cond-body\" aria-live=\"polite\"")
-                .contains("data-checklist-passed=\"false\"")
                 .doesNotContain("확정 조건 API 연동 대기")
                 .containsPattern("(?s)<button[^>]*id=\"btn-finalize\"[^>]*\\bdisabled\\b[^>]*>");
         assertThat(resource("static/js/features/vrun/vrun-detail.js"))
@@ -94,9 +91,6 @@ class PublishingTemplateStructureTest {
                 .contains("idempotencyKey: finalizeIdempotencyKey")
                 .contains("runStatus !== \"COMPLETED\"")
                 .contains("window.confirm")
-                .contains("safeInternalLink")
-                .contains("checklist.conditions.length !== 6")
-                .contains("finalizeButton.dataset.checklistPassed = String(checklist.passed)")
                 .doesNotContain("fetch(");
     }
 

--- a/src/test/java/com/susukkang/fgc/validation/controller/ValidationRunViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/controller/ValidationRunViewControllerTest.java
@@ -83,6 +83,10 @@ class ValidationRunViewControllerTest {
         return userWithRole(1L, "settle01", "SETTLEMENT");
     }
 
+    private static FgcUserDetails gaAdminUser() {
+        return userWithRole(3L, "gaadmin01", "GA_ADMIN");
+    }
+
     private ValidationRunListRow listRow(String status, int currentStep) {
         ValidationRunListRow row = new ValidationRunListRow();
         row.setValidationRunId(100L);
@@ -238,6 +242,21 @@ class ValidationRunViewControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string(org.hamcrest.Matchers.matchesPattern(
                         "(?s).*<button[^>]*id=\"btn-execute\"[^>]*\\bdisabled\\b[^>]*>.*")));
+    }
+
+    @Test
+    void detailExposesFinalizeCapabilityOnlyToFinalizeRoles() throws Exception {
+        given(validationRunDetailService.detail(100L)).willReturn(detailResponse("COMPLETED", 8));
+        given(validationRunSearchService.search(any(), anyInt(), anyInt()))
+                .willReturn(pageOf(listRow("COMPLETED", 8)));
+
+        mvc.perform(get("/validation-runs/100").with(user(settleUser())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("data-can-finalize=\"false\"")));
+
+        mvc.perform(get("/validation-runs/100").with(user(gaAdminUser())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("data-can-finalize=\"true\"")));
     }
 
     /**

--- a/src/test/java/com/susukkang/fgc/validation/service/ValidationRunFinalizationServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ValidationRunFinalizationServiceImplTest.java
@@ -172,7 +172,7 @@ class ValidationRunFinalizationServiceImplTest {
 
         assertThatThrownBy(() -> service.finalizeRun(44L, 7L, "shared-key"))
                 .isInstanceOfSatisfying(FgcBusinessException.class, exception ->
-                        assertThat(exception.getErrorCode()).isEqualTo(FgcErrorCode.VRUN_005));
+                        assertThat(exception.getErrorCode()).isEqualTo(FgcErrorCode.VRUN_006));
 
         verify(validationRunMapper, never()).findByIdForUpdate(44L);
     }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* VRUN-W02에서 FUN-044 검증 실행 확정 API를 호출하도록 연결했습니다.

## 🔗 2. 관련 이슈

* Closes #233

## 🛠 3. 구현 내용

* GA_ADMIN·SYSTEM_ADMIN 권한, COMPLETED 상태, 체크리스트 6개 통과를 모두 확인한 뒤 확정 버튼을 활성화합니다.
* IF-API-51 요청에 Idempotency-Key를 전달하고 중복 클릭과 중복 요청을 방지합니다.
* 확정 불변 경고, 성공 후 서버 화면 재조회, 공통 오류 표시를 적용합니다.

## 🧪 4. 테스트 방법

1. `gradlew.bat -g .gradle test --tests com.susukkang.fgc.ui.PendingActionButtonStructureTest --tests com.susukkang.fgc.ui.PublishingTemplateStructureTest --tests com.susukkang.fgc.validation.controller.ValidationRunViewControllerTest`
2. `gradlew.bat -g .gradle build`
3. 역할별 버튼 상태와 확정 성공 후 FINALIZED 화면을 확인합니다.

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* #232를 먼저 병합한 뒤 본 PR을 병합해 주세요.
* 화면 게이트와 서버 IF-API-51 권한·상태 검사가 같은 조건인지 확인 부탁드립니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* FGC-UI-VRUN-W02 확정 버튼과 확정 처리 피드백을 연결했습니다.

## 💬 9. 참고 사항

* 선행 PR: #232
* 병합 순서: #232 → 본 PR