### PR TITLE
[Docs] 인터페이스정의서 5-2 매핑표 DASH-W01 구분 확인

### DIFF
--- a/docs/05_인터페이스정의서_v2_0.md
+++ b/docs/05_인터페이스정의서_v2_0.md
@@ -277,6 +277,7 @@ DB가 던진 제약 이름(`uq_contract_no` 등)을 오류코드로 바꾸는 �
 
 - `구분` 열의 **MPA**는 페이지가 통째로 새로 그려지는 것, **Ajax**는 화면 일부만 서버에서 값을 받아 바꾸는 것입니다 (SIR-006).
 - 2차에 React로 바꿀 때는 **Ajax 표시된 것부터** 옮기면 됩니다. 이미 JSON을 쓰고 있기 때문입니다.
+- `구분`은 **1차 화면이 그 API를 어떻게 쓰는지**만 적습니다. `MPA`로 적혀 있어도 응답이 JSON이면 API 자체는 그대로 살아 있고 2차 React가 바로 씁니다 (예: IF-API-03 — 5-1 참조).
 
 ### 4-2. API 목록 (52개)
 
@@ -284,7 +285,7 @@ DB가 던진 제약 이름(`uq_contract_no` 등)을 오류코드로 바꾸는 �
 |---|---|---|---|---|---|---|---|
 | IF-API-01 | AUTH-W01 | `POST /login` | `username`, `password` | 302 → `/` 또는 `?error` | 익명 | MPA | FUN-001 |
 | IF-API-02 | AUTH-W01 | `POST /logout` | — | 302 → `/login?logout` | 전체 | MPA | FUN-001 |
-| IF-API-03 | DASH-W01 | `GET /api/v1/dashboard/summary?month=2026-07` | `month` | `capViolation`, `capWarning`, `arbitrageCandidate`, `reconMismatch`, `journalImbalance`, `openException`, `recentExceptions[]`, `recentRuns[]` | 전체 | **Ajax** | FUN-057 |
+| IF-API-03 | DASH-W01 | `GET /api/v1/dashboard/summary?month=2026-07` | `month` | `capViolation`, `capWarning`, `arbitrageCandidate`, `reconMismatch`, `journalImbalance`, `openException`, `recentExceptions[]`, `recentRuns[]` | 전체 | MPA | FUN-057 |
 | IF-API-04 | BASE-W01 | `GET /api/v1/base/organizations` | `keyword`, `asOf` | `content[]`: `organizationCode`, `organizationName`, `organizationType`, `parentId`, `effectiveFrom/To` | 전체 | MPA | FUN-005 |
 | IF-API-05 | BASE-W01 | `GET /api/v1/base/insurers` | `keyword` | `insurerCode`, `insurerName`, `insurerType` | 전체 | MPA | FUN-006 |
 | IF-API-06 | BASE-W01 | `GET /api/v1/base/products` | `insurerId`, `asOf` | `productName`, `standardProductCode`, `offeringVersion`, `salesStartDate`, `basicDocumentVersion`, `channelCode`, `feeRegimeCode`, `standardDeduction80Yn` | 전체 | MPA | FUN-007 |
@@ -362,7 +363,11 @@ DB가 던진 제약 이름(`uq_contract_no` 등)을 오류코드로 바꾸는 �
 > **MPA**(Multi Page Application: 서버가 HTML 페이지를 통째로 그려서 주는 방식)는 주소를 누를 때마다 화면 전체가 새로 그려집니다.
 > **Ajax**(화면 일부만 서버에서 값을 받아 다시 그리는 방식)는 페이지는 그대로 두고 숫자만 바꿉니다.
 >
-> 1차에서는 **입력·목록은 MPA**, **한도게이지·검증실행·대사상세는 Ajax**로 만듭니다.
+> 1차에서는 **입력·목록·대시보드는 MPA**, **한도게이지·검증실행·대사상세는 Ajax**로 만듭니다.
+>
+> 대시보드(DASH-W01)는 진입도 기준월 변경도 페이지가 통째로 다시 그려집니다. 헤더의 기준월 선택이 `?month=`를 붙여
+> 전체 리로드하는 공통 셸 동작을 그대로 따르고, 화면은 IF-API-03을 HTTP로 다시 부르지 않고 같은 `DashboardService`를
+> 서버에서 직접 씁니다. IF-API-03은 4-2에 그대로 남아 2차 React가 씁니다 (SRC-028 · 2026-08-19 결정).
 > 2차 React SPA는 4장의 `/api/v1/**`를 **그대로** 부르므로 백엔드를 다시 만들지 않습니다.
 
 ### 5-2. 매핑표
@@ -370,7 +375,7 @@ DB가 던진 제약 이름(`uq_contract_no` 등)을 오류코드로 바꾸는 �
 | 화면ID | MPA 라우트 | Thymeleaf 템플릿 | Ajax 엔드포인트 | 갱신 트리거 | 2차 React 경로 |
 |---|---|---|---|---|---|
 | AUTH-W01 | `GET /login` | `auth/login.html` | 없음 | — | `/login` |
-| DASH-W01 | `GET /` | `dashboard/index.html` | IF-API-03 | 진입 + 기준월 변경 | `/` |
+| DASH-W01 | `GET /` | `dashboard/index.html` | 없음 | — (진입·기준월 변경 모두 페이지 전체 리로드) | `/` |
 | BASE-W01 | `GET /base` | `base/index.html` | IF-API-04~08 | 탭 클릭 | `/base` |
 | POL-W01 | `GET /policies` | `policy/list.html` | IF-API-10 | 탭 클릭 | `/policies` |
 | CONT-W01 | `GET /contracts` | `contract/list.html` | 없음 | — | `/contracts` |

--- a/src/main/java/com/susukkang/fgc/dashboard/controller/DashboardViewController.java
+++ b/src/main/java/com/susukkang/fgc/dashboard/controller/DashboardViewController.java
@@ -19,6 +19,8 @@ import java.time.YearMonth;
  *
  * 기준월은 {@link com.susukkang.fgc.common.web.ShellAdvice} 가 세션에 넣어 둔 값을 받는다 —
  * 헤더 select 를 바꾸면 ?month= 로 돌아와 이 화면이 다시 집계된다(SIR-006: 1차는 MPA 전체 갱신).
+ * DASH-W01 을 Ajax 가 아니라 MPA 로 둔다는 결정은 인터페이스정의서 5-1·5-2 에 적혀 있다
+ * (근거대장 "DASH-W01 MPA/Ajax 판정", SRC-028 · 2026-08-19).
  */
 @Controller
 @RequiredArgsConstructor


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* 인터페이스정의서 5-2 매핑표가 DASH-W01을 Ajax(IF-API-03)로 적었으나 구현은 진입·기준월 변경 모두 서버 렌더링 + 전체 리로드.
* 구현을 문서에 맞춤.

## 🔗 2. 관련 이슈

* Closes #84

## 🛠 3. 구현 내용

* docs/05_인터페이스정의서_v2_0.md
    * 4-2 IF-API-03 구분 **Ajax** → MPA
    * 5-2 DASH-W01 → 없음 / — (진입·기준월 변경 모두 페이지 전체 리로드) (AUTH-W01 선례)
    * 5-1 총칙 → "입력·목록·대시보드는 MPA" + 왜 MPA인지·IF-API-03은 2차용으로 남는다는 문단
    * 4-1 → 구분 열이 "1차 화면의 사용 방식"일 뿐 API 생사와 무관함을 한 줄 명시 (MPA 표기를 "React에서 못 쓴다"로 오독하는 것 차단)
* DashboardViewController.java — javadoc 에 결정 근거 2줄 (PR #59 리뷰에서 질문이 나온 바로 그 자리)
* 근거대장.md(로컬 vault) — "DASH-W01 MPA/Ajax 판정 (2026-08-19)" 절 추가, SRC-028(구현 기술표준). 규제가 아니라 렌더링 방식 판단이라 사용 규칙 6에 해당.

## 🗄️ 4. DB / Flyway 변경

<!-- 해당 사항에 체크해주세요. -->

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## ✅ 5. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 6. 화면 변경

* 없음

## 💬 7. 참고 사항

* 4-2 IF-API-04~08(BASE-W01)이 같은 종류의 반대 방향 충돌입니다. 4-2는 MPA인데 5-2는 Ajax 엔드포인트로 적고, 실제 js/features/base/base-api.js는 /api/v1/base/*를 fetch 합니다. #84 범위 밖이라 손대지 않고 근거대장 "남은 것"에만 기록했습니다. 별도 이슈로 올릴까요?
* vault 사본 30_산출물/05_...md 는 repo 판보다 약 44행 뒤처져 있었습니다(3장 오류코드·§7-6 등). 근거대장의 "diff 0" 기재가 낡아 있어 사실대로 고쳤고, DASH-W01 판정분만 양쪽에 같이 반영했습니다. 전체 재동기화는 미처리.
