### PR TITLE
[Refactor] BASE-W01 공통 UI 컴포넌트 정리

### DIFF
--- a/src/main/resources/static/css/features/base.css
+++ b/src/main/resources/static/css/features/base.css
@@ -24,30 +24,48 @@
 }
 
 .base-panel {
+  display: grid;
   min-height: 24rem;
+  gap: var(--space-5);
+  padding-top: var(--space-5);
+  overflow: visible;
+  border-radius: 0;
 }
 
 .base-filter-form {
   flex-wrap: wrap;
-  padding: var(--space-3) var(--space-4);
-  border: 0;
-  border-bottom: 1px solid var(--color-border-subtle);
-  background: var(--color-bg-subtle);
+  padding: var(--space-5);
+  border-radius: var(--radius-12);
+  box-shadow: var(--shadow-xs);
 }
 
 .base-filter-form .field {
-  width: min(13rem, 100%);
+  width: auto;
+  flex: 1 1 13rem;
 }
 
 .base-filter-form .base-filter-keyword,
 .base-filter-form .base-filter-select {
-  width: min(21rem, 100%);
+  width: auto;
+  flex: 2 1 21rem;
 }
 
 .base-filter-actions {
-  display: flex;
+  flex-wrap: nowrap;
   gap: var(--space-2);
   margin-left: auto;
+}
+
+.base-result-surface {
+  display: grid;
+  min-width: 0;
+  overflow: hidden;
+  border-radius: var(--radius-12);
+}
+
+.base-result-header {
+  min-height: 4rem;
+  padding: var(--space-4) var(--space-6) var(--space-3);
 }
 
 .base-result-description {
@@ -64,17 +82,12 @@
 
 .base-result-count strong {
   color: var(--color-text-primary);
-  font-variant-numeric: tabular-nums;
 }
 
 .base-result-message {
-  display: grid;
-  min-height: 10rem;
-  place-items: center;
-  padding: var(--space-8);
-  color: var(--color-text-secondary);
+  margin: 0 var(--space-6) var(--space-4);
+  border-radius: var(--radius-8);
   font-size: 0.8125rem;
-  text-align: center;
 }
 
 .base-result-message.is-error {
@@ -91,6 +104,11 @@
   min-width: 88rem;
 }
 
+.base-table-viewport {
+  width: auto;
+  margin-inline: var(--space-6);
+}
+
 .base-code-label,
 .base-secondary-line {
   display: block;
@@ -101,7 +119,6 @@
 }
 
 .base-code-label {
-  font-family: var(--font-sans);
   font-variant-numeric: tabular-nums;
 }
 
@@ -110,16 +127,9 @@
   min-height: 3.5rem;
   align-items: center;
   justify-content: center;
-  padding: var(--space-2) var(--space-4);
+  margin: var(--space-4) var(--space-6) 0;
+  padding: var(--space-2) 0;
   border-top: 1px solid var(--color-border-subtle);
-}
-
-.base-panel-note {
-  padding: var(--space-3) var(--space-4);
-  border-top: 1px solid var(--color-border-subtle);
-  color: var(--color-text-secondary);
-  background: var(--color-bg-subtle);
-  font-size: 0.75rem;
 }
 
 .base-state-row:hover {
@@ -144,13 +154,39 @@
     flex-direction: column;
   }
 
+  .base-panel {
+    gap: var(--space-4);
+    padding-top: var(--space-4);
+  }
+
+  .base-filter-form {
+    padding: var(--space-4);
+  }
+
+  .base-result-header {
+    padding: var(--space-4);
+  }
+
   .base-filter-form .field,
   .base-filter-actions,
   .base-filter-actions .button {
     width: 100%;
   }
 
+  .base-filter-form .field {
+    flex: none;
+  }
+
   .base-filter-actions {
     margin-left: 0;
+  }
+
+  .base-result-message,
+  .base-table-viewport {
+    margin-inline: var(--space-4);
+  }
+
+  .base-pagination-footer {
+    margin-inline: var(--space-4);
   }
 }

--- a/src/main/resources/templates/base/index.html
+++ b/src/main/resources/templates/base/index.html
@@ -23,13 +23,6 @@
     </p>
   </header>
 
-  <aside class="guidance guidance-neutral base-information-banner" aria-label="기준정보 조회 안내">
-    <span class="material-symbols-rounded guidance-icon" aria-hidden="true">database</span>
-    <p class="guidance-copy">
-      원수사 자료는 표준 형식으로 정리되어 DB에 적재되어 있습니다. 이 화면에서는 파일 업로드나 기준정보 변경을 제공하지 않습니다.
-    </p>
-  </aside>
-
   <div class="base-workspace">
     <div class="tab-list" role="tablist" aria-label="기준정보 유형">
       <button class="tab-button" id="base-tab-organization" type="button" role="tab" aria-selected="true"
@@ -44,7 +37,7 @@
               aria-controls="base-panel-commission-item" data-base-tab="commission-item" tabindex="-1">수수료 항목</button>
     </div>
 
-    <section class="surface tab-panel base-panel" id="base-panel-organization" role="tabpanel"
+    <section class="tab-panel base-panel" id="base-panel-organization" role="tabpanel"
              aria-labelledby="base-tab-organization" data-base-panel="organization">
       <form class="filter-bar base-filter-form" data-base-form="organization">
         <label class="field base-filter-keyword">
@@ -55,57 +48,61 @@
           <span class="field-label">기준일</span>
           <input class="field-control" name="asOf" type="date" required>
         </label>
-        <div class="base-filter-actions">
+        <div class="filter-actions base-filter-actions">
           <button class="button button-secondary" type="button" data-base-reset="organization">초기화</button>
           <button class="button button-primary" type="submit">조회</button>
         </div>
       </form>
-      <header class="surface-header base-result-header">
-        <div>
-          <h2 class="surface-title">조직 목록</h2>
-          <p class="base-result-description">적용기간 안의 조직을 표시하며 사용중지 조직도 조회됩니다.</p>
+      <div class="surface base-result-surface">
+        <header class="surface-header base-result-header">
+          <div>
+            <h2 class="surface-title">조직 목록</h2>
+            <p class="base-result-description">적용기간 안의 조직을 표시하며 사용중지 조직도 조회됩니다.</p>
+          </div>
+          <span class="base-result-count"><strong class="tabular-nums" data-base-count="organization">0</strong>건</span>
+        </header>
+        <div class="empty-state base-result-message" data-base-message="organization" role="status" aria-live="polite">조직을 불러오는 중입니다.</div>
+        <div class="data-table-viewport base-table-viewport" data-base-table="organization" hidden>
+          <table class="data-table base-table base-organization-table">
+            <caption class="visually-hidden">조직 기준정보 목록</caption>
+            <thead><tr><th scope="col">조직코드</th><th scope="col">조직명</th><th scope="col">유형</th><th scope="col">상위 조직</th><th scope="col">적용 시작일</th><th scope="col">적용 종료일</th><th scope="col">상태</th></tr></thead>
+            <tbody data-base-body="organization"></tbody>
+          </table>
         </div>
-        <span class="base-result-count"><strong data-base-count="organization">0</strong>건</span>
-      </header>
-      <div class="base-result-message" data-base-message="organization" role="status" aria-live="polite">조직을 불러오는 중입니다.</div>
-      <div class="data-table-viewport base-table-viewport" data-base-table="organization" hidden>
-        <table class="data-table base-table base-organization-table">
-          <caption class="visually-hidden">조직 기준정보 목록</caption>
-          <thead><tr><th scope="col">조직코드</th><th scope="col">조직명</th><th scope="col">유형</th><th scope="col">상위 조직</th><th scope="col">적용 시작일</th><th scope="col">적용 종료일</th><th scope="col">상태</th></tr></thead>
-          <tbody data-base-body="organization"></tbody>
-        </table>
+        <footer class="base-pagination-footer"><nav class="pagination-controls" data-base-pagination="organization" aria-label="조직 목록 페이지"></nav></footer>
       </div>
-      <footer class="base-pagination-footer"><nav class="pagination-controls" data-base-pagination="organization" aria-label="조직 목록 페이지"></nav></footer>
     </section>
 
-    <section class="surface tab-panel base-panel" id="base-panel-insurer" role="tabpanel"
+    <section class="tab-panel base-panel" id="base-panel-insurer" role="tabpanel"
              aria-labelledby="base-tab-insurer" data-base-panel="insurer" hidden>
       <form class="filter-bar base-filter-form" data-base-form="insurer">
         <label class="field base-filter-keyword">
           <span class="field-label">보험회사 검색</span>
           <input class="field-control" name="keyword" type="search" placeholder="보험회사 코드 또는 이름" autocomplete="off">
         </label>
-        <div class="base-filter-actions">
+        <div class="filter-actions base-filter-actions">
           <button class="button button-secondary" type="button" data-base-reset="insurer">초기화</button>
           <button class="button button-primary" type="submit">조회</button>
         </div>
       </form>
-      <header class="surface-header base-result-header">
-        <div><h2 class="surface-title">보험회사 목록</h2><p class="base-result-description">상품 판매버전 조회의 선행 기준정보입니다.</p></div>
-        <span class="base-result-count"><strong data-base-count="insurer">0</strong>건</span>
-      </header>
-      <div class="base-result-message" data-base-message="insurer" role="status" aria-live="polite">보험회사를 불러오는 중입니다.</div>
-      <div class="data-table-viewport base-table-viewport" data-base-table="insurer" hidden>
-        <table class="data-table base-table">
-          <caption class="visually-hidden">보험회사 기준정보 목록</caption>
-          <thead><tr><th scope="col">보험회사 코드</th><th scope="col">보험회사명</th><th scope="col">구분</th><th scope="col">상태</th></tr></thead>
-          <tbody data-base-body="insurer"></tbody>
-        </table>
+      <div class="surface base-result-surface">
+        <header class="surface-header base-result-header">
+          <div><h2 class="surface-title">보험회사 목록</h2><p class="base-result-description">상품 판매버전 조회의 선행 기준정보입니다.</p></div>
+          <span class="base-result-count"><strong class="tabular-nums" data-base-count="insurer">0</strong>건</span>
+        </header>
+        <div class="empty-state base-result-message" data-base-message="insurer" role="status" aria-live="polite">보험회사를 불러오는 중입니다.</div>
+        <div class="data-table-viewport base-table-viewport" data-base-table="insurer" hidden>
+          <table class="data-table base-table">
+            <caption class="visually-hidden">보험회사 기준정보 목록</caption>
+            <thead><tr><th scope="col">보험회사 코드</th><th scope="col">보험회사명</th><th scope="col">구분</th><th scope="col">상태</th></tr></thead>
+            <tbody data-base-body="insurer"></tbody>
+          </table>
+        </div>
+        <footer class="base-pagination-footer"><nav class="pagination-controls" data-base-pagination="insurer" aria-label="보험회사 목록 페이지"></nav></footer>
       </div>
-      <footer class="base-pagination-footer"><nav class="pagination-controls" data-base-pagination="insurer" aria-label="보험회사 목록 페이지"></nav></footer>
     </section>
 
-    <section class="surface tab-panel base-panel" id="base-panel-product" role="tabpanel"
+    <section class="tab-panel base-panel" id="base-panel-product" role="tabpanel"
              aria-labelledby="base-tab-product" data-base-panel="product" hidden>
       <form class="filter-bar base-filter-form" data-base-form="product">
         <label class="field base-filter-select">
@@ -118,27 +115,29 @@
           <span class="field-label">계약 기준일</span>
           <input class="field-control" name="asOf" type="date" required>
         </label>
-        <div class="base-filter-actions">
+        <div class="filter-actions base-filter-actions">
           <button class="button button-secondary" type="button" data-base-reset="product">초기화</button>
           <button class="button button-primary" type="submit">조회</button>
         </div>
       </form>
-      <header class="surface-header base-result-header">
-        <div><h2 class="surface-title">상품 판매버전 목록</h2><p class="base-result-description">같은 상품이라도 판매버전과 채널이 다르면 별도로 표시합니다.</p></div>
-        <span class="base-result-count"><strong data-base-count="product">0</strong>건</span>
-      </header>
-      <div class="base-result-message" data-base-message="product" role="status" aria-live="polite">보험회사를 선택하면 상품을 조회합니다.</div>
-      <div class="data-table-viewport base-table-viewport" data-base-table="product" hidden>
-        <table class="data-table base-table base-product-table">
-          <caption class="visually-hidden">보험상품 판매버전 기준정보 목록</caption>
-          <thead><tr><th scope="col">상품코드</th><th scope="col">상품명</th><th scope="col">표준상품코드</th><th scope="col">상품군</th><th scope="col">판매버전</th><th scope="col">판매기간</th><th scope="col">기초서류</th><th scope="col">채널</th><th scope="col">수수료체계</th><th scope="col">80% 공제</th></tr></thead>
-          <tbody data-base-body="product"></tbody>
-        </table>
+      <div class="surface base-result-surface">
+        <header class="surface-header base-result-header">
+          <div><h2 class="surface-title">상품 판매버전 목록</h2><p class="base-result-description">같은 상품이라도 판매버전과 채널이 다르면 별도로 표시합니다.</p></div>
+          <span class="base-result-count"><strong class="tabular-nums" data-base-count="product">0</strong>건</span>
+        </header>
+        <div class="empty-state base-result-message" data-base-message="product" role="status" aria-live="polite">보험회사를 선택하면 상품을 조회합니다.</div>
+        <div class="data-table-viewport base-table-viewport" data-base-table="product" hidden>
+          <table class="data-table base-table base-product-table">
+            <caption class="visually-hidden">보험상품 판매버전 기준정보 목록</caption>
+            <thead><tr><th scope="col">상품코드</th><th scope="col">상품명</th><th scope="col">표준상품코드</th><th scope="col">상품군</th><th scope="col">판매버전</th><th scope="col">판매기간</th><th scope="col">기초서류</th><th scope="col">채널</th><th scope="col">수수료체계</th><th scope="col">80% 공제</th></tr></thead>
+            <tbody data-base-body="product"></tbody>
+          </table>
+        </div>
+        <footer class="base-pagination-footer"><nav class="pagination-controls" data-base-pagination="product" aria-label="상품 목록 페이지"></nav></footer>
       </div>
-      <footer class="base-pagination-footer"><nav class="pagination-controls" data-base-pagination="product" aria-label="상품 목록 페이지"></nav></footer>
     </section>
 
-    <section class="surface tab-panel base-panel" id="base-panel-agent" role="tabpanel"
+    <section class="tab-panel base-panel" id="base-panel-agent" role="tabpanel"
              aria-labelledby="base-tab-agent" data-base-panel="agent" hidden>
       <form class="filter-bar base-filter-form" data-base-form="agent">
         <label class="field base-filter-select">
@@ -153,73 +152,76 @@
           <span class="field-label">기준일</span>
           <input class="field-control" name="asOf" type="date" required>
         </label>
-        <div class="base-filter-actions">
+        <div class="filter-actions base-filter-actions">
           <button class="button button-secondary" type="button" data-base-reset="agent">초기화</button>
           <button class="button button-primary" type="submit">조회</button>
         </div>
       </form>
-      <header class="surface-header base-result-header">
-        <div><h2 class="surface-title">설계사 목록</h2><p class="base-result-description">위촉 유효기간과 상태, 소속 조직 및 신인활동지원 정보를 확인합니다.</p></div>
-        <span class="base-result-count"><strong data-base-count="agent">0</strong>건</span>
-      </header>
-      <div class="base-result-message" data-base-message="agent" role="status" aria-live="polite">설계사를 불러오는 중입니다.</div>
-      <div class="data-table-viewport base-table-viewport" data-base-table="agent" hidden>
-        <table class="data-table base-table base-agent-table">
-          <caption class="visually-hidden">보험설계사 기준정보 목록</caption>
-          <thead><tr><th scope="col">설계사 코드</th><th scope="col">설계사명</th><th scope="col">직급</th><th scope="col">소속 조직</th><th scope="col">위촉일</th><th scope="col">해촉일</th><th scope="col">상태</th><th scope="col">최근 등록일</th><th scope="col">직전 3년 경력</th><th scope="col">신인지원</th></tr></thead>
-          <tbody data-base-body="agent"></tbody>
-        </table>
+      <div class="surface base-result-surface">
+        <header class="surface-header base-result-header">
+          <div><h2 class="surface-title">설계사 목록</h2><p class="base-result-description">위촉 유효기간과 상태, 소속 조직 및 신인활동지원 정보를 확인합니다.</p></div>
+          <span class="base-result-count"><strong class="tabular-nums" data-base-count="agent">0</strong>건</span>
+        </header>
+        <div class="empty-state base-result-message" data-base-message="agent" role="status" aria-live="polite">설계사를 불러오는 중입니다.</div>
+        <div class="data-table-viewport base-table-viewport" data-base-table="agent" hidden>
+          <table class="data-table base-table base-agent-table">
+            <caption class="visually-hidden">보험설계사 기준정보 목록</caption>
+            <thead><tr><th scope="col">설계사 코드</th><th scope="col">설계사명</th><th scope="col">직급</th><th scope="col">소속 조직</th><th scope="col">위촉일</th><th scope="col">해촉일</th><th scope="col">상태</th><th scope="col">최근 등록일</th><th scope="col">직전 3년 경력</th><th scope="col">신인지원</th></tr></thead>
+            <tbody data-base-body="agent"></tbody>
+          </table>
+        </div>
+        <footer class="base-pagination-footer"><nav class="pagination-controls" data-base-pagination="agent" aria-label="설계사 목록 페이지"></nav></footer>
       </div>
-      <footer class="base-pagination-footer"><nav class="pagination-controls" data-base-pagination="agent" aria-label="설계사 목록 페이지"></nav></footer>
     </section>
 
-    <section class="surface tab-panel base-panel" id="base-panel-commission-item" role="tabpanel"
+    <section class="tab-panel base-panel" id="base-panel-commission-item" role="tabpanel"
              aria-labelledby="base-tab-commission-item" data-base-panel="commission-item" hidden>
       <form class="filter-bar base-filter-form" data-base-form="commission-item">
         <label class="field">
           <span class="field-label">기준일</span>
           <input class="field-control" name="asOf" type="date" required>
         </label>
-        <div class="filter-actions">
+        <div class="filter-actions base-filter-actions">
           <button class="button button-secondary" type="button" data-base-reset="commission-item">초기화</button>
           <button class="button button-primary" type="submit">조회</button>
         </div>
       </form>
-      <header class="surface-header base-result-header">
-        <div><h2 class="surface-title">수수료 항목 목록</h2><p class="base-result-description">선택한 기준일에 유효한 항목입니다.</p></div>
-        <span class="base-result-count"><strong data-base-count="commission-item" th:text="${#lists.size(commissionItems)}">0</strong>건</span>
-      </header>
-      <div class="base-result-message" data-base-message="commission-item" role="status" aria-live="polite" hidden></div>
-      <div class="data-table-viewport base-table-viewport" data-base-table="commission-item">
-        <table class="data-table base-table">
-          <caption class="visually-hidden">수수료 항목 기준정보 목록</caption>
-          <thead><tr><th scope="col">항목코드</th><th scope="col">항목명</th><th scope="col">지급/차감</th><th scope="col">분류</th><th scope="col">적용 시작일</th><th scope="col">적용 종료일</th></tr></thead>
-          <tbody data-base-body="commission-item">
-          <tr th:each="item : ${commissionItems}">
-            <td class="tabular-nums" th:text="${item.itemCode()}">BASE_COMMISSION</td>
-            <td th:text="${item.itemName()}">FC 기본수수료</td>
-            <td><span class="status-badge"
-                      th:classappend="${item.cashflowType() == 'PAYMENT' ? ' status-badge-success' : (item.cashflowType() == 'DEDUCTION' ? ' status-badge-warning' : ' status-badge-neutral')}"
-                      th:text="${item.cashflowType() == 'PAYMENT' ? '지급' : (item.cashflowType() == 'DEDUCTION' ? '차감' : item.cashflowType())}">지급</span></td>
-            <td th:text="${item.itemCode() == 'SETTLEMENT_SUPPORT' ? '정착지원' :
-                         (item.itemCode() == 'NEWCOMER_SUPPORT' ? '신인지원' :
-                         (item.itemCategory() == 'SALES' ? '모집수수료' :
-                         (item.itemCategory() == 'MAINTENANCE' ? '유지관리' :
-                         (item.itemCategory() == 'INCENTIVE' ? '판매촉진' :
-                         (item.itemCategory() == 'MANAGEMENT' ? '관리자수수료' :
-                         (item.itemCategory() == 'SUPPORT' ? '지원' :
-                         (item.itemCategory() == 'COST' ? '공통비' :
-                         (item.itemCategory() == 'ADJUSTMENT' ? '조정' :
-                         (item.itemCategory() == 'CLAWBACK' ? '환수' :
-                         (item.itemCategory() == 'RECOVERY' ? '회수' : item.itemCategory()))))))))))}">모집수수료</td>
-            <td class="tabular-nums" th:text="${item.effectiveFrom()}">2026-01-01</td>
-            <td class="tabular-nums" th:text="${item.effectiveTo() ?: '-'}">-</td>
-          </tr>
-          <tr class="base-state-row" th:if="${#lists.isEmpty(commissionItems)}"><td colspan="6"><div class="empty-state">조건에 맞는 수수료 항목이 없습니다.</div></td></tr>
-          </tbody>
-        </table>
+      <div class="surface base-result-surface">
+        <header class="surface-header base-result-header">
+          <div><h2 class="surface-title">수수료 항목 목록</h2><p class="base-result-description">선택한 기준일에 유효한 항목입니다.</p></div>
+          <span class="base-result-count"><strong class="tabular-nums" data-base-count="commission-item" th:text="${#lists.size(commissionItems)}">0</strong>건</span>
+        </header>
+        <div class="empty-state base-result-message" data-base-message="commission-item" role="status" aria-live="polite" hidden></div>
+        <div class="data-table-viewport base-table-viewport" data-base-table="commission-item">
+          <table class="data-table base-table">
+            <caption class="visually-hidden">수수료 항목 기준정보 목록</caption>
+            <thead><tr><th scope="col">항목코드</th><th scope="col">항목명</th><th scope="col">지급/차감</th><th scope="col">분류</th><th scope="col">적용 시작일</th><th scope="col">적용 종료일</th></tr></thead>
+            <tbody data-base-body="commission-item">
+            <tr th:each="item : ${commissionItems}">
+              <td class="tabular-nums" th:text="${item.itemCode()}">BASE_COMMISSION</td>
+              <td th:text="${item.itemName()}">FC 기본수수료</td>
+              <td><span class="status-badge"
+                        th:classappend="${item.cashflowType() == 'PAYMENT' ? ' status-badge-success' : (item.cashflowType() == 'DEDUCTION' ? ' status-badge-warning' : ' status-badge-neutral')}"
+                        th:text="${item.cashflowType() == 'PAYMENT' ? '지급' : (item.cashflowType() == 'DEDUCTION' ? '차감' : item.cashflowType())}">지급</span></td>
+              <td th:text="${item.itemCode() == 'SETTLEMENT_SUPPORT' ? '정착지원' :
+                           (item.itemCode() == 'NEWCOMER_SUPPORT' ? '신인지원' :
+                           (item.itemCategory() == 'SALES' ? '모집수수료' :
+                           (item.itemCategory() == 'MAINTENANCE' ? '유지관리' :
+                           (item.itemCategory() == 'INCENTIVE' ? '판매촉진' :
+                           (item.itemCategory() == 'MANAGEMENT' ? '관리자수수료' :
+                           (item.itemCategory() == 'SUPPORT' ? '지원' :
+                           (item.itemCategory() == 'COST' ? '공통비' :
+                           (item.itemCategory() == 'ADJUSTMENT' ? '조정' :
+                           (item.itemCategory() == 'CLAWBACK' ? '환수' :
+                           (item.itemCategory() == 'RECOVERY' ? '회수' : item.itemCategory()))))))))))}">모집수수료</td>
+              <td class="tabular-nums" th:text="${item.effectiveFrom()}">2026-01-01</td>
+              <td class="tabular-nums" th:text="${item.effectiveTo() ?: '-'}">-</td>
+            </tr>
+            <tr class="base-state-row" th:if="${#lists.isEmpty(commissionItems)}"><td colspan="6"><div class="empty-state">조건에 맞는 수수료 항목이 없습니다.</div></td></tr>
+            </tbody>
+          </table>
+        </div>
       </div>
-      <div class="base-panel-note">1,200% 산입 여부는 항목 자체가 아니라 적용 룰셋에서 결정하므로 이 화면에 표시하지 않습니다.</div>
     </section>
   </div>
 </main>

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -187,10 +187,13 @@ class PublishingTemplateStructureTest {
     void baseReferenceScreenUsesSeparatedApiAndPageScripts() throws IOException {
         assertThat(resource("templates/base/index.html"))
                 .contains("class=\"page-header base-page-header\"")
-                .contains("class=\"guidance guidance-neutral base-information-banner\"")
+                .doesNotContain("class=\"guidance")
                 .contains("class=\"tab-list\"")
-                .contains("class=\"surface tab-panel base-panel\"")
+                .contains("class=\"tab-panel base-panel\"")
                 .contains("class=\"filter-bar base-filter-form\"")
+                .contains("class=\"filter-actions base-filter-actions\"")
+                .contains("class=\"surface base-result-surface\"")
+                .contains("class=\"empty-state base-result-message\"")
                 .contains("class=\"data-table base-table")
                 .contains("data-base-tab=\"organization\"")
                 .contains("data-base-tab=\"product\"")
@@ -201,6 +204,8 @@ class PublishingTemplateStructureTest {
                 .contains("적용 시작일")
                 .contains("적용 종료일")
                 .contains("status-badge-success")
+                .doesNotContain("class=\"surface tab-panel base-panel\"")
+                .doesNotContain("base-panel-note")
                 .doesNotContain("<script>")
                 .doesNotContain("style=\"")
                 .doesNotContain("onclick=\"");
@@ -232,7 +237,9 @@ class PublishingTemplateStructureTest {
 
         assertThat(resource("static/css/features/base.css"))
                 .contains(".base-page")
-                .contains("@media (max-width: 47.9375rem)");
+                .contains("@media (max-width: 47.9375rem)")
+                .doesNotContain(".base-information-banner")
+                .doesNotContain(".base-panel-note");
     }
 
     private static String resource(String path) throws IOException {


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- BASE-W01의 필터와 조회 결과 영역을 독립된 Surface 구조로 정리했습니다.
- Guidance 및 안내성 Note를 제거하고 공통 UI 컴포넌트 사용 범위를 확대했습니다.
- 데스크톱과 좁은 화면에서 카드 간격과 테이블 스크롤 동작을 개선했습니다.

## 🔗 2. 관련 이슈

- Refs #138

## 🛠 3. 구현 내용

- 필터 영역과 결과 헤더·테이블·페이지네이션을 별도 카드로 분리
- 공통 `Filter Bar`, `Field`, `Button`, `Surface`, `Table`, `Pagination`, `Status Badge` 구조 유지
- 필터 Action 영역을 공통 `filter-actions` 컴포넌트로 전환
- 로딩·오류·빈 결과 영역을 공통 `empty-state` 컴포넌트로 전환
- 결과 건수에 공통 `tabular-nums` 유틸리티 적용
- 상단 Guidance와 수수료 항목 하단 안내 Note 제거
- 제거된 UI에 대응하는 미사용 CSS와 공통 컴포넌트 중복 스타일 정리
- 720px에서 필터 필드가 세로로 과도하게 확장되던 반응형 문제 수정
- 기존 탭 전환, 필터, 조회, 초기화, 페이징 및 API 연결용 `data-*` 인터페이스 보존

## 🧪 4. 테스트 방법

1. `./gradlew test`를 실행해 전체 테스트가 통과하는지 확인합니다.
2. `/base`에 접속해 조직·보험회사·상품·설계사·수수료 항목 탭을 전환합니다.
3. 각 탭에서 조회·초기화·페이지네이션과 로딩·빈 결과 상태를 확인합니다.
4. 1440px, 900px, 720px에서 필터와 결과 카드 정렬 및 본문 가로 넘침 여부를 확인합니다.
5. 넓은 테이블이 화면 전체가 아닌 테이블 영역 내부에서 가로 스크롤되는지 확인합니다.

## 🗄️ 5. DB / Flyway 변경

- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

- 없음

## 📋 6. 리뷰 요구사항

- 필터와 결과 영역이 첨부된 BASE-W01 초안처럼 별도 Surface로 구분되는지 확인 부탁드립니다.
- Guidance 제거 후 Page Header와 탭 사이의 여백이 자연스러운지 확인 부탁드립니다.
- 공통 컴포넌트 전환 후 기존 BASE 조회 기능과 상태 표현에 회귀가 없는지 확인 부탁드립니다.
- 좁은 화면에서 본문 가로 넘침 없이 테이블 내부 스크롤이 동작하는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

- [x] `develop` 기준 브랜치에서 작업했습니다.
- [x] 로컬 빌드에 성공했습니다.
- [x] 애플리케이션 실행을 확인했습니다.
- [x] 관련 기능을 직접 테스트했습니다.
- [x] 관련 구조 테스트를 보강했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 스타일과 안내 UI를 제거했습니다.

## 🖼️ 8. 화면 변경

- BASE-W01 필터와 결과 영역을 별도 카드로 분리
- 카드 간격 및 결과 테이블 좌우 여백 조정
- Guidance 및 수수료 항목 하단 안내 Note 제거
- 모바일 필터 레이아웃과 테이블 내부 가로 스크롤 개선

## 💬 9. 참고 사항

- 백엔드 Controller, Service, DTO, Mapper 및 API 계약은 변경하지 않았습니다.
- 기존 BASE 화면의 탭·필터·초기화·페이징 동작은 그대로 유지합니다.
- `./gradlew test` 전체 테스트가 통과했습니다.