### PR TITLE
[Bug] 수수료 지급건 INS->GA 등록안되는 버그 자잘한 버그 수정

### DIFF
--- a/src/main/resources/static/css/features/exception.css
+++ b/src/main/resources/static/css/features/exception.css
@@ -139,11 +139,11 @@
 
 .exception-pagination {
   display: flex;
-  min-height: 3.5rem;
+  min-height: 2.5rem;
   align-items: center;
-  justify-content: space-between;
-  gap: var(--space-4);
-  padding: var(--space-3) var(--space-4);
+  justify-content: flex-end;
+  gap: 1rem;
+  padding: 0.5rem 1rem;
   border-top: 1px solid var(--color-border-subtle);
   color: var(--color-text-secondary);
   font-size: 0.75rem;

--- a/src/main/resources/static/js/features/schedule/schedule-list.js
+++ b/src/main/resources/static/js/features/schedule/schedule-list.js
@@ -351,16 +351,15 @@
     currentPageText.textContent = String(page);
     totalPagesText.textContent = String(displayedTotalPages);
     renderPageNumbers(page, displayedTotalPages);
-    setPageButton(previousButton, page <= 1);
-    setPageButton(nextButton, totalPages === 0 || page >= totalPages);
+    setPageButton(previousButton, pageGroupStart(page) === 1);
+    setPageButton(nextButton, totalPages === 0 || pageGroupStart(page) + 5 > totalPages);
     pagination.hidden = false;
   }
 
   function renderPageNumbers(page, totalPages) {
     pageNumbers.replaceChildren();
-    var start = Math.max(1, page - 2);
+    var start = pageGroupStart(page);
     var end = Math.min(totalPages, start + 4);
-    start = Math.max(1, end - 4);
     for (var current = start; current <= end; current += 1) {
       var button = document.createElement("button");
       button.type = "button";
@@ -376,6 +375,10 @@
       })(current);
       pageNumbers.appendChild(button);
     }
+  }
+
+  function pageGroupStart(page) {
+    return Math.floor((page - 1) / 5) * 5 + 1;
   }
 
   function renderPage(pageData) {
@@ -448,15 +451,17 @@
   });
 
   previousButton.addEventListener("click", function () {
-    if (!currentState || currentState.page <= 1) return;
-    currentState.page -= 1;
+    if (!currentState) return;
+    var previousGroupLastPage = pageGroupStart(currentState.page) - 1;
+    if (previousGroupLastPage < 1) return;
+    currentState.page = previousGroupLastPage;
     updateBrowserUrl(currentState, false);
     load(currentState);
   });
 
   nextButton.addEventListener("click", function () {
     if (!currentState || nextButton.disabled) return;
-    currentState.page += 1;
+    currentState.page = pageGroupStart(currentState.page) + 5;
     updateBrowserUrl(currentState, false);
     load(currentState);
   });

--- a/src/main/resources/static/js/features/transaction/transaction-form.js
+++ b/src/main/resources/static/js/features/transaction/transaction-form.js
@@ -284,7 +284,7 @@
     fillOptions(select, [
       ["DIRECT", "직접 귀속"], ["SETTLEMENT_SUPPORT_MONTHLY", "정착지원금 월배부"],
       ["FIRST_CONTRACT_CARRY_FORWARD", "최초계약 이월"], ["APPROVED_ALLOCATION", "승인 배부"],
-      ["MANUAL_REVIEW", "수기 검토"], ["NEWCOMER_NON_CONTRACT", "신인 비계약"]
+      ["MANUAL_REVIEW", "수기 검토"]
     ]);
     return select;
   }
@@ -338,24 +338,32 @@
     var decision = row.querySelector("[data-inclusion]");
     var evidence = row.querySelector("[data-attr-evidence]");
     var contractCell = contract.parentElement;
+    var methodCell = method.parentElement;
     var noContract = contractCell.querySelector("[data-no-contract]");
+    var automaticMethod = methodCell.querySelector("[data-automatic-method]");
     var previousDecision = decision.value;
 
     if (!noContract) {
       noContract = document.createElement("span");
       noContract.dataset.noContract = "";
       noContract.className = "fgc-muted";
-      noContract.textContent = "계약 없음";
+      noContract.textContent = "-";
       noContract.hidden = true;
       contractCell.appendChild(noContract);
+    }
+    if (!automaticMethod) {
+      automaticMethod = document.createElement("span");
+      automaticMethod.dataset.automaticMethod = "";
+      automaticMethod.className = "fgc-muted";
+      automaticMethod.textContent = "-";
+      automaticMethod.hidden = true;
+      methodCell.appendChild(automaticMethod);
     }
 
     scope.textContent = newcomerSupport ? "설계사" : "계약";
     contract.hidden = newcomerSupport;
     contract.disabled = newcomerSupport;
     noContract.hidden = !newcomerSupport;
-    var newcomerOption = method.querySelector('option[value="NEWCOMER_NON_CONTRACT"]');
-    if (newcomerOption) newcomerOption.disabled = !newcomerSupport;
     ["SETTLEMENT_SUPPORT_MONTHLY", "FIRST_CONTRACT_CARRY_FORWARD"].forEach(function (value) {
       var option = method.querySelector('option[value="' + value + '"]');
       if (option) option.disabled = isInsurerToGa();
@@ -363,8 +371,16 @@
     });
     if (newcomerSupport) {
       contract.value = "";
+      if (!method.querySelector('option[value="NEWCOMER_NON_CONTRACT"]')) {
+        var newcomerOption = document.createElement("option");
+        newcomerOption.value = "NEWCOMER_NON_CONTRACT";
+        newcomerOption.textContent = "신인 비계약";
+        method.appendChild(newcomerOption);
+      }
       method.value = "NEWCOMER_NON_CONTRACT";
       method.disabled = true;
+      method.hidden = true;
+      automaticMethod.hidden = false;
       fillOptions(decision, [
         ["EXCLUDED:NEW_AGENT_SUPPORT", "제외 · 신인 지원"],
         ["REVIEW_REQUIRED", "검토필요"]
@@ -375,6 +391,10 @@
       return;
     }
 
+    var newcomerOption = method.querySelector('option[value="NEWCOMER_NON_CONTRACT"]');
+    if (newcomerOption) newcomerOption.remove();
+    method.hidden = false;
+    automaticMethod.hidden = true;
     if (method.value === "NEWCOMER_NON_CONTRACT") method.value = "DIRECT";
     method.disabled = false;
     fillOptions(decision, inclusionOptions());

--- a/src/main/resources/static/js/features/transaction/transaction-list.js
+++ b/src/main/resources/static/js/features/transaction/transaction-list.js
@@ -81,8 +81,8 @@ if (typeof module !== "undefined" && module.exports) {
     updateUrl();
     load();
   });
-  previousButton.addEventListener("click", function () { changePage(state.page - 1); });
-  nextButton.addEventListener("click", function () { changePage(state.page + 1); });
+  previousButton.addEventListener("click", function () { changePage(pageGroupStart(state.page) - 1); });
+  nextButton.addEventListener("click", function () { changePage(pageGroupStart(state.page) + 5); });
 
   load();
 
@@ -212,16 +212,15 @@ if (typeof module !== "undefined" && module.exports) {
     currentPageText.textContent = page;
     totalPagesText.textContent = totalPages;
     renderPageNumbers(page, totalPages);
-    previousButton.disabled = page <= 1;
-    nextButton.disabled = page >= totalPages;
+    previousButton.disabled = pageGroupStart(page) === 1;
+    nextButton.disabled = pageGroupStart(page) + 5 > totalPages;
     pagination.hidden = number(pageData.totalElements) === 0;
   }
 
   function renderPageNumbers(page, totalPages) {
     pageNumbers.replaceChildren();
-    var start = Math.max(1, page - 2);
+    var start = pageGroupStart(page);
     var end = Math.min(totalPages, start + 4);
-    start = Math.max(1, end - 4);
     for (var current = start; current <= end; current += 1) {
       var button = document.createElement("button");
       button.type = "button";
@@ -231,6 +230,10 @@ if (typeof module !== "undefined" && module.exports) {
       else (function (target) { button.addEventListener("click", function () { changePage(target); }); })(current);
       pageNumbers.appendChild(button);
     }
+  }
+
+  function pageGroupStart(page) {
+    return Math.floor((page - 1) / 5) * 5 + 1;
   }
 
   function changePage(page) {

--- a/src/main/resources/templates/audit/list.html
+++ b/src/main/resources/templates/audit/list.html
@@ -153,14 +153,26 @@
           </tbody>
         </table>
       </div>
-      <footer class="audit-pagination" th:if="${logs.totalPages > 1}">
+      <footer class="audit-pagination" th:if="${logs.totalPages > 1}"
+              th:with="groupStart=${(logs.page - 1) - ((logs.page - 1) % 5) + 1}, groupEnd=${T(java.lang.Math).min(groupStart + 4, logs.totalPages)}">
+        <span class="audit-pagination-status tabular-nums" aria-live="polite"
+              th:text="${logs.page} + ' / ' + ${logs.totalPages} + ' 페이지'">1 / 1 페이지</span>
         <nav class="audit-pagination-nav" aria-label="감사 기록 페이지 이동">
-          <a class="button button-secondary" th:if="${logs.page > 1}"
-             th:href="@{/audit-logs(entityType=${form.entityType},entityId=${form.entityId},userId=${form.userId},action=${form.action},from=${form.from},to=${form.to},page=${logs.page - 1})}">이전</a>
-          <span class="audit-pagination-status tabular-nums" aria-live="polite"
-                th:text="${logs.page} + ' / ' + ${logs.totalPages}">1 / 1</span>
-          <a class="button button-secondary" th:if="${logs.page < logs.totalPages}"
-             th:href="@{/audit-logs(entityType=${form.entityType},entityId=${form.entityId},userId=${form.userId},action=${form.action},from=${form.from},to=${form.to},page=${logs.page + 1})}">다음</a>
+          <a class="pagination-button" th:if="${groupStart > 1}"
+             th:href="@{/audit-logs(entityType=${form.entityType},entityId=${form.entityId},userId=${form.userId},action=${form.action},from=${form.from},to=${form.to},page=${groupStart - 1})}"
+             aria-label="이전 5페이지"><span class="material-symbols-rounded" aria-hidden="true">chevron_left</span></a>
+          <span class="pagination-button is-disabled" th:unless="${groupStart > 1}"
+                aria-label="이전 5페이지" aria-disabled="true" tabindex="-1"><span class="material-symbols-rounded" aria-hidden="true">chevron_left</span></span>
+          <th:block th:each="pageNumber : ${#numbers.sequence(groupStart, groupEnd)}">
+            <span class="pagination-button is-active" th:if="${pageNumber == logs.page}" aria-current="page" th:text="${pageNumber}">1</span>
+            <a class="pagination-button" th:unless="${pageNumber == logs.page}" th:text="${pageNumber}"
+               th:href="@{/audit-logs(entityType=${form.entityType},entityId=${form.entityId},userId=${form.userId},action=${form.action},from=${form.from},to=${form.to},page=${pageNumber})}">1</a>
+          </th:block>
+          <a class="pagination-button" th:if="${groupEnd < logs.totalPages}"
+             th:href="@{/audit-logs(entityType=${form.entityType},entityId=${form.entityId},userId=${form.userId},action=${form.action},from=${form.from},to=${form.to},page=${groupEnd + 1})}"
+             aria-label="다음 5페이지"><span class="material-symbols-rounded" aria-hidden="true">chevron_right</span></a>
+          <span class="pagination-button is-disabled" th:unless="${groupEnd < logs.totalPages}"
+                aria-label="다음 5페이지" aria-disabled="true" tabindex="-1"><span class="material-symbols-rounded" aria-hidden="true">chevron_right</span></span>
         </nav>
       </footer>
     </section>

--- a/src/main/resources/templates/contract/list.html
+++ b/src/main/resources/templates/contract/list.html
@@ -49,14 +49,19 @@
       </table>
       <aside class="contract-premium-help"><span class="material-symbols-rounded" aria-hidden="true">info</span><div><h3>월납환산 초회보험료</h3><p>주기 보험료를 월 기준으로 환산한 값이며 1,200% 한도 계산 기준으로 사용합니다.</p></div></aside>
     </div>
-    <nav class="contract-pagination" aria-label="계약 목록 페이지">
-      <span><span th:text="${contracts.page()}">1</span> / <span th:text="${contracts.totalPages() == 0 ? 1 : contracts.totalPages()}">1</span> 페이지</span>
+    <nav class="contract-pagination" aria-label="계약 목록 페이지"
+         th:with="totalPageCount=${contracts.totalPages() == 0 ? 1 : contracts.totalPages()}, groupStart=${(contracts.page() - 1) - ((contracts.page() - 1) % 5) + 1}, groupEnd=${T(java.lang.Math).min(groupStart + 4, totalPageCount)}">
+      <span><span th:text="${contracts.page()}">1</span> / <span th:text="${totalPageCount}">1</span> 페이지</span>
       <div class="pagination-controls">
-        <a class="pagination-button" th:if="${contracts.page() > 1}" th:href="@{/contracts(page=${contracts.page() - 1},size=${contracts.size()},contractNo=${condition.contractNo},insurerId=${condition.insurerId},productOfferingId=${condition.productOfferingId},agentId=${condition.agentId},orgId=${condition.orgId},contractDateFrom=${condition.contractDateFrom},contractDateTo=${condition.contractDateTo},currentStatus=${condition.currentStatus},capResultStatus=${condition.capResultStatus})}" aria-label="이전 페이지"><span class="material-symbols-rounded" aria-hidden="true">chevron_left</span></a>
-        <span class="pagination-button is-disabled" th:unless="${contracts.page() > 1}" aria-label="이전 페이지" aria-disabled="true" tabindex="-1"><span class="material-symbols-rounded" aria-hidden="true">chevron_left</span></span>
-        <span class="pagination-button is-active" aria-current="page" th:text="${contracts.page()}">1</span>
-        <a class="pagination-button" th:if="${contracts.page() < contracts.totalPages()}" th:href="@{/contracts(page=${contracts.page() + 1},size=${contracts.size()},contractNo=${condition.contractNo},insurerId=${condition.insurerId},productOfferingId=${condition.productOfferingId},agentId=${condition.agentId},orgId=${condition.orgId},contractDateFrom=${condition.contractDateFrom},contractDateTo=${condition.contractDateTo},currentStatus=${condition.currentStatus},capResultStatus=${condition.capResultStatus})}" aria-label="다음 페이지"><span class="material-symbols-rounded" aria-hidden="true">chevron_right</span></a>
-        <span class="pagination-button is-disabled" th:unless="${contracts.page() < contracts.totalPages()}" aria-label="다음 페이지" aria-disabled="true" tabindex="-1"><span class="material-symbols-rounded" aria-hidden="true">chevron_right</span></span>
+        <a class="pagination-button" th:if="${groupStart > 1}" th:href="@{/contracts(page=${groupStart - 1},size=${contracts.size()},contractNo=${condition.contractNo},insurerId=${condition.insurerId},productOfferingId=${condition.productOfferingId},agentId=${condition.agentId},orgId=${condition.orgId},contractDateFrom=${condition.contractDateFrom},contractDateTo=${condition.contractDateTo},currentStatus=${condition.currentStatus},capResultStatus=${condition.capResultStatus})}" aria-label="이전 5페이지"><span class="material-symbols-rounded" aria-hidden="true">chevron_left</span></a>
+        <span class="pagination-button is-disabled" th:unless="${groupStart > 1}" aria-label="이전 5페이지" aria-disabled="true" tabindex="-1"><span class="material-symbols-rounded" aria-hidden="true">chevron_left</span></span>
+        <th:block th:each="pageNumber : ${#numbers.sequence(groupStart, groupEnd)}">
+          <span class="pagination-button is-active" th:if="${pageNumber == contracts.page()}" aria-current="page" th:text="${pageNumber}">1</span>
+          <a class="pagination-button" th:unless="${pageNumber == contracts.page()}" th:text="${pageNumber}"
+             th:href="@{/contracts(page=${pageNumber},size=${contracts.size()},contractNo=${condition.contractNo},insurerId=${condition.insurerId},productOfferingId=${condition.productOfferingId},agentId=${condition.agentId},orgId=${condition.orgId},contractDateFrom=${condition.contractDateFrom},contractDateTo=${condition.contractDateTo},currentStatus=${condition.currentStatus},capResultStatus=${condition.capResultStatus})}">1</a>
+        </th:block>
+        <a class="pagination-button" th:if="${groupEnd < totalPageCount}" th:href="@{/contracts(page=${groupEnd + 1},size=${contracts.size()},contractNo=${condition.contractNo},insurerId=${condition.insurerId},productOfferingId=${condition.productOfferingId},agentId=${condition.agentId},orgId=${condition.orgId},contractDateFrom=${condition.contractDateFrom},contractDateTo=${condition.contractDateTo},currentStatus=${condition.currentStatus},capResultStatus=${condition.capResultStatus})}" aria-label="다음 5페이지"><span class="material-symbols-rounded" aria-hidden="true">chevron_right</span></a>
+        <span class="pagination-button is-disabled" th:unless="${groupEnd < totalPageCount}" aria-label="다음 5페이지" aria-disabled="true" tabindex="-1"><span class="material-symbols-rounded" aria-hidden="true">chevron_right</span></span>
       </div>
     </nav>
   </section>

--- a/src/main/resources/templates/exception/list.html
+++ b/src/main/resources/templates/exception/list.html
@@ -179,30 +179,34 @@
           </tbody>
         </table>
       </div>
-      <nav class="exception-pagination" aria-label="예외 목록 페이지">
+      <nav class="exception-pagination" aria-label="예외 목록 페이지"
+           th:with="totalPageCount=${casePage.totalPages() == 0 ? 1 : casePage.totalPages()}, groupStart=${(casePage.page() - 1) - ((casePage.page() - 1) % 5) + 1}, groupEnd=${T(java.lang.Math).min(groupStart + 4, totalPageCount)}">
         <span>
           <span th:text="${casePage.page()}">1</span> /
-          <span th:text="${casePage.totalPages() == 0 ? 1 : casePage.totalPages()}">1</span> 페이지
+          <span th:text="${totalPageCount}">1</span> 페이지
         </span>
         <div class="pagination-controls">
-          <a class="pagination-button" th:if="${casePage.page() > 1}"
-             th:href="@{/exceptions(type=${typeFilter},reasonCode=${reasonCodeFilter},severity=${severityFilter},status=${statusFilter},assigneeFilter=${assigneeFilter},validationMonth=${validationMonthFilter},contractNo=${contractNoFilter},month=${month},page=${casePage.page() - 1})}"
-             aria-label="이전 페이지">
+          <a class="pagination-button" th:if="${groupStart > 1}"
+             th:href="@{/exceptions(type=${typeFilter},reasonCode=${reasonCodeFilter},severity=${severityFilter},status=${statusFilter},assigneeFilter=${assigneeFilter},validationMonth=${validationMonthFilter},contractNo=${contractNoFilter},month=${month},page=${groupStart - 1})}"
+             aria-label="이전 5페이지">
             <span class="material-symbols-rounded" aria-hidden="true">chevron_left</span>
           </a>
-          <span class="pagination-button is-disabled" th:unless="${casePage.page() > 1}"
-                aria-label="이전 페이지" aria-disabled="true" tabindex="-1">
+          <span class="pagination-button is-disabled" th:unless="${groupStart > 1}"
+                aria-label="이전 5페이지" aria-disabled="true" tabindex="-1">
             <span class="material-symbols-rounded" aria-hidden="true">chevron_left</span>
           </span>
-          <span class="pagination-button is-active" aria-current="page"
-                th:text="${casePage.page()}">1</span>
-          <a class="pagination-button" th:if="${casePage.page() < casePage.totalPages()}"
-             th:href="@{/exceptions(type=${typeFilter},reasonCode=${reasonCodeFilter},severity=${severityFilter},status=${statusFilter},assigneeFilter=${assigneeFilter},validationMonth=${validationMonthFilter},contractNo=${contractNoFilter},month=${month},page=${casePage.page() + 1})}"
-             aria-label="다음 페이지">
+          <th:block th:each="pageNumber : ${#numbers.sequence(groupStart, groupEnd)}">
+            <span class="pagination-button is-active" th:if="${pageNumber == casePage.page()}" aria-current="page" th:text="${pageNumber}">1</span>
+            <a class="pagination-button" th:unless="${pageNumber == casePage.page()}" th:text="${pageNumber}"
+               th:href="@{/exceptions(type=${typeFilter},reasonCode=${reasonCodeFilter},severity=${severityFilter},status=${statusFilter},assigneeFilter=${assigneeFilter},validationMonth=${validationMonthFilter},contractNo=${contractNoFilter},month=${month},page=${pageNumber})}">1</a>
+          </th:block>
+          <a class="pagination-button" th:if="${groupEnd < totalPageCount}"
+             th:href="@{/exceptions(type=${typeFilter},reasonCode=${reasonCodeFilter},severity=${severityFilter},status=${statusFilter},assigneeFilter=${assigneeFilter},validationMonth=${validationMonthFilter},contractNo=${contractNoFilter},month=${month},page=${groupEnd + 1})}"
+             aria-label="다음 5페이지">
             <span class="material-symbols-rounded" aria-hidden="true">chevron_right</span>
           </a>
-          <span class="pagination-button is-disabled" th:unless="${casePage.page() < casePage.totalPages()}"
-                aria-label="다음 페이지" aria-disabled="true" tabindex="-1">
+          <span class="pagination-button is-disabled" th:unless="${groupEnd < totalPageCount}"
+                aria-label="다음 5페이지" aria-disabled="true" tabindex="-1">
             <span class="material-symbols-rounded" aria-hidden="true">chevron_right</span>
           </span>
         </div>

--- a/src/test/java/com/susukkang/fgc/contract/controller/ContractViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/controller/ContractViewControllerTest.java
@@ -115,7 +115,7 @@ class ContractViewControllerTest {
                 .andExpect(content().string(containsString("100,000원")))
                 .andExpect(content().string(containsString("aria-current=\"page\"")))
                 .andExpect(content().string(containsString(
-                        "aria-label=\"다음 페이지\" aria-disabled=\"true\" tabindex=\"-1\"")));
+                        "aria-label=\"다음 5페이지\" aria-disabled=\"true\" tabindex=\"-1\"")));
 
         ArgumentCaptor<ContractSearchCondition> captor = ArgumentCaptor.forClass(ContractSearchCondition.class);
         verify(contractService).selectByCondition(captor.capture(), org.mockito.ArgumentMatchers.eq(2), org.mockito.ArgumentMatchers.eq(20));

--- a/src/test/java/com/susukkang/fgc/ui/AppShellWorkspaceStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/AppShellWorkspaceStructureTest.java
@@ -67,7 +67,7 @@ class AppShellWorkspaceStructureTest {
     private static String resource(String path) throws IOException {
         try (var input = AppShellWorkspaceStructureTest.class.getClassLoader().getResourceAsStream(path)) {
             assertThat(input).as(path).isNotNull();
-            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8).replace("\r\n", "\n");
         }
     }
 }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- 수수료 지급 건 등록 화면에서 지급단계별 선택 가능 항목과 귀속 판정 옵션을 분리했습니다.
- 원수사→GA 단계에서 설계사 지급·지원 성격의 항목을 선택하지 못하도록 보완했습니다.

## 🔗 2. 관련 이슈

* Closes #

## 🛠 3. 구현 내용

- 지급단계를 변경하면 기존 수수료 항목과 귀속행을 초기화합니다.
- 원수사→GA에서는 아래 수수료 항목을 목록에서 제외합니다.
  - 정착지원금
  - 신인활동지원금
  - 공통비 귀속분
  - 관리자수수료
  - 시책수수료
- 원수사→GA 귀속 판정은 `산입`, `검토필요`, `제외·준법경영비`만 노출합니다.
- GA→설계사에서는 녹취·방송·신인지원 관련 제외 판정을 제공합니다.
- 신인활동지원비 선택 시 계약번호와 귀속방법은 선택 UI 대신 `-`로 표시하고, 내부적으로 신인 비계약 귀속방식을 자동 적용합니다.
- 서버에서도 원수사→GA 요청에 금지 수수료 항목 또는 준법경영비 외 제외유형이 들어오면 저장을 거절합니다.

## 🧪 4. 테스트 방법

1. 지급단계를 GA→설계사에서 원수사→GA로 변경합니다.
2. 수수료 항목과 기존 귀속행이 초기화되는지 확인합니다.
3. 원수사→GA 수수료 항목에 정착지원금·신인지원·공통비·관리자수수료·시책수수료가 보이지 않는지 확인합니다.
4. 원수사→GA 귀속 판정에 산입·검토필요·준법경영비만 보이는지 확인합니다.
5. 신인활동지원비 선택 시 계약번호와 귀속방법이 `-`로 표시되는지 확인합니다.
6. API로 원수사→GA 금지 항목 또는 녹취/방송/신인지원 제외유형을 요청했을 때 저장이 거절되는지 확인합니다.

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

- 지급단계별 수수료 항목 및 귀속 판정 제한이 업무 규칙과 일치하는지 확인 부탁드립니다.
- 프런트 선택 제한과 서버 저장 검증 범위가 충분한지 확인 부탁드립니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [ ] 로컬 빌드에 성공했습니다. (`JAVA_HOME` 환경 설정 확인 필요)
* [ ] 애플리케이션 실행을 확인했습니다.
* [ ] 관련 기능을 직접 테스트했습니다.
* [ ] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [ ] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 있음 — 지급단계별 수수료 항목·귀속 판정 선택지와 신인활동지원비 귀속행 표시 변경

## 💬 9. 참고 사항

- 준법경영비 제외는 원수사→GA 단계에서만 허용됩니다.
- 신인 비계약 귀속은 신인활동지원비에만 자동 적용됩니다.