### PR TITLE
[Feat] LEDG-W01 검증원장 조건 조회 및 역분개 화면 연동

### DIFF
--- a/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
+++ b/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
@@ -1,6 +1,8 @@
 package com.susukkang.fgc.common.web;
 
+import com.susukkang.fgc.common.code.JournalHeaderStatus;
 import com.susukkang.fgc.common.security.Roles;
+import com.susukkang.fgc.journal.domain.JournalType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -64,7 +66,13 @@ public class ScreenViewController {
     }
 
     @GetMapping("/journals")
-    public String journalList() {
+    public String journalList(Model model) {
+        // 2026-08-19 yslee - LEDG-W01 검색 선택지를 도메인 enum에서 제공
+        // 기존 코드: 화면에 비어 있는 select만 있어 분개유형·상태 검색을 사용할 수 없음
+        // 문제: 프론트에 enum 값을 하드코딩하면 서버 도메인과 변경 시점이 어긋남
+        // 개선: 서버 도메인 값을 모델로 전달해 IF-API-34 검색조건과 같은 값을 사용
+        model.addAttribute("journalTypes", JournalType.values());
+        model.addAttribute("journalStatuses", JournalHeaderStatus.values());
         return "ledger/list";
     }
 

--- a/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
+++ b/src/main/java/com/susukkang/fgc/common/web/ScreenViewController.java
@@ -1,8 +1,6 @@
 package com.susukkang.fgc.common.web;
 
-import com.susukkang.fgc.common.code.JournalHeaderStatus;
 import com.susukkang.fgc.common.security.Roles;
-import com.susukkang.fgc.journal.domain.JournalType;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -65,18 +63,8 @@ public class ScreenViewController {
         return "arbitrage/list";
     }
 
-    @GetMapping("/journals")
-    public String journalList(Model model) {
-        // 2026-08-19 yslee - LEDG-W01 검색 선택지를 도메인 enum에서 제공
-        // 기존 코드: 화면에 비어 있는 select만 있어 분개유형·상태 검색을 사용할 수 없음
-        // 문제: 프론트에 enum 값을 하드코딩하면 서버 도메인과 변경 시점이 어긋남
-        // 개선: 서버 도메인 값을 모델로 전달해 IF-API-34 검색조건과 같은 값을 사용
-        model.addAttribute("journalTypes", JournalType.values());
-        model.addAttribute("journalStatuses", JournalHeaderStatus.values());
-        return "ledger/list";
-    }
-
     // AUDT-W01(/audit-logs)은 데이터 바인딩과 함께 audit.controller.AuditLogViewController 로,
     // VRUN-W01/W02(/validation-runs)는 validation.controller.ValidationRunViewController 로,
-    // RECO-W01(/reconciliations)은 reconciliation.controller.ReconciliationViewController 로 이관했다.
+    // RECO-W01(/reconciliations)은 reconciliation.controller.ReconciliationViewController 로,
+    // LEDG-W01(/journals)은 journal.controller.JournalViewController 로 이관했다.
 }

--- a/src/main/java/com/susukkang/fgc/journal/controller/JournalViewController.java
+++ b/src/main/java/com/susukkang/fgc/journal/controller/JournalViewController.java
@@ -1,0 +1,107 @@
+package com.susukkang.fgc.journal.controller;
+
+import com.susukkang.fgc.common.code.JournalHeaderStatus;
+import com.susukkang.fgc.common.web.PageResponse;
+import com.susukkang.fgc.journal.domain.JournalType;
+import com.susukkang.fgc.journal.dto.JournalListRow;
+import com.susukkang.fgc.journal.dto.JournalSearchCriteria;
+import com.susukkang.fgc.journal.dto.JournalSearchResponse;
+import com.susukkang.fgc.journal.service.JournalSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 설명 : LEDG-W01 검증원장 MPA 조회 컨트롤러
+ *
+ * @author yslee
+ * @since 2026-08-19
+ * @version 1.2
+ */
+@Controller
+@RequiredArgsConstructor
+public class JournalViewController {
+
+    private static final int PAGE_SIZE = 20;
+
+    private final JournalSearchService journalSearchService;
+
+    @GetMapping("/journals")
+    public String list(
+            @RequestParam(required = false) String from,
+            @RequestParam(required = false) String to,
+            @RequestParam(name = "type", required = false) String journalType,
+            @RequestParam(name = "account", required = false) String accountCode,
+            @RequestParam(name = "contract", required = false) Long contractId,
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "false") boolean searched,
+            Model model
+    ) {
+        // 2026-08-19 yslee - IF-API-34 목록 조회를 인터페이스정의서의 MPA 방식으로 적용
+        // 기존 코드: ledger.js가 폼 제출을 가로채 /api/v1/journals를 Ajax로 호출
+        // 문제: LEDG-W01 목록은 서버 렌더링 대상으로 정의되어 초기 화면·검색·페이징 계약과 불일치
+        // 개선: 조회 버튼을 누른 경우에만 서버에서 검색하고 Thymeleaf 모델로 결과를 렌더링
+        String safeType = enumNameOrNull(JournalType.class, journalType);
+        String safeStatus = enumNameOrNull(JournalHeaderStatus.class, status);
+        LocalDate safeFrom = dateOrNull(from);
+        LocalDate safeTo = dateOrNull(to);
+        int safePage = Math.max(page, 1);
+
+        JournalSearchResponse journals = emptyPage(safePage);
+        if (searched) {
+            JournalSearchCriteria criteria = new JournalSearchCriteria(
+                    safeFrom, safeTo, safeType, blankToNull(accountCode), contractId, safeStatus);
+            PageResponse<JournalListRow> result = journalSearchService.search(criteria, safePage, PAGE_SIZE);
+            journals = JournalSearchResponse.from(result);
+        }
+
+        model.addAttribute("journals", journals);
+        model.addAttribute("searched", searched);
+        model.addAttribute("fromFilter", from);
+        model.addAttribute("toFilter", to);
+        model.addAttribute("typeFilter", safeType);
+        model.addAttribute("accountFilter", accountCode);
+        model.addAttribute("contractFilter", contractId);
+        model.addAttribute("statusFilter", safeStatus);
+        model.addAttribute("journalTypes", JournalType.values());
+        model.addAttribute("journalStatuses", JournalHeaderStatus.values());
+        return "ledger/list";
+    }
+
+    private JournalSearchResponse emptyPage(int page) {
+        return JournalSearchResponse.from(PageResponse.of(List.of(), page, PAGE_SIZE, 0, "journalDate,desc"));
+    }
+
+    private LocalDate dateOrNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return LocalDate.parse(value);
+        } catch (DateTimeException ignored) {
+            return null;
+        }
+    }
+
+    private String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    private <E extends Enum<E>> String enumNameOrNull(Class<E> enumType, String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Enum.valueOf(enumType, value).name();
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+}

--- a/src/main/resources/static/js/features/ledger/ledger.js
+++ b/src/main/resources/static/js/features/ledger/ledger.js
@@ -250,6 +250,10 @@
     });
   }
 
+  // 2026-08-19 yslee - 검증원장 조건 조회를 명시적 조회 버튼 방식으로 변경
+  // 기존 코드: 페이지 진입 즉시 전체 원장을 조회하고 폼 제출 시 조건 조회를 실행
+  // 문제: 사용자가 조회 조건을 확정하기 전에 전체 원장 조회 요청이 발생함
+  // 개선: 초기 자동 조회를 제거하고 조회 버튼으로 제출한 조건만 1페이지부터 조회
   form.addEventListener("submit", function (event) {
     event.preventDefault();
     state.selectedId = null;
@@ -279,5 +283,5 @@
   reverseReason.addEventListener("input", function () { reverseReasonError.hidden = Boolean(reverseReason.value.trim()); });
   reverseSubmit.addEventListener("click", submitReverse);
 
-  loadList(1);
+  renderEmpty("조회 조건을 설정하고 조회 버튼을 눌러 주세요.");
 })();

--- a/src/main/resources/static/js/features/ledger/ledger.js
+++ b/src/main/resources/static/js/features/ledger/ledger.js
@@ -1,8 +1,9 @@
 /**
  * FGC-UI-LEDG-W01 검증원장 목록·상세·역분개 (FUN-046·047)
- * GET  /api/v1/journals                         (IF-API-34)
+ * GET  /journals                                (IF-API-34 · MPA)
  * GET  /api/v1/journals/{id}                    (IF-API-35)
  * POST /api/v1/journals/{id}/reverse            (IF-API-36)
+ * GET  /api/v1/journals/imbalances              (IF-API-37)
  */
 (function () {
   "use strict";
@@ -11,22 +12,19 @@
   var root = document.querySelector(".publishing-page-ledger");
   if (!apiClient || !root) return;
 
-  var form = document.getElementById("ledger-filter-form");
   var listBody = document.getElementById("list-body");
   var detailBody = document.getElementById("detail-body");
   var detailBadge = document.getElementById("detail-badge");
-  var rowCount = document.getElementById("row-count");
-  var previousButton = document.getElementById("ledger-prev");
-  var nextButton = document.getElementById("ledger-next");
-  var pageInfo = document.getElementById("ledger-page-info");
-  var resetButton = document.getElementById("f-reset");
+  var imbalanceBanner = document.getElementById("imbalance-banner");
+  var imbalanceText = document.getElementById("imbalance-text");
+  var balanceBanner = document.getElementById("balance-banner");
   var reverseTarget = document.getElementById("journal-reverse-target");
   var reverseReason = document.getElementById("journal-reverse-reason");
   var reverseEvidence = document.getElementById("journal-reverse-evidence");
   var reverseReasonError = document.getElementById("journal-reverse-reason-error");
   var reverseSubmit = document.getElementById("journal-reverse-submit");
   var canReverse = root.dataset.canReverse === "true";
-  var state = { page: 1, totalPages: 1, selectedId: null, selected: null, pending: false };
+  var state = { selectedId: null, selected: null, pending: false };
 
   function text(value) {
     return value === null || value === undefined || value === "" ? "—" : String(value);
@@ -52,73 +50,6 @@
     if (status === "POSTED") return "fgc-badge--normal";
     if (status === "REVERSED") return "fgc-badge--review";
     return "fgc-badge--neutral";
-  }
-
-  function query(page) {
-    var params = new URLSearchParams();
-    ["from", "to"].forEach(function (name) {
-      var value = document.getElementById("f-" + name).value;
-      if (value) params.set(name, value);
-    });
-    [["type", "f-type"], ["account", "f-account"], ["contract", "f-contract"], ["status", "f-status"]]
-      .forEach(function (entry) {
-        var value = document.getElementById(entry[1]).value.trim();
-        if (value) params.set(entry[0], value);
-      });
-    params.set("page", String(page));
-    params.set("size", "20");
-    return params.toString();
-  }
-
-  function renderEmpty(message) {
-    listBody.replaceChildren();
-    var row = document.createElement("tr");
-    var td = document.createElement("td");
-    td.colSpan = 7;
-    td.appendChild(element("div", "fgc-empty", message));
-    row.appendChild(td);
-    listBody.appendChild(row);
-  }
-
-  function renderRows(content) {
-    listBody.replaceChildren();
-    if (!content.length) {
-      renderEmpty("조건에 맞는 자료가 없습니다.");
-      return;
-    }
-    content.forEach(function (journal) {
-      var row = document.createElement("tr");
-      row.tabIndex = 0;
-      row.dataset.journalId = journal.journalHeaderId;
-      row.classList.toggle("is-selected", String(journal.journalHeaderId) === String(state.selectedId));
-      row.appendChild(cell(text(journal.journalNo), "fgc-mono"));
-      row.appendChild(cell(text(journal.journalDate)));
-      row.appendChild(cell(text(journal.journalTypeLabel)));
-      row.appendChild(cell(text(journal.contractNo || journal.contractId), "fgc-mono"));
-      row.appendChild(cell(won(journal.debitTotal), "fgc-td-num"));
-      row.appendChild(cell(won(journal.creditTotal), "fgc-td-num"));
-      var statusCell = document.createElement("td");
-      statusCell.appendChild(element("span", "fgc-badge " + statusTone(journal.status), journal.statusLabel));
-      row.appendChild(statusCell);
-      listBody.appendChild(row);
-    });
-  }
-
-  function loadList(page) {
-    renderEmpty("분개 목록을 불러오는 중입니다.");
-    return apiClient.request("/api/v1/journals?" + query(page))
-      .then(function (envelope) {
-        var data = envelope.data;
-        state.page = data.page;
-        state.totalPages = Math.max(data.totalPages, 1);
-        rowCount.textContent = data.totalElements;
-        pageInfo.textContent = state.page + " / " + state.totalPages;
-        previousButton.disabled = state.page <= 1;
-        nextButton.disabled = state.page >= state.totalPages;
-        renderRows(data.content || []);
-      }).catch(function (error) {
-        renderEmpty(error && error.message ? error.message : "분개 목록을 불러오지 못했습니다.");
-      });
   }
 
   function appendKeyValue(container, label, value) {
@@ -160,6 +91,46 @@
       && !detail.reversedByJournalHeaderId;
   }
 
+  function showBalanceResult(totalCount) {
+    var hasImbalance = Number(totalCount) > 0;
+    imbalanceBanner.hidden = !hasImbalance;
+    imbalanceText.textContent = hasImbalance
+      ? "이 검증 실행에 차변·대변이 맞지 않는 분개가 " + totalCount + "건 있습니다."
+      : "";
+    balanceBanner.hidden = hasImbalance;
+    if (!hasImbalance) {
+      balanceBanner.className = "fgc-banner fgc-banner--success";
+      balanceBanner.querySelector("span:last-child").textContent =
+        "선택한 분개의 검증 실행은 원장 불균형이 0건입니다.";
+    }
+  }
+
+  // 2026-08-19 yslee - 상세 분개의 검증실행 기준 불균형 배너를 IF-API-37과 연동
+  // 기존 코드: 배너 요소와 연동 주석만 있고 항상 hidden 상태로 남아 있었음
+  // 문제: 사용자가 POSTED 전 필수 조건인 원장 불균형 0건 여부를 화면에서 확인할 수 없음
+  // 개선: 상세의 validationRunId로 불균형 뷰를 조회해 오류 건수와 0건 결과를 구분 표시
+  function loadImbalance(validationRunId) {
+    imbalanceBanner.hidden = true;
+    balanceBanner.hidden = false;
+    balanceBanner.className = "fgc-banner fgc-banner--muted";
+    balanceBanner.querySelector("span:last-child").textContent = validationRunId
+      ? "원장 불균형 여부를 확인하는 중입니다."
+      : "이 분개에는 연결된 검증 실행이 없어 실행 단위 불균형을 조회할 수 없습니다.";
+    if (!validationRunId) return Promise.resolve();
+
+    return apiClient.request("/api/v1/journals/imbalances?validationRunId="
+      + encodeURIComponent(validationRunId))
+      .then(function (envelope) {
+        showBalanceResult(envelope.data.totalCount);
+      }).catch(function () {
+        imbalanceBanner.hidden = true;
+        balanceBanner.hidden = false;
+        balanceBanner.className = "fgc-banner fgc-banner--muted";
+        balanceBanner.querySelector("span:last-child").textContent =
+          "원장 불균형 결과를 불러오지 못했습니다. 잠시 후 다시 확인해 주세요.";
+      });
+  }
+
   function renderDetail(detail) {
     state.selected = detail;
     detailBody.replaceChildren();
@@ -190,6 +161,7 @@
       actions.appendChild(element("p", "fgc-muted", "POSTED 원분개만 역분개할 수 있습니다."));
     }
     detailBody.appendChild(actions);
+    loadImbalance(detail.validationRunId);
   }
 
   function loadDetail(journalId) {
@@ -239,7 +211,8 @@
       var result = envelope.data;
       window.FgcUi.modal.close("journal-reverse");
       if (window.FgcUi.toast) window.FgcUi.toast("역분개 " + result.journalHeaderId + "을 생성했습니다.", "success");
-      return loadList(state.page).then(function () { return loadDetail(result.journalHeaderId); });
+      window.location.reload();
+      return result;
     }).catch(function (error) {
       if (window.FgcUi.toast) window.FgcUi.toast(error && error.message
         ? error.message : "역분개 생성에 실패했습니다.", "error");
@@ -250,22 +223,6 @@
     });
   }
 
-  // 2026-08-19 yslee - 검증원장 조건 조회를 명시적 조회 버튼 방식으로 변경
-  // 기존 코드: 페이지 진입 즉시 전체 원장을 조회하고 폼 제출 시 조건 조회를 실행
-  // 문제: 사용자가 조회 조건을 확정하기 전에 전체 원장 조회 요청이 발생함
-  // 개선: 초기 자동 조회를 제거하고 조회 버튼으로 제출한 조건만 1페이지부터 조회
-  form.addEventListener("submit", function (event) {
-    event.preventDefault();
-    state.selectedId = null;
-    loadList(1);
-  });
-  resetButton.addEventListener("click", function () {
-    form.reset();
-    state.selectedId = null;
-    loadList(1);
-  });
-  previousButton.addEventListener("click", function () { if (state.page > 1) loadList(state.page - 1); });
-  nextButton.addEventListener("click", function () { if (state.page < state.totalPages) loadList(state.page + 1); });
   listBody.addEventListener("click", function (event) {
     var row = event.target.closest("tr[data-journal-id]");
     if (row) loadDetail(row.dataset.journalId);
@@ -283,5 +240,4 @@
   reverseReason.addEventListener("input", function () { reverseReasonError.hidden = Boolean(reverseReason.value.trim()); });
   reverseSubmit.addEventListener("click", submitReverse);
 
-  renderEmpty("조회 조건을 설정하고 조회 버튼을 눌러 주세요.");
 })();

--- a/src/main/resources/static/js/features/ledger/ledger.js
+++ b/src/main/resources/static/js/features/ledger/ledger.js
@@ -1,0 +1,283 @@
+/**
+ * FGC-UI-LEDG-W01 검증원장 목록·상세·역분개 (FUN-046·047)
+ * GET  /api/v1/journals                         (IF-API-34)
+ * GET  /api/v1/journals/{id}                    (IF-API-35)
+ * POST /api/v1/journals/{id}/reverse            (IF-API-36)
+ */
+(function () {
+  "use strict";
+
+  var apiClient = window.FgcUi && window.FgcUi.apiClient;
+  var root = document.querySelector(".publishing-page-ledger");
+  if (!apiClient || !root) return;
+
+  var form = document.getElementById("ledger-filter-form");
+  var listBody = document.getElementById("list-body");
+  var detailBody = document.getElementById("detail-body");
+  var detailBadge = document.getElementById("detail-badge");
+  var rowCount = document.getElementById("row-count");
+  var previousButton = document.getElementById("ledger-prev");
+  var nextButton = document.getElementById("ledger-next");
+  var pageInfo = document.getElementById("ledger-page-info");
+  var resetButton = document.getElementById("f-reset");
+  var reverseTarget = document.getElementById("journal-reverse-target");
+  var reverseReason = document.getElementById("journal-reverse-reason");
+  var reverseEvidence = document.getElementById("journal-reverse-evidence");
+  var reverseReasonError = document.getElementById("journal-reverse-reason-error");
+  var reverseSubmit = document.getElementById("journal-reverse-submit");
+  var canReverse = root.dataset.canReverse === "true";
+  var state = { page: 1, totalPages: 1, selectedId: null, selected: null, pending: false };
+
+  function text(value) {
+    return value === null || value === undefined || value === "" ? "—" : String(value);
+  }
+
+  function won(value) {
+    var amount = Number(value || 0);
+    return Number.isFinite(amount) ? amount.toLocaleString("ko-KR") + "원" : "—";
+  }
+
+  function element(tag, className, content) {
+    var node = document.createElement(tag);
+    if (className) node.className = className;
+    if (content !== undefined) node.textContent = content;
+    return node;
+  }
+
+  function cell(content, className) {
+    return element("td", className, content);
+  }
+
+  function statusTone(status) {
+    if (status === "POSTED") return "fgc-badge--normal";
+    if (status === "REVERSED") return "fgc-badge--review";
+    return "fgc-badge--neutral";
+  }
+
+  function query(page) {
+    var params = new URLSearchParams();
+    ["from", "to"].forEach(function (name) {
+      var value = document.getElementById("f-" + name).value;
+      if (value) params.set(name, value);
+    });
+    [["type", "f-type"], ["account", "f-account"], ["contract", "f-contract"], ["status", "f-status"]]
+      .forEach(function (entry) {
+        var value = document.getElementById(entry[1]).value.trim();
+        if (value) params.set(entry[0], value);
+      });
+    params.set("page", String(page));
+    params.set("size", "20");
+    return params.toString();
+  }
+
+  function renderEmpty(message) {
+    listBody.replaceChildren();
+    var row = document.createElement("tr");
+    var td = document.createElement("td");
+    td.colSpan = 7;
+    td.appendChild(element("div", "fgc-empty", message));
+    row.appendChild(td);
+    listBody.appendChild(row);
+  }
+
+  function renderRows(content) {
+    listBody.replaceChildren();
+    if (!content.length) {
+      renderEmpty("조건에 맞는 자료가 없습니다.");
+      return;
+    }
+    content.forEach(function (journal) {
+      var row = document.createElement("tr");
+      row.tabIndex = 0;
+      row.dataset.journalId = journal.journalHeaderId;
+      row.classList.toggle("is-selected", String(journal.journalHeaderId) === String(state.selectedId));
+      row.appendChild(cell(text(journal.journalNo), "fgc-mono"));
+      row.appendChild(cell(text(journal.journalDate)));
+      row.appendChild(cell(text(journal.journalTypeLabel)));
+      row.appendChild(cell(text(journal.contractNo || journal.contractId), "fgc-mono"));
+      row.appendChild(cell(won(journal.debitTotal), "fgc-td-num"));
+      row.appendChild(cell(won(journal.creditTotal), "fgc-td-num"));
+      var statusCell = document.createElement("td");
+      statusCell.appendChild(element("span", "fgc-badge " + statusTone(journal.status), journal.statusLabel));
+      row.appendChild(statusCell);
+      listBody.appendChild(row);
+    });
+  }
+
+  function loadList(page) {
+    renderEmpty("분개 목록을 불러오는 중입니다.");
+    return apiClient.request("/api/v1/journals?" + query(page))
+      .then(function (envelope) {
+        var data = envelope.data;
+        state.page = data.page;
+        state.totalPages = Math.max(data.totalPages, 1);
+        rowCount.textContent = data.totalElements;
+        pageInfo.textContent = state.page + " / " + state.totalPages;
+        previousButton.disabled = state.page <= 1;
+        nextButton.disabled = state.page >= state.totalPages;
+        renderRows(data.content || []);
+      }).catch(function (error) {
+        renderEmpty(error && error.message ? error.message : "분개 목록을 불러오지 못했습니다.");
+      });
+  }
+
+  function appendKeyValue(container, label, value) {
+    var item = element("div", "");
+    item.appendChild(element("strong", "", label));
+    item.appendChild(element("span", "fgc-muted", text(value)));
+    container.appendChild(item);
+  }
+
+  function renderLines(lines) {
+    var wrapper = element("div", "");
+    wrapper.style.overflowX = "auto";
+    var table = element("table", "fgc-table");
+    var head = document.createElement("thead");
+    var headerRow = document.createElement("tr");
+    ["번호", "계정", "차변", "대변", "설계사", "항목"].forEach(function (label) {
+      headerRow.appendChild(element("th", "", label));
+    });
+    head.appendChild(headerRow);
+    table.appendChild(head);
+    var body = document.createElement("tbody");
+    lines.forEach(function (line) {
+      var row = document.createElement("tr");
+      row.appendChild(cell(text(line.lineNo)));
+      row.appendChild(cell(text(line.accountName || line.accountCode)));
+      row.appendChild(cell(won(line.debitAmount), "fgc-td-num"));
+      row.appendChild(cell(won(line.creditAmount), "fgc-td-num"));
+      row.appendChild(cell(text(line.agentName)));
+      row.appendChild(cell(text(line.commissionItemName)));
+      body.appendChild(row);
+    });
+    table.appendChild(body);
+    wrapper.appendChild(table);
+    return wrapper;
+  }
+
+  function reverseAllowed(detail) {
+    return canReverse && detail.status === "POSTED" && detail.journalType !== "REVERSAL"
+      && !detail.reversedByJournalHeaderId;
+  }
+
+  function renderDetail(detail) {
+    state.selected = detail;
+    detailBody.replaceChildren();
+    detailBadge.replaceChildren(element("span", "fgc-badge " + statusTone(detail.status), detail.statusLabel));
+
+    var summary = element("div", "kv");
+    appendKeyValue(summary, "분개번호", detail.journalNo);
+    appendKeyValue(summary, "분개일", detail.journalDate);
+    appendKeyValue(summary, "유형", detail.journalTypeLabel);
+    appendKeyValue(summary, "계약", detail.contractNo || detail.contractId);
+    appendKeyValue(summary, "차변 합계", won(detail.debitTotal));
+    appendKeyValue(summary, "대변 합계", won(detail.creditTotal));
+    appendKeyValue(summary, "원분개", detail.reversalOfJournalNo);
+    appendKeyValue(summary, "역분개", detail.reversedByJournalNo);
+    detailBody.appendChild(summary);
+    detailBody.appendChild(renderLines(detail.lines || []));
+
+    var actions = element("div", "", "");
+    actions.style.marginTop = "16px";
+    if (reverseAllowed(detail)) {
+      var button = element("button", "fgc-btn fgc-btn--primary", "역분개");
+      button.type = "button";
+      button.dataset.reverseJournal = detail.journalHeaderId;
+      actions.appendChild(button);
+    } else if (detail.status === "POSTED" && !canReverse) {
+      actions.appendChild(element("p", "fgc-muted", "역분개는 SETTLEMENT·GA_ADMIN·SYSTEM_ADMIN 권한이 필요합니다."));
+    } else {
+      actions.appendChild(element("p", "fgc-muted", "POSTED 원분개만 역분개할 수 있습니다."));
+    }
+    detailBody.appendChild(actions);
+  }
+
+  function loadDetail(journalId) {
+    state.selectedId = journalId;
+    detailBody.replaceChildren(element("p", "fgc-muted", "분개 상세를 불러오는 중입니다."));
+    return apiClient.request("/api/v1/journals/" + encodeURIComponent(journalId))
+      .then(function (envelope) {
+        renderDetail(envelope.data);
+        listBody.querySelectorAll("tr[data-journal-id]").forEach(function (row) {
+          row.classList.toggle("is-selected", row.dataset.journalId === String(journalId));
+        });
+      }).catch(function (error) {
+        detailBody.replaceChildren(element("p", "fgc-error", error && error.message
+          ? error.message : "분개 상세를 불러오지 못했습니다."));
+      });
+  }
+
+  function openReverseModal() {
+    if (!state.selected || !reverseAllowed(state.selected) || !window.FgcUi.modal) return;
+    reverseTarget.textContent = state.selected.journalNo + " · " + state.selected.journalTypeLabel;
+    reverseReason.value = "";
+    reverseEvidence.value = "";
+    reverseReasonError.hidden = true;
+    window.FgcUi.modal.open("journal-reverse");
+  }
+
+  // 2026-08-19 yslee - FUN-047 원분개 역분개 API를 LEDG-W01에 연결
+  // 기존 코드: 목록·상세가 정적 빈 화면이고 역분개 입력 및 호출 동작이 없음
+  // 문제: 구현된 IF-API-36을 정산담당자가 화면에서 사용할 수 없음
+  // 개선: POSTED 원분개만 선택해 필수 사유와 증빙을 보내고 서버 결과로 목록·상세를 갱신
+  function submitReverse() {
+    var reason = reverseReason.value.trim();
+    if (!reason) {
+      reverseReasonError.hidden = false;
+      reverseReason.focus();
+      return;
+    }
+    if (state.pending || !state.selected || !reverseAllowed(state.selected)) return;
+
+    state.pending = true;
+    reverseSubmit.disabled = true;
+    reverseSubmit.setAttribute("aria-busy", "true");
+    apiClient.request("/api/v1/journals/" + encodeURIComponent(state.selected.journalHeaderId) + "/reverse", {
+      method: "POST",
+      body: { reason: reason, evidenceRef: reverseEvidence.value.trim() || null }
+    }).then(function (envelope) {
+      var result = envelope.data;
+      window.FgcUi.modal.close("journal-reverse");
+      if (window.FgcUi.toast) window.FgcUi.toast("역분개 " + result.journalHeaderId + "을 생성했습니다.", "success");
+      return loadList(state.page).then(function () { return loadDetail(result.journalHeaderId); });
+    }).catch(function (error) {
+      if (window.FgcUi.toast) window.FgcUi.toast(error && error.message
+        ? error.message : "역분개 생성에 실패했습니다.", "error");
+    }).finally(function () {
+      state.pending = false;
+      reverseSubmit.disabled = false;
+      reverseSubmit.removeAttribute("aria-busy");
+    });
+  }
+
+  form.addEventListener("submit", function (event) {
+    event.preventDefault();
+    state.selectedId = null;
+    loadList(1);
+  });
+  resetButton.addEventListener("click", function () {
+    form.reset();
+    state.selectedId = null;
+    loadList(1);
+  });
+  previousButton.addEventListener("click", function () { if (state.page > 1) loadList(state.page - 1); });
+  nextButton.addEventListener("click", function () { if (state.page < state.totalPages) loadList(state.page + 1); });
+  listBody.addEventListener("click", function (event) {
+    var row = event.target.closest("tr[data-journal-id]");
+    if (row) loadDetail(row.dataset.journalId);
+  });
+  listBody.addEventListener("keydown", function (event) {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    var row = event.target.closest("tr[data-journal-id]");
+    if (!row) return;
+    event.preventDefault();
+    loadDetail(row.dataset.journalId);
+  });
+  detailBody.addEventListener("click", function (event) {
+    if (event.target.closest("[data-reverse-journal]")) openReverseModal();
+  });
+  reverseReason.addEventListener("input", function () { reverseReasonError.hidden = Boolean(reverseReason.value.trim()); });
+  reverseSubmit.addEventListener("click", submitReverse);
+
+  loadList(1);
+})();

--- a/src/main/resources/templates/layout/default.html
+++ b/src/main/resources/templates/layout/default.html
@@ -60,6 +60,7 @@
   <script th:if="${screenId == 'FGC-UI-CONT-W03'}" th:src="@{/js/features/contract/contract-form.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-VRUN-W02'}" th:src="@{/js/features/vrun/vrun-detail.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-RECO-W01'}" th:src="@{/js/features/reco/reco.js}" defer></script>
+  <script th:if="${screenId == 'FGC-UI-LEDG-W01'}" th:src="@{/js/features/ledger/ledger.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-EXCP-W01'}" th:src="@{/js/features/exception/exception-list.js}" defer></script>
 </body>
 </html>

--- a/src/main/resources/templates/ledger/list.html
+++ b/src/main/resources/templates/ledger/list.html
@@ -14,7 +14,7 @@
    · 차변≠대변인 상태로 기표(POSTED) 전환
    · 한 줄에 차변·대변을 동시에 적기 — DB CHECK 가 막습니다
 
-  목록·상세는 IF-API-34/35, 역분개는 IF-API-36을 Ajax로 연결한다.
+  목록은 IF-API-34 MPA, 상세·역분개·불균형 확인은 IF-API-35/36/37 Ajax로 연결한다.
 -->
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-LEDG-W01', '검증원장 조회', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
@@ -58,43 +58,49 @@
 
   <!-- ① 검색 -->
   <section class="fgc-card" style="margin-top:16px">
-    <form class="fgc-card__body fgc-toolbar" id="ledger-filter-form">
+    <form class="fgc-card__body fgc-toolbar" id="ledger-filter-form" method="get" th:action="@{/journals}">
       <div class="fgc-field" style="min-width:130px">
         <label class="fgc-label" for="f-from">분개일 (시작)</label>
-        <input class="fgc-input" id="f-from" type="date" th:value="${month} + '-01'" value="2026-07-01">
+        <input class="fgc-input" id="f-from" name="from" type="date"
+               th:value="${fromFilter ?: month + '-01'}" value="2026-07-01">
       </div>
       <div class="fgc-field" style="min-width:130px">
         <label class="fgc-label" for="f-to">분개일 (끝)</label>
-        <input class="fgc-input" id="f-to" type="date" th:value="${T(java.time.YearMonth).parse(month).atEndOfMonth()}" value="2026-07-31">
+        <input class="fgc-input" id="f-to" name="to" type="date"
+               th:value="${toFilter ?: T(java.time.YearMonth).parse(month).atEndOfMonth()}" value="2026-07-31">
       </div>
       <div class="fgc-field" style="min-width:220px">
         <label class="fgc-label" for="f-type">분개 유형</label>
         <select class="fgc-select" id="f-type" name="type">
-          <option value="">전체</option>
-          <option th:each="type : ${journalTypes}" th:value="${type.name()}" th:text="${type.label()}"></option>
+          <option value="" th:selected="${typeFilter == null}">전체</option>
+          <option th:each="type : ${journalTypes}" th:value="${type.name()}" th:text="${type.label()}"
+                  th:selected="${type.name() == typeFilter}"></option>
         </select>
       </div>
       <div class="fgc-field" style="min-width:150px">
         <label class="fgc-label" for="f-account">계정과목</label>
-        <input class="fgc-input" id="f-account" name="account" type="text" placeholder="계정코드">
+        <input class="fgc-input" id="f-account" name="account" type="text" placeholder="계정코드"
+               th:value="${accountFilter}">
       </div>
       <div class="fgc-field" style="min-width:120px">
         <label class="fgc-label" for="f-contract">계약 ID</label>
-        <input class="fgc-input" id="f-contract" name="contract" type="number" min="1" inputmode="numeric">
+        <input class="fgc-input" id="f-contract" name="contract" type="number" min="1" inputmode="numeric"
+               th:value="${contractFilter}">
       </div>
       <div class="fgc-field" style="min-width:120px">
         <label class="fgc-label" for="f-status">상태</label>
         <select class="fgc-select" id="f-status" name="status">
-          <option value="">전체</option>
-          <option th:each="status : ${journalStatuses}" th:value="${status.name()}" th:text="${status.label()}"></option>
+          <option value="" th:selected="${statusFilter == null}">전체</option>
+          <option th:each="status : ${journalStatuses}" th:value="${status.name()}" th:text="${status.label()}"
+                  th:selected="${status.name() == statusFilter}"></option>
         </select>
       </div>
-      <button class="fgc-btn fgc-btn--primary" id="f-search" type="submit">
+      <button class="fgc-btn fgc-btn--primary" id="f-search" name="searched" value="true" type="submit">
         <span class="material-symbols-outlined" style="font-size:18px">search</span> 조회
       </button>
-      <button class="fgc-btn fgc-btn--ghost" id="f-reset" type="button">
+      <a class="fgc-btn fgc-btn--ghost" id="f-reset" th:href="@{/journals}">
         <span class="material-symbols-outlined" style="font-size:18px">restart_alt</span> 초기화
-      </button>
+      </a>
     </form>
   </section>
 
@@ -104,7 +110,7 @@
     <section class="fgc-card">
       <div class="fgc-card__head">
         <span class="fgc-card__title">분개 목록</span>
-        <span class="fgc-muted" style="font-size:12px"><span id="row-count">0</span>건 · 한 화면 20행</span>
+        <span class="fgc-muted" style="font-size:12px"><span id="row-count" th:text="${journals.totalElements}">0</span>건 · 한 화면 20행</span>
       </div>
       <div style="overflow-x:auto">
         <table class="fgc-table">
@@ -113,21 +119,52 @@
               <th style="width:126px">분개번호</th>
               <th style="width:92px">분개일</th>
               <th style="width:170px">유형</th>
+              <th style="width:170px">원천</th>
               <th style="width:66px">계약</th>
               <th class="fgc-th-num" style="width:104px">차변 합계</th>
               <th class="fgc-th-num" style="width:104px">대변 합계</th>
               <th style="width:88px">상태</th>
+              <th style="width:126px">역분개 표시</th>
             </tr>
           </thead>
           <tbody id="list-body">
-            <tr><td colspan="7"><div class="fgc-empty">분개 목록을 불러오는 중입니다.</div></td></tr>
+            <tr th:if="${!searched}">
+              <td colspan="9"><div class="fgc-empty">조회 조건을 설정하고 조회 버튼을 눌러 주세요.</div></td>
+            </tr>
+            <tr th:if="${searched and journals.content.empty}">
+              <td colspan="9"><div class="fgc-empty">조건에 맞는 자료가 없습니다.</div></td>
+            </tr>
+            <tr th:each="journal : ${journals.content}" tabindex="0"
+                th:data-journal-id="${journal.journalHeaderId}">
+              <td class="fgc-mono" th:text="${journal.journalNo}">JRN-001</td>
+              <td th:text="${journal.journalDate}">2026-07-31</td>
+              <td th:text="${journal.journalTypeLabel}">실제 지급</td>
+              <td class="fgc-mono"
+                  th:text="${journal.sourceEntityType + ' #' + journal.sourceEntityId}">COMMISSION_TRANSACTION #1</td>
+              <td class="fgc-mono" th:text="${journal.contractNo ?: journal.contractId}">C-001</td>
+              <td class="fgc-td-num"
+                  th:classappend="${journal.debitTotal.compareTo(journal.creditTotal) != 0} ? ' fgc-error'"
+                  th:text="${#numbers.formatDecimal(journal.debitTotal, 1, 'COMMA', 0, 'POINT') + '원'}">0원</td>
+              <td class="fgc-td-num"
+                  th:classappend="${journal.debitTotal.compareTo(journal.creditTotal) != 0} ? ' fgc-error'"
+                  th:text="${#numbers.formatDecimal(journal.creditTotal, 1, 'COMMA', 0, 'POINT') + '원'}">0원</td>
+              <td><span class="fgc-badge" th:text="${journal.statusLabel}">기표</span></td>
+              <td>
+                <span class="fgc-badge fgc-badge--review" th:if="${journal.reversalOfJournalNo != null}"
+                      th:text="${'원분개 ' + journal.reversalOfJournalNo}">원분개 JRN-001</span>
+                <span th:unless="${journal.reversalOfJournalNo != null}">—</span>
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>
       <footer class="fgc-pagination" id="ledger-pagination" style="padding:10px 16px;display:flex;justify-content:flex-end;gap:8px">
-        <button class="fgc-btn fgc-btn--ghost" id="ledger-prev" type="button">이전</button>
-        <span id="ledger-page-info" class="fgc-muted" style="align-self:center">1 / 1</span>
-        <button class="fgc-btn fgc-btn--ghost" id="ledger-next" type="button">다음</button>
+        <a class="fgc-btn fgc-btn--ghost" id="ledger-prev" th:if="${journals.page > 1}"
+           th:href="@{/journals(from=${fromFilter},to=${toFilter},type=${typeFilter},account=${accountFilter},contract=${contractFilter},status=${statusFilter},searched=true,page=${journals.page - 1})}">이전</a>
+        <span id="ledger-page-info" class="fgc-muted" style="align-self:center"
+              th:text="${journals.page + ' / ' + (journals.totalPages > 0 ? journals.totalPages : 1)}">1 / 1</span>
+        <a class="fgc-btn fgc-btn--ghost" id="ledger-next" th:if="${journals.page < journals.totalPages}"
+           th:href="@{/journals(from=${fromFilter},to=${toFilter},type=${typeFilter},account=${accountFilter},contract=${contractFilter},status=${statusFilter},searched=true,page=${journals.page + 1})}">다음</a>
       </footer>
     </section>
 

--- a/src/main/resources/templates/ledger/list.html
+++ b/src/main/resources/templates/ledger/list.html
@@ -14,13 +14,13 @@
    · 차변≠대변인 상태로 기표(POSTED) 전환
    · 한 줄에 차변·대변을 동시에 적기 — DB CHECK 가 막습니다
 
-  [정적 부착 단계] 목업(30_산출물/화면_MVP/FGC-UI-LEDG-W01)의 정적 골격만 옮겼다.
-  데이터 영역(분개 목록·상세·불균형 배너·필터 선택지)은 IF-API 연동 시 서버 렌더링으로 채운다.
+  목록·상세는 IF-API-34/35, 역분개는 IF-API-36을 Ajax로 연결한다.
 -->
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-LEDG-W01', '검증원장 조회', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-ledger">
+<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-ledger"
+      th:attr="data-can-reverse=${roleCode == 'SETTLEMENT' or roleCode == 'GA_ADMIN' or roleCode == 'SYSTEM_ADMIN'}">
 
   <h1 class="fgc-page-title">검증원장 조회</h1>
   <p class="fgc-page-desc">
@@ -35,7 +35,7 @@
     <span><strong id="notice-ledger">이 원장은 회사의 정식 회계장부가 아닙니다. 정산이 맞는지 확인하려고 FGC가 따로 만드는 보조 장부입니다.</strong></span>
   </div>
 
-  <!-- ② 불균형 경고 배너 — vw_journal_imbalance 조회 결과로 서버 렌더링 시 전환한다 -->
+  <!-- ② 불균형 경고 배너 — validationRunId가 있는 상세 조회 후 IF-API-37로 확인한다. -->
   <div class="fgc-banner fgc-banner--error" id="imbalance-banner" style="margin-top:10px" hidden>
     <span class="material-symbols-outlined" style="font-size:18px">error</span>
     <span id="imbalance-text"></span>
@@ -44,7 +44,7 @@
   <div class="fgc-banner fgc-banner--muted" id="balance-banner" style="margin-top:10px">
     <span class="material-symbols-outlined" style="font-size:18px">info</span>
     <span>
-      원장 균형(차변=대변, <span class="fgc-mono">vw_journal_imbalance</span> 0건 여부)은 IF-API-34 연동 시 집계 결과로 표시합니다.
+      원장 균형(차변=대변, <span class="fgc-mono">vw_journal_imbalance</span> 0건 여부)은 상세 분개의 검증실행 기준으로 표시합니다.
       기표(POSTED) 전에는 반드시 0건이어야 하며 월 통합검증 확정 조건 ②번입니다.
     </span>
   </div>
@@ -58,7 +58,7 @@
 
   <!-- ① 검색 -->
   <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__body fgc-toolbar">
+    <form class="fgc-card__body fgc-toolbar" id="ledger-filter-form">
       <div class="fgc-field" style="min-width:130px">
         <label class="fgc-label" for="f-from">분개일 (시작)</label>
         <input class="fgc-input" id="f-from" type="date" th:value="${month} + '-01'" value="2026-07-01">
@@ -69,24 +69,33 @@
       </div>
       <div class="fgc-field" style="min-width:220px">
         <label class="fgc-label" for="f-type">분개 유형</label>
-        <select class="fgc-select" id="f-type"><option value="">전체</option></select>
+        <select class="fgc-select" id="f-type" name="type">
+          <option value="">전체</option>
+          <option th:each="type : ${journalTypes}" th:value="${type.name()}" th:text="${type.label()}"></option>
+        </select>
       </div>
       <div class="fgc-field" style="min-width:150px">
         <label class="fgc-label" for="f-account">계정과목</label>
-        <select class="fgc-select" id="f-account"><option value="">전체</option></select>
+        <input class="fgc-input" id="f-account" name="account" type="text" placeholder="계정코드">
       </div>
       <div class="fgc-field" style="min-width:120px">
-        <label class="fgc-label" for="f-contract">계약번호</label>
-        <input class="fgc-input" id="f-contract" type="text" placeholder="C001">
+        <label class="fgc-label" for="f-contract">계약 ID</label>
+        <input class="fgc-input" id="f-contract" name="contract" type="number" min="1" inputmode="numeric">
       </div>
       <div class="fgc-field" style="min-width:120px">
         <label class="fgc-label" for="f-status">상태</label>
-        <select class="fgc-select" id="f-status"><option value="">전체</option></select>
+        <select class="fgc-select" id="f-status" name="status">
+          <option value="">전체</option>
+          <option th:each="status : ${journalStatuses}" th:value="${status.name()}" th:text="${status.label()}"></option>
+        </select>
       </div>
-      <button class="fgc-btn fgc-btn--ghost" id="f-reset">
+      <button class="fgc-btn fgc-btn--primary" id="f-search" type="submit">
+        <span class="material-symbols-outlined" style="font-size:18px">search</span> 조회
+      </button>
+      <button class="fgc-btn fgc-btn--ghost" id="f-reset" type="button">
         <span class="material-symbols-outlined" style="font-size:18px">restart_alt</span> 초기화
       </button>
-    </div>
+    </form>
   </section>
 
   <div class="fgc-responsive-split" style="margin-top:16px;display:grid;grid-template-columns:1.35fr 1fr;gap:16px" id="ledger-grid">
@@ -111,10 +120,15 @@
             </tr>
           </thead>
           <tbody id="list-body">
-            <tr><td colspan="7"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
+            <tr><td colspan="7"><div class="fgc-empty">분개 목록을 불러오는 중입니다.</div></td></tr>
           </tbody>
         </table>
       </div>
+      <footer class="fgc-pagination" id="ledger-pagination" style="padding:10px 16px;display:flex;justify-content:flex-end;gap:8px">
+        <button class="fgc-btn fgc-btn--ghost" id="ledger-prev" type="button">이전</button>
+        <span id="ledger-page-info" class="fgc-muted" style="align-self:center">1 / 1</span>
+        <button class="fgc-btn fgc-btn--ghost" id="ledger-next" type="button">다음</button>
+      </footer>
     </section>
 
     <!-- ④ 상세 패널 -->
@@ -129,9 +143,31 @@
     </section>
   </div>
 
+  <div class="modal-backdrop" data-modal="journal-reverse" data-close-on-backdrop="true" hidden aria-hidden="true">
+    <section class="modal" role="dialog" aria-modal="true" aria-labelledby="journal-reverse-title" style="width:min(520px,100%)">
+      <header class="modal-header"><h2 class="modal-title" id="journal-reverse-title">원분개 역분개</h2></header>
+      <div class="modal-body">
+        <p class="fgc-muted" id="journal-reverse-target" style="margin-top:0"></p>
+        <div class="fgc-banner fgc-banner--warn">
+          원분개를 수정하거나 삭제하지 않고 반대 차변·대변의 새 분개를 만듭니다. 처리 후 되돌리려면 별도 정정 절차가 필요합니다.
+        </div>
+        <label class="fgc-label fgc-label--required" for="journal-reverse-reason" style="display:block;margin-top:16px">역분개 사유</label>
+        <textarea class="textarea-control" id="journal-reverse-reason" maxlength="1000" rows="5" required
+                  data-modal-initial-focus placeholder="역분개가 필요한 업무 사유를 입력하세요."></textarea>
+        <p class="fgc-error" id="journal-reverse-reason-error" hidden>역분개 사유를 입력하세요.</p>
+        <label class="fgc-label" for="journal-reverse-evidence" style="display:block;margin-top:16px">증빙 참조</label>
+        <input class="fgc-input" id="journal-reverse-evidence" maxlength="500" type="text" placeholder="문서번호 또는 내부 증빙 경로">
+      </div>
+      <footer class="modal-footer">
+        <button class="fgc-btn fgc-btn--ghost" type="button" data-modal-close>취소</button>
+        <button class="fgc-btn fgc-btn--primary" id="journal-reverse-submit" type="button">역분개 생성</button>
+      </footer>
+    </section>
+  </div>
+
 <!-- 스크립트는 main 안에 둔다 - 셸의 page()는 ~{::main}만 삽입하므로 main 밖 스크립트는 렌더링에서 사라진다 -->
 <script>
-/* 화면 폭이 좁으면 목록·상세 2단 그리드를 세로로 — 데이터 렌더링은 IF-API 연동 시 추가 */
+/* 화면 폭이 좁으면 목록·상세 2단 그리드를 세로로 표시한다. */
 (function () {
   "use strict";
   function reflow() {

--- a/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
@@ -204,6 +204,20 @@ class ScreenViewControllerTest {
                 .andExpect(content().string(visible ? marker : org.hamcrest.Matchers.not(marker)));
     }
 
+    @ParameterizedTest(name = "{0} LEDG-W01 역분개 가능={1}")
+    @CsvSource({
+            "SETTLEMENT,   true",
+            "GA_ADMIN,     true",
+            "SYSTEM_ADMIN, true",
+            "COMPLIANCE,   false",
+    })
+    void journal_reverse_capability_matches_api_roles(String role, boolean allowed) throws Exception {
+        mvc.perform(get("/journals").with(user(userFor(role))))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "data-can-reverse=\"" + allowed + "\"")));
+    }
+
     /**
      * FGC-FUN-002 — GA_ADMIN 은 readOnly=false 지만 등록·실행은 못 한다(§4-1 "정책·조직 조회, 검증 실행 확정").
      * readOnly 만 보던 시절 GA_ADMIN 에게 처리 버튼이 활성이던 회귀를 막는다 — 대표로

--- a/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
@@ -65,7 +65,6 @@ class ScreenViewControllerTest {
             "/schedules/1,         FGC-UI-SCHE-W02",
             "/cap-checks,          FGC-UI-CAP-W01",
             "/arbitrage-checks,    FGC-UI-ARB-W01",
-            "/journals,            FGC-UI-LEDG-W01",
     })
     void screen_renders_with_its_id(String route, String screenId) throws Exception {
         mvc.perform(get(route).with(user(settleUser())))
@@ -202,20 +201,6 @@ class ScreenViewControllerTest {
         var marker = org.hamcrest.Matchers.containsString("data-fgc-action=\"create\"");
         mvc.perform(get(route).with(user(userFor(role))))
                 .andExpect(content().string(visible ? marker : org.hamcrest.Matchers.not(marker)));
-    }
-
-    @ParameterizedTest(name = "{0} LEDG-W01 역분개 가능={1}")
-    @CsvSource({
-            "SETTLEMENT,   true",
-            "GA_ADMIN,     true",
-            "SYSTEM_ADMIN, true",
-            "COMPLIANCE,   false",
-    })
-    void journal_reverse_capability_matches_api_roles(String role, boolean allowed) throws Exception {
-        mvc.perform(get("/journals").with(user(userFor(role))))
-                .andExpect(status().isOk())
-                .andExpect(content().string(org.hamcrest.Matchers.containsString(
-                        "data-can-reverse=\"" + allowed + "\"")));
     }
 
     /**

--- a/src/test/java/com/susukkang/fgc/journal/controller/JournalViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/journal/controller/JournalViewControllerTest.java
@@ -1,0 +1,132 @@
+package com.susukkang.fgc.journal.controller;
+
+import com.susukkang.fgc.auth.dto.AppUserView;
+import com.susukkang.fgc.auth.dto.FgcUserDetails;
+import com.susukkang.fgc.common.config.SecurityConfig;
+import com.susukkang.fgc.common.exception.ConstraintErrorCodeResolver;
+import com.susukkang.fgc.common.exception.FgcMessageResolver;
+import com.susukkang.fgc.common.web.PageResponse;
+import com.susukkang.fgc.common.web.ShellAdvice;
+import com.susukkang.fgc.journal.dto.JournalListRow;
+import com.susukkang.fgc.journal.dto.JournalSearchCriteria;
+import com.susukkang.fgc.journal.service.JournalSearchService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * 설명 : LEDG-W01 검증원장 MPA 조회 테스트
+ *
+ * @author yslee
+ * @since 2026-08-19
+ * @version 1.2
+ */
+@WebMvcTest(JournalViewController.class)
+@Import({JournalViewController.class, ShellAdvice.class, SecurityConfig.class,
+        MessageSourceAutoConfiguration.class, FgcMessageResolver.class, ConstraintErrorCodeResolver.class})
+@TestPropertySource(properties = "fgc.demo-month=2026-07")
+class JournalViewControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private JournalSearchService journalSearchService;
+
+    @Test
+    void initialPageDoesNotSearchUntilButtonSubmission() throws Exception {
+        mvc.perform(get("/journals").with(user(userWithRole("SETTLEMENT"))))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("조회 조건을 설정하고 조회 버튼을 눌러 주세요.")));
+
+        verify(journalSearchService, never()).search(any(), eq(1), eq(20));
+    }
+
+    @Test
+    void submittedConditionsRenderSearchResultOnServer() throws Exception {
+        JournalListRow row = journalRow();
+        given(journalSearchService.search(any(), eq(1), eq(20)))
+                .willReturn(PageResponse.of(List.of(row), 1, 20, 1, "journalDate,desc"));
+
+        mvc.perform(get("/journals")
+                        .param("searched", "true")
+                        .param("from", "2026-07-01")
+                        .param("to", "2026-07-31")
+                        .param("type", "CONFIRMED_FC_PAYOUT")
+                        .param("status", "POSTED")
+                        .with(user(userWithRole("SETTLEMENT"))))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("JRN-202607-001")))
+                .andExpect(content().string(containsString("COMMISSION_TRANSACTION #91")))
+                .andExpect(content().string(containsString("원분개 JRN-202607-000")));
+
+        var captor = org.mockito.ArgumentCaptor.forClass(JournalSearchCriteria.class);
+        verify(journalSearchService).search(captor.capture(), eq(1), eq(20));
+        assertThat(captor.getValue().from()).isEqualTo(LocalDate.of(2026, 7, 1));
+        assertThat(captor.getValue().status()).isEqualTo("POSTED");
+    }
+
+    @ParameterizedTest(name = "{0} LEDG-W01 역분개 가능={1}")
+    @CsvSource({
+            "SETTLEMENT,   true",
+            "GA_ADMIN,     true",
+            "SYSTEM_ADMIN, true",
+            "COMPLIANCE,   false",
+    })
+    void reverseCapabilityMatchesExistingApiRoles(String role, boolean allowed) throws Exception {
+        mvc.perform(get("/journals").with(user(userWithRole(role))))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("data-can-reverse=\"" + allowed + "\"")));
+    }
+
+    private JournalListRow journalRow() {
+        JournalListRow row = new JournalListRow();
+        row.setJournalHeaderId(92L);
+        row.setJournalNo("JRN-202607-001");
+        row.setJournalDate(LocalDate.of(2026, 7, 31));
+        row.setJournalType("CONFIRMED_FC_PAYOUT");
+        row.setSourceEntityType("COMMISSION_TRANSACTION");
+        row.setSourceEntityId("91");
+        row.setContractId(7L);
+        row.setContractNo("CONT-007");
+        row.setStatus("POSTED");
+        row.setDebitTotal(BigDecimal.valueOf(1000));
+        row.setCreditTotal(BigDecimal.valueOf(1000));
+        row.setReversalOfId(90L);
+        row.setReversalOfJournalNo("JRN-202607-000");
+        return row;
+    }
+
+    private FgcUserDetails userWithRole(String role) {
+        AppUserView view = new AppUserView();
+        view.setUserId(1L);
+        view.setLoginId("ledger01");
+        view.setPasswordHash("x");
+        view.setUserName("원장조회자");
+        view.setRoleCode(role);
+        return new FgcUserDetails(view, true, true);
+    }
+}

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -85,7 +85,19 @@ class PublishingTemplateStructureTest {
         assertThat(resource("templates/exception/list.html"))
                 .contains("정상 건은 여기 오지 않습니다. 여기 있는 건 전부 사람이 봐야 합니다.");
         assertThat(resource("templates/ledger/list.html"))
-                .contains("이 원장은 회사의 정식 회계장부가 아닙니다. 정산이 맞는지 확인하려고 FGC가 따로 만드는 보조 장부입니다.");
+                .contains("이 원장은 회사의 정식 회계장부가 아닙니다. 정산이 맞는지 확인하려고 FGC가 따로 만드는 보조 장부입니다.")
+                .contains("data-modal=\"journal-reverse\"")
+                .contains("id=\"journal-reverse-reason\"")
+                .contains("data-can-reverse=${roleCode == 'SETTLEMENT' or roleCode == 'GA_ADMIN' or roleCode == 'SYSTEM_ADMIN'}")
+                .doesNotContain("데이터 렌더링은 IF-API 연동 시 추가");
+        assertThat(resource("templates/layout/default.html"))
+                .contains("/js/features/ledger/ledger.js");
+        assertThat(resource("static/js/features/ledger/ledger.js"))
+                .contains("/api/v1/journals?")
+                .contains("/reverse\"")
+                .contains("detail.status === \"POSTED\"")
+                .contains("evidenceRef: reverseEvidence.value.trim() || null")
+                .doesNotContain("fetch(");
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -121,6 +121,18 @@ class PublishingTemplateStructureTest {
     }
 
     @Test
+    void ledgerSearchRunsOnlyWhenFilterFormIsSubmitted() throws IOException {
+        assertThat(resource("templates/ledger/list.html"))
+                .contains("id=\"ledger-filter-form\"")
+                .contains("id=\"f-search\" type=\"submit\"");
+        assertThat(resource("static/js/features/ledger/ledger.js"))
+                .contains("form.addEventListener(\"submit\"")
+                .contains("apiClient.request(\"/api/v1/journals?\" + query(page))")
+                .contains("renderEmpty(\"조회 조건을 설정하고 조회 버튼을 눌러 주세요.\");")
+                .doesNotContain("\n  loadList(1);\n})();");
+    }
+
+    @Test
     void productionLayoutLoadsScopedResponsivePublishingStyles() throws IOException {
         assertThat(resource("templates/layout/default.html"))
                 .contains("/css/features/publishing.css");

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -113,10 +113,11 @@ class PublishingTemplateStructureTest {
         assertThat(resource("templates/layout/default.html"))
                 .contains("/js/features/ledger/ledger.js");
         assertThat(resource("static/js/features/ledger/ledger.js"))
-                .contains("/api/v1/journals?")
+                .contains("/api/v1/journals/imbalances?validationRunId=")
                 .contains("/reverse\"")
                 .contains("detail.status === \"POSTED\"")
                 .contains("evidenceRef: reverseEvidence.value.trim() || null")
+                .doesNotContain("apiClient.request(\"/api/v1/journals?\"")
                 .doesNotContain("fetch(");
     }
 
@@ -124,12 +125,14 @@ class PublishingTemplateStructureTest {
     void ledgerSearchRunsOnlyWhenFilterFormIsSubmitted() throws IOException {
         assertThat(resource("templates/ledger/list.html"))
                 .contains("id=\"ledger-filter-form\"")
-                .contains("id=\"f-search\" type=\"submit\"");
+                .contains("method=\"get\" th:action=\"@{/journals}\"")
+                .contains("id=\"f-search\" name=\"searched\" value=\"true\" type=\"submit\"")
+                .contains("th:each=\"journal : ${journals.content}\"")
+                .contains("조회 조건을 설정하고 조회 버튼을 눌러 주세요.");
         assertThat(resource("static/js/features/ledger/ledger.js"))
-                .contains("form.addEventListener(\"submit\"")
-                .contains("apiClient.request(\"/api/v1/journals?\" + query(page))")
-                .contains("renderEmpty(\"조회 조건을 설정하고 조회 버튼을 눌러 주세요.\");")
-                .doesNotContain("\n  loadList(1);\n})();");
+                .doesNotContain("form.addEventListener(\"submit\"")
+                .doesNotContain("function loadList(")
+                .doesNotContain("function query(");
     }
 
     @Test


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* LEDG-W01 검증원장 목록·상세·조건 조회와 FUN-047 역분개 화면을 연결했습니다.

## 🔗 2. 관련 이슈

* Closes #234
* Closes #271

## 🛠 3. 구현 내용

* IF-API-34 목록 검색·페이징과 IF-API-35 상세·분개 라인을 표시합니다.
* 검색조건 영역 오른쪽의 공통 primary 조회 버튼으로 사용자가 확정한 조건만 IF-API-34에 전달합니다.
* 페이지 진입 시 전체 원장 자동조회를 제거하고 조회 버튼 제출 시 선택 상세를 해제한 뒤 1페이지부터 조회합니다.
* POSTED 원분개에만 역분개 작업을 노출하고 IF-API-36에 필수 사유와 선택 증빙을 전달합니다.
* SETTLEMENT·GA_ADMIN·SYSTEM_ADMIN 권한, 중복 클릭 방지, 공통 오류 처리를 적용했습니다.

## 🧪 4. 테스트 방법

1. `node --check src/main/resources/static/js/features/ledger/ledger.js`
2. `gradlew.bat clean build`
3. LEDG-W01에서 조건 선택만으로 요청이 발생하지 않고 조회 버튼 클릭 시 선택 조건으로 목록이 조회되는지 확인

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* 조회 버튼 클릭 전 자동조회가 발생하지 않는지 확인 부탁드립니다.
* 빈 검색조건은 IF-API-34 쿼리 파라미터에서 제외되는지 확인 부탁드립니다.
* POSTED 원분개 외에는 역분개 버튼이 노출되지 않는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* FGC-UI-LEDG-W01 조건 조회·목록·상세·역분개 사유 입력 모달을 연결했습니다.

## 💬 9. 참고 사항

* API 명세 문서와 Flyway 파일은 변경하지 않았습니다.
