### PR TITLE
[Fix] ADJUSTED 한글 표기를 조정으로 통일

### DIFF
--- a/src/main/java/com/susukkang/fgc/common/code/ScheduleHeaderStatus.java
+++ b/src/main/java/com/susukkang/fgc/common/code/ScheduleHeaderStatus.java
@@ -12,7 +12,7 @@ public enum ScheduleHeaderStatus {
     PLANNED("예정"),
     CONFIRMED("확정"),
     MATCHED("대사일치"),
-    ADJUSTED("조정완료"),
+    ADJUSTED("조정"),
     HOLD("보류"),
     CANCELLED("취소"),
     RESTARTED("재개");

--- a/src/main/java/com/susukkang/fgc/common/code/ScheduleLineStatus.java
+++ b/src/main/java/com/susukkang/fgc/common/code/ScheduleLineStatus.java
@@ -12,7 +12,7 @@ public enum ScheduleLineStatus {
     PLANNED,  //예정 계약이 생성되고 막 생성 된 상태
     CONFIRMED,//확정 정산 담당자가 확정을 누를 경우
     MATCHED,  //대사일치 실제 수수료 지급과 명세가 같은 경우
-    ADJUSTED, //조정완료 실제 수수료 지급과 명세가 다른 경우
+    ADJUSTED, // 조정: 실제 수수료 지급과 명세가 다른 경우
     HOLD,     //보류 계약이 미납된 경우
     CANCELLED,//취소 계약이 해지된 경우
     RESTARTED //재개 계약이 부활한 경우

--- a/src/main/resources/static/js/features/schedule/schedule-detail.js
+++ b/src/main/resources/static/js/features/schedule/schedule-detail.js
@@ -25,7 +25,7 @@
     PLANNED: "예정",
     CONFIRMED: "확정",
     MATCHED: "대사일치",
-    ADJUSTED: "조정완료",
+    ADJUSTED: "조정",
     HOLD: "보류",
     CANCELLED: "취소",
     RESTARTED: "재개"

--- a/src/main/resources/static/js/features/schedule/schedule-list.js
+++ b/src/main/resources/static/js/features/schedule/schedule-list.js
@@ -70,7 +70,7 @@
       PLANNED: "예정",
       CONFIRMED: "확정",
       MATCHED: "대사일치",
-      ADJUSTED: "조정완료",
+      ADJUSTED: "조정",
       HOLD: "보류",
       CANCELLED: "취소",
       RESTARTED: "재개"

--- a/src/main/resources/templates/schedule/list.html
+++ b/src/main/resources/templates/schedule/list.html
@@ -62,7 +62,7 @@
           <option value="PLANNED">예정</option>
           <option value="CONFIRMED">확정</option>
           <option value="MATCHED">대사일치</option>
-          <option value="ADJUSTED">조정완료</option>
+          <option value="ADJUSTED">조정</option>
           <option value="HOLD">보류</option>
           <option value="CANCELLED">취소</option>
           <option value="RESTARTED">재개</option>

--- a/src/test/java/com/susukkang/fgc/schedule/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/schedule/controller/ScheduleControllerTest.java
@@ -57,7 +57,7 @@ class ScheduleControllerTest {
                 .andExpect(jsonPath("$.data.content[0].schedulePurpose").value("COMPARISON"))
                 .andExpect(jsonPath("$.data.content[0].schedulePurposeLabel").value("비교"))
                 .andExpect(jsonPath("$.data.content[0].status").value("ADJUSTED"))
-                .andExpect(jsonPath("$.data.content[0].statusLabel").value("조정완료"));
+                .andExpect(jsonPath("$.data.content[0].statusLabel").value("조정"));
     }
 
     @Test
@@ -74,7 +74,7 @@ class ScheduleControllerTest {
                 .andExpect(jsonPath("$.data.header.paymentStageLabel").value("GA→설계사"))
                 .andExpect(jsonPath("$.data.header.scheduleRegimeLabel").value("4년 분급(2027)"))
                 .andExpect(jsonPath("$.data.header.schedulePurposeLabel").value("비교"))
-                .andExpect(jsonPath("$.data.header.statusLabel").value("조정완료"));
+                .andExpect(jsonPath("$.data.header.statusLabel").value("조정"));
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/schedule/view/ScheduleListViewTest.java
+++ b/src/test/java/com/susukkang/fgc/schedule/view/ScheduleListViewTest.java
@@ -50,6 +50,8 @@ class ScheduleListViewTest {
                 .andExpect(content().string(containsString("name=\"regime\"")))
                 .andExpect(content().string(containsString("name=\"purpose\"")))
                 .andExpect(content().string(containsString("name=\"status\"")))
+                .andExpect(content().string(containsString("value=\"ADJUSTED\">조정</option>")))
+                .andExpect(content().string(not(containsString("조정완료"))))
                 .andExpect(content().string(containsString("value=\"OPERATIONAL\" selected")))
                 .andExpect(content().string(containsString("data-table-viewport schedule-table-viewport")))
                 .andExpect(content().string(containsString("/css/features/schedule.css")))


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- 스케줄 상태 코드 `ADJUSTED`의 한글 표시를 화면정의서 기준인 `조정`으로 통일했습니다.
- 상태 코드, API 구조, DB 및 상태 전이 로직은 변경하지 않았습니다.

## 🔗 2. 관련 이슈

- Closes #241

## 🛠 3. 구현 내용

- `ScheduleHeaderStatus.ADJUSTED`의 서버 응답 라벨을 `조정`으로 변경
- SCHE-W01 상태 검색 옵션과 목록 fallback 문구를 `조정`으로 변경
- SCHE-W02 상세 및 회차 상태 fallback 문구를 `조정`으로 통일
- API 응답 라벨 및 화면 렌더링 테스트 기대값 보강
- `조정완료` 문구가 화면에 다시 노출되지 않도록 구조 테스트 추가

## 🧪 4. 테스트 방법

1. 아래 대상 테스트를 실행합니다.
   ```bash
   ./gradlew test \
     --tests 'com.susukkang.fgc.schedule.controller.ScheduleControllerTest' \
     --tests 'com.susukkang.fgc.schedule.view.ScheduleListViewTest'
   ```
2. 전체 회귀 테스트를 실행합니다.
   ```bash
   ./gradlew test
   ```
3. 예상 스케줄 목록과 상세에서 `ADJUSTED` 상태가 `조정`으로 표시되는지 확인합니다.

## 🗄️ 5. DB / Flyway 변경

- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

- 없음

## 📋 6. 리뷰 요구사항

- `ADJUSTED`의 한글 표기가 화면정의서와 동일하게 `조정`으로 통일되었는지 확인 부탁드립니다.
- 상태 코드와 API 응답 구조, 스케줄 상태 전이 로직에는 영향이 없는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

- [x] `develop` 최신 내용을 반영했습니다.
- [x] 로컬 빌드에 성공했습니다.
- [ ] 애플리케이션 실행을 확인했습니다.
- [ ] 관련 기능을 직접 테스트했습니다.
- [x] 테스트 코드가 필요한 경우 작성했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

- 예상 스케줄 목록 및 상세의 `ADJUSTED` 표시 문구
  - 변경 전: `조정완료`
  - 변경 후: `조정`

## 💬 9. 참고 사항

- 상태 코드 `ADJUSTED`는 그대로 유지됩니다.
- API 필드 구조와 DB 스키마 변경은 없습니다.
- 대상 테스트와 전체 `./gradlew test`가 모두 통과했습니다.