### PR TITLE
[Docs] 인터페이스정의서 4-2 구분·5-2 매핑표를 실제 구현과 일치시키기 (BASE-W01 IF-API-04~08 외)

### DIFF
--- a/docs/05_인터페이스정의서_v2_0.md
+++ b/docs/05_인터페이스정의서_v2_0.md
@@ -278,6 +278,7 @@ DB가 던진 제약 이름(`uq_contract_no` 등)을 오류코드로 바꾸는 �
 - `구분` 열의 **MPA**는 페이지가 통째로 새로 그려지는 것, **Ajax**는 화면 일부만 서버에서 값을 받아 바꾸는 것입니다 (SIR-006).
 - 2차에 React로 바꿀 때는 **Ajax 표시된 것부터** 옮기면 됩니다. 이미 JSON을 쓰고 있기 때문입니다.
 - `구분`은 **1차 화면이 그 API를 어떻게 쓰는지**만 적습니다. `MPA`로 적혀 있어도 응답이 JSON이면 API 자체는 그대로 살아 있고 2차 React가 바로 씁니다 (예: IF-API-03 — 5-1 참조).
+- `화면` 열은 **대표 화면**입니다. IF-API-04~08(기준정보)처럼 여러 화면이 공유하는 API는 대표 화면만 적습니다 — 어느 화면이 어떤 API를 부르는지는 5-2·5-3이 기준입니다.
 
 ### 4-2. API 목록 (52개)
 
@@ -286,39 +287,39 @@ DB가 던진 제약 이름(`uq_contract_no` 등)을 오류코드로 바꾸는 �
 | IF-API-01 | AUTH-W01 | `POST /login` | `username`, `password` | 302 → `/` 또는 `?error` | 익명 | MPA | FUN-001 |
 | IF-API-02 | AUTH-W01 | `POST /logout` | — | 302 → `/login?logout` | 전체 | MPA | FUN-001 |
 | IF-API-03 | DASH-W01 | `GET /api/v1/dashboard/summary?month=2026-07` | `month` | `capViolation`, `capWarning`, `arbitrageCandidate`, `reconMismatch`, `journalImbalance`, `openException`, `recentExceptions[]`, `recentRuns[]` | 전체 | MPA | FUN-057 |
-| IF-API-04 | BASE-W01 | `GET /api/v1/base/organizations` | `keyword`, `asOf` | `content[]`: `organizationCode`, `organizationName`, `organizationType`, `parentId`, `effectiveFrom/To` | 전체 | MPA | FUN-005 |
-| IF-API-05 | BASE-W01 | `GET /api/v1/base/insurers` | `keyword` | `insurerCode`, `insurerName`, `insurerType` | 전체 | MPA | FUN-006 |
-| IF-API-06 | BASE-W01 | `GET /api/v1/base/products` | `insurerId`, `asOf` | `productName`, `standardProductCode`, `offeringVersion`, `salesStartDate`, `basicDocumentVersion`, `channelCode`, `feeRegimeCode`, `standardDeduction80Yn` | 전체 | MPA | FUN-007 |
-| IF-API-07 | BASE-W01 | `GET /api/v1/base/agents` | `organizationId`, `keyword` | `agentCode`, `agentName`, `rankCode`, `agentStatus`, `priorThreeYearExperienceYn` | 전체 | MPA | FUN-008 |
-| IF-API-08 | BASE-W01 | `GET /api/v1/base/commission-items` | `asOf` | `itemCode`, `itemName`, `cashflowType`, `itemCategory` | 전체 | MPA | FUN-009 |
+| IF-API-04 | BASE-W01 | `GET /api/v1/base/organizations` | `keyword`, `asOf` | `content[]`: `organizationCode`, `organizationName`, `organizationType`, `parentId`, `effectiveFrom/To` | 전체 | **Ajax** | FUN-005 |
+| IF-API-05 | BASE-W01 | `GET /api/v1/base/insurers` | `keyword` | `insurerCode`, `insurerName`, `insurerType` | 전체 | **Ajax** | FUN-006 |
+| IF-API-06 | BASE-W01 | `GET /api/v1/base/products` | `insurerId`, `asOf` | `productName`, `standardProductCode`, `offeringVersion`, `salesStartDate`, `basicDocumentVersion`, `channelCode`, `feeRegimeCode`, `standardDeduction80Yn` | 전체 | **Ajax** | FUN-007 |
+| IF-API-07 | BASE-W01 | `GET /api/v1/base/agents` | `organizationId`, `keyword` | `agentCode`, `agentName`, `rankCode`, `agentStatus`, `priorThreeYearExperienceYn` | 전체 | **Ajax** | FUN-008 |
+| IF-API-08 | BASE-W01 | `GET /api/v1/base/commission-items` | `asOf` | `itemCode`, `itemName`, `cashflowType`, `itemCategory` | 전체 | **Ajax** | FUN-009 |
 | IF-API-09 | POL-W01 | `GET /api/v1/policies?type=&asOf=&status=` | `type`, `asOf`, `status` | `policyCode`, `versionNo`, `sourceClass`, `status`, `effectiveFrom/To`, `regulationRefs[]` | 전체 | MPA | FUN-011·012·013 |
 | IF-API-10 | POL-W01 | `GET /api/v1/policies/{policyVersionId}` | — | `commissionRules[]`, `capRuleSets[]`(항목 판정 중첩), `refundRateTables[]`(차월 라인 중첩), `sourceRefs[]` | 전체 | **Ajax**(탭) | FUN-011·013 |
-| IF-API-11 | CONT-W01 | `GET /api/v1/contracts?page=1&size=20&insurerId=&productOfferingId=&agentId=&orgId=&contractDateFrom=&contractDateTo=&currentStatus=&capResultStatus=&contractNo=` | 검색조건 | `contractNo`, `insurerName`, `productName`, `monthlyEquivalentFirstPremium`, `contractDate`, `currentStatus/Label`, `capResultStatus`, `dataOrigin` | 전체 | MPA | FUN-018 |
-| IF-API-12 | CONT-W02 | `GET /api/v1/contracts/{id}` | — | 계약 기본 + 수정 복원용 `insurerId`, `productOfferingId`, `agentId`, `organizationId`와 표시명 | 전체 | MPA | FUN-018 |
+| IF-API-11 | CONT-W01 | `GET /api/v1/contracts?page=1&size=20&insurerId=&productOfferingId=&agentId=&orgId=&contractDateFrom=&contractDateTo=&currentStatus=&capResultStatus=&contractNo=` | 검색조건 | `contractNo`, `insurerName`, `productName`, `monthlyEquivalentFirstPremium`, `contractDate`, `currentStatus/Label`, `capResultStatus`, `dataOrigin` | 전체 | MPA · TRAN-W02는 Ajax | FUN-018 |
+| IF-API-12 | CONT-W02 | `GET /api/v1/contracts/{id}` | — | 계약 기본 + 수정 복원용 `insurerId`, `productOfferingId`, `agentId`, `organizationId`와 표시명 | 전체 | **Ajax** | FUN-018 |
 | IF-API-13 | CONT-W02 탭2 | `GET /api/v1/contracts/{id}/schedules` | `paymentStage` | `headers[]` + `lines[]` | 전체 | **Ajax** | FUN-036·039 |
 | IF-API-14 | CONT-W02 탭3 | `GET /api/v1/contracts/{id}/cap-checks` | — | **지급단계별 2건** (합산 금지) | 전체 | **Ajax** | FUN-032·035 |
 | IF-API-15 | CONT-W02 탭4 | `GET /api/v1/contracts/{id}/arbitrage-checks` | — | `arbitrage_check` + 기준일별 시계열 | 전체 | **Ajax** | FUN-063 |
 | IF-API-16 | CONT-W02 탭1 | `GET /api/v1/contracts/{id}/status-events` | — | `eventSeq`, `previousStatus`, `newStatus`, **`effectiveAt`, `receivedAt`, `processings[]`**(`processingJob`, `processingStatus`, `processedAt`), `sourceSystem`, `sourceEventKey` | 전체 | **Ajax** | (9장) |
 | IF-API-17 | CONT-W02 탭5·6 | `GET /api/v1/contracts/{id}/journals` · `/transactions` | — | 분개 · 지급 건 | 전체 | **Ajax** | FUN-046·065 |
-| IF-API-18 | CONT-W03 | `POST /api/v1/contracts` | `insurerId`, `productOfferingId`, `contractNo`, `contractDate`, `contractStatus`, `agentId`, `organizationId`, `premiumPerCycleAmount`, `paymentCycleCode`(월/3개월/6개월/연/일시납), `firstPremiumAmount`, `monthlyEquivalentFirstPremium`, `paymentTermMonths`, `standardSurrenderDeductionAmount?` | `contractId` + **같은 트랜잭션에서 만든 `scheduleHeaderIds[]`** | SETTLEMENT | MPA | FUN-018·030·036·040 |
-| IF-API-19 | CONT-W03 | `PUT /api/v1/contracts/{id}` | IF-API-18과 동일 | `contractId`, 새 버전의 `scheduleHeaderIds[]`, `regeneratedScheduleIds[]` (**기존 스케줄 버전은 보존**) | SETTLEMENT | MPA | FUN-018·030·036 |
+| IF-API-18 | CONT-W03 | `POST /api/v1/contracts` | `insurerId`, `productOfferingId`, `contractNo`, `contractDate`, `contractStatus`, `agentId`, `organizationId`, `premiumPerCycleAmount`, `paymentCycleCode`(월/3개월/6개월/연/일시납), `firstPremiumAmount`, `monthlyEquivalentFirstPremium`, `paymentTermMonths`, `standardSurrenderDeductionAmount?` | `contractId` + **같은 트랜잭션에서 만든 `scheduleHeaderIds[]`** | SETTLEMENT | **Ajax** | FUN-018·030·036·040 |
+| IF-API-19 | CONT-W03 | `PUT /api/v1/contracts/{id}` | IF-API-18과 동일 | `contractId`, 새 버전의 `scheduleHeaderIds[]`, `regeneratedScheduleIds[]` (**기존 스케줄 버전은 보존**) | SETTLEMENT | **Ajax** | FUN-018·030·036 |
 | IF-API-19A | CONT-W02 | `POST /api/v1/contracts/{id}/schedules/regenerate?reason=CONTRACT_DETAIL_MANUAL` | `reason`(필수, 계약 상세 버튼은 `CONTRACT_DETAIL_MANUAL` 고정) | 양 지급단계의 새 `scheduleHeaderIds[]` (**기존 버전·확정 회차 보존**) | SETTLEMENT | Ajax | FUN-039·040 |
 | IF-API-19B | CONT-W02 | `POST /api/v1/contracts/{id}/cap-check` | — | 지급단계별 `CapCheckSaveResult[]`(`capCheckId`, `result{paymentStage, checkKind:"MANUAL", asOfDate, limitAmount, includedAmount, usagePct, resultStatus, ...}`) | SETTLEMENT | Ajax | FUN-032·035·061 |
-| IF-API-20 | TRAN-W01 | `GET /api/v1/transactions?settlementMonth=&paymentStage=&insurerId=&contractNo=&agentId=&commissionItemId=&status=&sourceType=&noAttributionOnly=&attributionImbalanceOnly=&page=1&size=20` | 검색조건 | 목록 + `attributionCount`, `differenceAmount` | 전체 | MPA | FUN-065·031·044 |
-| IF-API-21 | TRAN-W01 | `GET /api/v1/transactions/{id}` | — | 지급 건 + 귀속행 전체 | 전체 | MPA | FUN-065 |
-| IF-API-22 | TRAN-W02 | `POST /api/v1/transactions` **(저장 전용)** | `paymentStage`, `sourceType`, `sourceBusinessKey`, `settlementMonth`, `commissionItemId`, `amount`, `cashflowType`, `attributions[]` | `commissionTransactionId`, `status:"DRAFT"` | SETTLEMENT | MPA | FUN-065·031 |
-| IF-API-23 | TRAN-W02 | `PUT /api/v1/transactions/{id}` | 동일 (DRAFT만) | 동일 | SETTLEMENT | MPA | FUN-065 |
+| IF-API-20 | TRAN-W01 | `GET /api/v1/transactions?settlementMonth=&paymentStage=&insurerId=&contractNo=&agentId=&commissionItemId=&status=&sourceType=&noAttributionOnly=&attributionImbalanceOnly=&page=1&size=20` | 검색조건 | 목록 + `attributionCount`, `differenceAmount` | 전체 | **Ajax** | FUN-065·031·044 |
+| IF-API-21 | TRAN-W01 | `GET /api/v1/transactions/{id}` | — | 지급 건 + 귀속행 전체 | 전체 | **Ajax** | FUN-065 |
+| IF-API-22 | TRAN-W02 | `POST /api/v1/transactions` **(저장 전용)** | `paymentStage`, `sourceType`, `sourceBusinessKey`, `settlementMonth`, `commissionItemId`, `amount`, `cashflowType`, `attributions[]` | `commissionTransactionId`, `status:"DRAFT"` | SETTLEMENT | **Ajax** | FUN-065·031 |
+| IF-API-23 | TRAN-W02 | `PUT /api/v1/transactions/{id}` | 동일 (DRAFT만) | 동일 | SETTLEMENT | **Ajax** | FUN-065 |
 | IF-API-24 | TRAN-W02 | `POST /api/v1/transactions/{id}/precheck` | — | 저장 없이 계산만 → `capPreview[]`(게이지 2개), `blockers[]` | SETTLEMENT | **Ajax** | FUN-033 |
 | IF-API-25 | TRAN-W02 | `POST /api/v1/transactions/{id}/confirm` **(확정 전용)** | `Idempotency-Key` | `status:"CONFIRMED"`, `capCheckIds[]`, `journalHeaderId` / 실패 시 3장 오류 | SETTLEMENT | **Ajax** | FUN-065·031·033·034 |
 | IF-API-26 | TRAN-W02 | `POST /api/v1/transactions/{id}/cancel` | `reason`(필수) | `status:"CANCELLED"` | SETTLEMENT | Ajax | FUN-065 |
-| IF-API-27 | SCHE-W01 | `GET /api/v1/schedules?contractNo=&stage=&regime=&purpose=&status=` | 검색조건 | 헤더 목록(`paymentStage`, `scheduleRegime`, `schedulePurpose`, `status` 코드와 각 `*Label`) | 전체 | MPA | FUN-036·039·040 |
-| IF-API-28 | SCHE-W02 | `GET /api/v1/schedules/{id}` | — | 코드·`*Label`을 포함한 헤더 + 회차별 라인 + `ruleRef`(근거) | 전체 | MPA | FUN-036·039 |
+| IF-API-27 | SCHE-W01 | `GET /api/v1/schedules?contractNo=&stage=&regime=&purpose=&status=` | 검색조건 | 헤더 목록(`paymentStage`, `scheduleRegime`, `schedulePurpose`, `status` 코드와 각 `*Label`) | 전체 | **Ajax** | FUN-036·039·040 |
+| IF-API-28 | SCHE-W02 | `GET /api/v1/schedules/{id}` | — | 코드·`*Label`을 포함한 헤더 + 회차별 라인 + `ruleRef`(근거) | 전체 | **Ajax** | FUN-036·039 |
 | IF-API-28A | SCHE-W02 | `GET /api/v1/schedules/{id}/versions` | — | 같은 계약·지급단계의 코드·`*Label` 포함 스케줄 버전 목록(최신순) | 전체 | Ajax | FUN-039 |
 | IF-API-29 | SCHE-W02 | `POST /api/v1/schedules/{id}/regenerate` | `reason`(필수) | 새 `scheduleHeaderId`, `versionNo` | SETTLEMENT | Ajax | FUN-039·040 |
 | IF-API-29A | SCHE-W02 | `POST /api/v1/schedules/{id}/confirm` | — | 확정된 헤더(`header.status:"CONFIRMED"`) + 회차별 라인(`lines[].lineStatus`는 실제 상태 유지) | SETTLEMENT | Ajax | FUN-039·040 |
-| IF-API-30 | CAP-W01 | `GET /api/v1/cap-checks?month=&stage=&status=&insurerId=&contractNo=&orgId=&page=1&size=20` | 검색조건 + `page`(1-base, 기본 1), `size`(기본 20·최대 100) | `summary{normal,warning,violation,reviewRequired}`(`stage` 적용·`status` 제외) + 전체 검색범위의 `stageSummary[2]`(`stage`·`status` 제외, `violationCount`, `warningCount`, `reviewRequiredCount`) + `agentSummary[]`(GA→설계사만, `stage`·`status` 제외, `violationCount`, `warningCount`, `reviewRequiredCount`, `worstContractNo`, `worstUsagePct`, 모니터링 전용) + 페이징 `content[]`, `page`, `size`, `totalElements`, `totalPages`, `sort` | 전체 | MPA(게이지만 Ajax) | FUN-030·032·034 |
+| IF-API-30 | CAP-W01 | `GET /api/v1/cap-checks?month=&stage=&status=&insurerId=&contractNo=&orgId=&page=1&size=20` | 검색조건 + `page`(1-base, 기본 1), `size`(기본 20·최대 100) | `summary{normal,warning,violation,reviewRequired}`(`stage` 적용·`status` 제외) + 전체 검색범위의 `stageSummary[2]`(`stage`·`status` 제외, `violationCount`, `warningCount`, `reviewRequiredCount`) + `agentSummary[]`(GA→설계사만, `stage`·`status` 제외, `violationCount`, `warningCount`, `reviewRequiredCount`, `worstContractNo`, `worstUsagePct`, 모니터링 전용) + 페이징 `content[]`, `page`, `size`, `totalElements`, `totalPages`, `sort` | 전체 | **Ajax** | FUN-030·032·034 |
 | IF-API-31 | CAP-W02 | `GET /api/v1/cap-checks/{capCheckId}/details` | — | `capCheck` + `details[]`(`detailSeq`, `commissionItemName`, `classificationSnapshot`, `amount`, `decisionReason`, `evidenceRef` nullable; 미연결 시 화면은 "증빙 미연결 / 후속 연결 대기" 표기) + `calculationSnapshot` | 전체 | **Ajax(팝업)** | FUN-035 |
-| IF-API-32 | ARB-W01 | `GET /api/v1/arbitrage-checks?month=&status=&stage=&insurerId=&contractNo=` | 검색조건 | 요약 3종 + 목록(`paymentStage`/`paymentStageLabel`, `resultStatus`/`resultStatusLabel` 동봉) | 전체 | MPA | FUN-063 |
+| IF-API-32 | ARB-W01 | `GET /api/v1/arbitrage-checks?month=&status=&stage=&insurerId=&contractNo=` | 검색조건 | 요약 3종 + 목록(`paymentStage`/`paymentStageLabel`, `resultStatus`/`resultStatusLabel` 동봉) | 전체 | **Ajax** | FUN-063 |
 | IF-API-33 | ARB-W01 | `POST /api/v1/contracts/{id}/arbitrage-check` | `asOfDate`, `reason` | `arbitrageCheckId`, `resultStatus`, **`validationRunId`** (`run_type='MANUAL_CONTRACT'`로 자동 생성) | SETTLEMENT | Ajax | FUN-063 |
 | IF-API-34 | LEDG-W01 | `GET /api/v1/journals?from=&to=&type=&account=&contract=&status=` | 검색조건 | 헤더 목록 + 차대 합계 | 전체 | MPA | FUN-046 |
 | IF-API-35 | LEDG-W01 | `GET /api/v1/journals/{id}` | — | 헤더 + 차변·대변 줄 | 전체 | Ajax | FUN-046 |
@@ -332,7 +333,7 @@ DB가 던진 제약 이름(`uq_contract_no` 등)을 오류코드로 바꾸는 �
 | IF-API-43 | EXCP-W01 | `GET /api/v1/exceptions?type=&types=&reasonCode=&severity=&status=&assignee=&unassignedOnly=&validationMonth=&contractNo=&validationRunId=&page=` | 검색조건 (SRC-032 개정: `reasonCode` 상세 원인·`validationMonth` 검증월 추가. FUN-044 체크리스트는 `validationRunId`와 복수 `types`를 사용. 화면 담당자 select는 화면 전용 `assigneeFilter` 하나로 보내고 서버가 `assignee`/`unassignedOnly`로 푼다. `page` 1-base, 20행) | 요약 카드 + 목록 | 전체 | MPA | FUN-052·053·044 |
 | IF-API-44 | EXCP-W01 | `POST /api/v1/exceptions/{id}/actions` | `actionType`, `reason`(필수), `evidenceRef` | 새 상태 + `actionSeq` | SETTLEMENT·GA_ADMIN | Ajax | FUN-053·034 |
 | IF-API-45 | VRUN-W01 | `POST /api/v1/validation-runs` | `validationMonth`, `runType` | `validationRunId`, `runNo`, `status:"CREATED"` | SETTLEMENT | MPA | FUN-041 |
-| IF-API-46 | VRUN-W01 | `GET /api/v1/validation-runs?month=&status=` | 검색조건 | 실행 목록 + 진행 단계 | 전체 | MPA | FUN-041 |
+| IF-API-46 | VRUN-W01 | `GET /api/v1/validation-runs?month=&status=` | 검색조건 | 실행 목록 + 진행 단계 | 전체 | MPA · RECO-W01은 Ajax | FUN-041 |
 | IF-API-47 | VRUN-W02 | `GET /api/v1/validation-runs/{id}` | — | 헤더 + `validation_target[]` + 결과 요약 4블록 + 예외 생성 결과(`exceptionSummary`: 검출/신규/재검출/재발/미검출/미처리 — SRC-032 2026-08-18 추가) | 전체 | MPA | FUN-042·043·052 |
 | IF-API-48 | VRUN-W02 | `POST /api/v1/validation-runs/{id}/execute` | — | `202 Accepted` + `status:"RUNNING"`, `currentStep` (**배치는 비동기**) | SETTLEMENT | **Ajax** | FUN-042·043 |
 | IF-API-49 | VRUN-W02 | `GET /api/v1/validation-runs/{id}/progress` | — | `status`, `currentStep(0~10)`, `totalSteps(10)`, `progressPct`, `failedStep`, `failureMessage` | 전체 | **Ajax(2초 폴링)** | FUN-043 |
@@ -378,23 +379,32 @@ DB가 던진 제약 이름(`uq_contract_no` 등)을 오류코드로 바꾸는 �
 | DASH-W01 | `GET /` | `dashboard/index.html` | 없음 | — (진입·기준월 변경 모두 페이지 전체 리로드) | `/` |
 | BASE-W01 | `GET /base` | `base/index.html` | IF-API-04~08 | 탭 클릭 | `/base` |
 | POL-W01 | `GET /policies` | `policy/list.html` | IF-API-10 | 탭 클릭 | `/policies` |
-| CONT-W01 | `GET /contracts` | `contract/list.html` | 없음 | — | `/contracts` |
-| CONT-W02 | `GET /contracts/{id}` | `contract/detail.html` | **IF-API-13~17·19A·19B** | 탭 클릭 시 조회 · [스케줄 재생성] · [한도 재검증] | `/contracts/:id` |
-| CONT-W03 | `GET /contracts/new` · `/{id}/edit` | `contract/form.html` | 없음 (form submit) | — | `/contracts/new` |
-| TRAN-W01 | `GET /transactions` | `transaction/list.html` | 없음 | — | `/transactions` |
-| TRAN-W02 | `GET /transactions/new` | `transaction/form.html` | **IF-API-24 사전검증 · IF-API-25 확정** | [사전검증]·[확정] 버튼 | `/transactions/new` |
-| SCHE-W01 | `GET /schedules` | `schedule/list.html` | 없음 | — | `/schedules` |
-| SCHE-W02 | `GET /schedules/{id}` | `schedule/detail.html` | IF-API-29·29A | [새 버전 만들기]·[확정] | `/schedules/:id` |
-| CAP-W01 | `GET /cap-checks` | `cap/list.html` | **IF-API-30** (게이지 부분) | 진입 + 필터 변경 | `/cap-checks` |
+| CONT-W01 | `GET /contracts` | `contract/list.html` | 없음 | — (목록 본문은 서버 렌더링) | `/contracts` |
+| CONT-W02 | `GET /contracts/{id}` | `contract/detail.html` | **IF-API-12·13~17·19A·19B·31** | 진입(본문) · 탭 클릭 시 조회 · [스케줄 재생성] · [한도 재검증] · 금액 클릭(CAP-W02 모달) | `/contracts/:id` |
+| CONT-W03 | `GET /contracts/new` · `/{id}/edit` | `contract/form.html` | **IF-API-12·14·18·19** | 수정 진입 시 조회 · [저장] — **form submit 이 아니라 fetch 다** | `/contracts/new` |
+| TRAN-W01 | `GET /transactions` | `transaction/list.html` | **IF-API-20** | 진입 + 필터·페이지 변경 | `/transactions` |
+| TRAN-W02 | `GET /transactions/new` | `transaction/form.html` | **IF-API-11·21·22·23·24·25** | 계약 검색 · 수정 진입 시 조회 · [저장]·[사전검증]·[확정] 버튼 | `/transactions/new` |
+| SCHE-W01 | `GET /schedules` | `schedule/list.html` | **IF-API-27** | 진입 + 필터 변경 | `/schedules` |
+| SCHE-W02 | `GET /schedules/{id}` | `schedule/detail.html` | **IF-API-28·28A·29·29A** | 진입(본문·버전 목록) · [새 버전 만들기]·[확정] | `/schedules/:id` |
+| CAP-W01 | `GET /cap-checks` | `cap/list.html` | **IF-API-30·31** | 진입 + 필터 변경(목록 **전체**가 Ajax) · 금액 클릭(CAP-W02 모달) | `/cap-checks` |
 | CAP-W02 | (팝업, 라우트 없음) | `cap/detail-modal.html` fragment | **IF-API-31** | 금액 클릭 | 모달 컴포넌트 |
-| ARB-W01 | `GET /arbitrage-checks` | `arbitrage/list.html` | IF-API-33 | [이 계약만 다시 검증] | `/arbitrage-checks` |
+| ARB-W01 | `GET /arbitrage-checks` | `arbitrage/list.html` | **IF-API-32·33** | 진입 + 필터 변경 · [이 계약만 다시 검증] | `/arbitrage-checks` |
 | LEDG-W01 | `GET /journals` | `ledger/list.html` | **IF-API-35·36·37** | 행 클릭 · [역분개] · 진입 | `/journals` |
-| RECO-W01 | `GET /reconciliations` | `reco/list.html` | **IF-API-38·40·42** | [대사 실행] + 폴링 | `/reconciliations` |
+| RECO-W01 | `GET /reconciliations` | `reco/list.html` | **IF-API-38·40·42·46** | [대사 실행](직전 IF-API-46 으로 최신 완료 실행 조회) + 폴링 — 실행 이력 목록은 서버 렌더링 | `/reconciliations` |
 | RECO-W02 | (팝업) | `reco/compare-modal.html` | **IF-API-41** | 결과행 클릭 | 모달 |
 | EXCP-W01 | `GET /exceptions` | `exception/list.html` | **IF-API-44** | [처리 저장] | `/exceptions` |
 | VRUN-W01 | `GET /validation-runs` | `vrun/list.html` | 없음 | — | `/validation-runs` |
 | VRUN-W02 | `GET /validation-runs/{id}` | `vrun/detail.html` | **IF-API-48·49·50·51** | [실행] 후 2초 폴링 | `/validation-runs/:id` |
 | AUDT-W01 | `GET /audit-logs` | `audit/list.html` | 없음 | — | `/audit-logs` |
+
+> **기준정보 선택지(IF-API-04~08)는 이 표에 적지 않는다** — 필터·드롭다운을 쓰는 화면
+> (CONT-W01·CONT-W03·TRAN-W01·TRAN-W02·CAP-W01·ARB-W01·RECO-W01)은 진입 시 이 5개를 Ajax 로
+> 채운다. 화면마다 반복하면 표가 안 읽히므로 5-3 규칙으로 한 번만 적는다.
+>
+> **아직 코드가 없는 행** — 설계는 유효하므로 표는 그대로 두되, 지금 구현되어 있지 않다는 것만 밝힌다.
+> LEDG-W01 의 IF-API-34~37(`ledger/list.html` 이 정적 골격 단계 · 이슈 #234) ·
+> VRUN-W02 의 IF-API-51(`btn-finalize` 가 `disabled` · 이슈 #233) ·
+> TRAN-W02 의 IF-API-26(지급 건 취소 · 담당 이슈 없음).
 
 ### 5-3. MPA·Ajax 공통 규칙 (SIR-006 인수조건)
 
@@ -405,6 +415,8 @@ DB가 던진 제약 이름(`uq_contract_no` 등)을 오류코드로 바꾸는 �
 | 오류 문구 | 양쪽 모두 3장 코드 + 부록 A 문구 |
 | 로딩 상태 | Ajax 영역은 스켈레톤. MPA는 브라우저 기본 |
 | 교육용 표시 | 화면 미표기 — 2026-08-12 팀 결정으로 화면 표기 의무 삭제(근거대장 "COR-009 화면 표기 개정"). 교육용 고지는 문서 수준으로 유지 (COR-009) |
+| 기준정보 선택지 | IF-API-04~08 은 필터·드롭다운을 쓰는 **모든 화면**이 진입 시 Ajax 로 채운다 (`js/features/base/base-api.js`). 5-2 매핑표에 화면마다 반복해 적지 않는다 |
+| 4-2 ↔ 5-2 정합 | 4-2 `구분`이 `Ajax` 인 API 는 5-2 의 어느 행엔가 나타나거나 5-2 표 아래 "아직 코드가 없는 행" 각주에 있어야 한다. 한쪽만 고치면 두 표가 다시 어긋난다 (이슈 #84·#246) |
 
 ---
 


### PR DESCRIPTION
# 📌 Pull Request

## 무엇을 했나

#84(DASH-W01)를 고치면서 같은 종류의 충돌이 한 행이 아니라는 것이 드러났다.
`docs/05_인터페이스정의서_v2_0.md`의 **4-2 `구분` 열**과 **5-2 매핑표**를
21개 화면 · 56개 API 전수로 구현과 대조했다.

**코드는 한 줄도 고치지 않았다. 문서만 바꾼다.**

> ### ✅ 팀 결정 반영 완료 (2026-08-19)
>
> "지금 와서 코드를 전면 수정하기는 어렵다 — **문서를 고치는 쪽으로 간다**" 로 결론이 났다.
> 아래 (b) 항목 13건 전부 **문서 교정 완료**. 체크박스는 승인 확인 표시다.
>
> | 구분 | 내용 | 건수 | 처리 |
> |---|---|---|---|
> | **(a)** | 문서 내부 모순 — 4-2와 5-2가 처음부터 달랐다 | 5 | ✅ 오기 정정 |
> | **(b)** | 구현이 문서를 벗어났다 | 13 | ✅ **문서를 구현에 맞춤 (팀 승인)** |
> | **(c)** | 미구현 — 문서는 유효, 코드가 없다 | 2 | 표 유지 · 각주로만 표시 |
> | **(d)** | 재발 방지 구조 | 4 | ✅ 4-1 각주 2 · 5-3 규칙 2 |
> | **(e)** | AI 리뷰 대응 | 3 | ✅ 아래 별도 섹션 |

---

## 어떻게 판정했나 — 3중 교차

| 단계 | 근거 |
|---|---|
| ① 화면 → 스크립트 | `layout/default.html:47-63`의 `screenId`별 조건부 로딩 |
| ② 스크립트 → API | 각 JS **+ 템플릿 인라인 `<script>`** 의 `/api/v1` 호출 |
| ③ 본문 렌더링 방식 | 각 ViewController의 `model.addAttribute` 유무 |

②가 중요했다. `static/js`만 grep 하면 **IF-API-12·16·19A·19B를 미구현으로 오판**한다 —
CONT-W02는 정적 JS가 아니라 `contract/detail.html:352,441,460,476` 인라인 스크립트에서 부른다.
반대로 템플릿 상단 주석 블록에도 API 경로가 잔뜩 적혀 있어, 주석과 실제 호출을 분리해서 셌다.

---

## (a) 문서 내부 모순 — 5건 · 오기 정정

**4-2는 `MPA`, 5-2는 `Ajax`. 같은 문서 두 곳이 처음부터 서로 달랐다.**
구현자는 5-2 BASE-W01 행(`IF-API-04~08 / 탭 클릭`)을 보고 만들었다.
누가 문서를 어기고 다르게 만든 게 아니라, **4-2 `구분` 열이 채워지지 않았던 것**이다.

- [x] **IF-API-04** `GET /api/v1/base/organizations` — `base-list.js:285`
- [x] **IF-API-05** `GET /api/v1/base/insurers` — `base-list.js:286`
- [x] **IF-API-06** `GET /api/v1/base/products` — `base-list.js:287`
- [x] **IF-API-07** `GET /api/v1/base/agents` — `base-list.js:288`
- [x] **IF-API-08** `GET /api/v1/base/commission-items` — `base-list.js:289`

→ 4-2 `구분`을 `**Ajax**`로 정정. 5-2는 원래 맞았으므로 그대로.

---

## (b) 구현이 문서를 벗어났다 — 13건 · **문서 교정 완료**

### 판정 근거

커밋 이력상 **팀의 일관된 작업 패턴**이었고, 4-2 `구분` 열만 그동안 갱신되지 않았다.

| 커밋 | 메시지 |
|---|---|
| `b5287894` | **[Feat] CONT,TRAN,SCHE 계약·지급 탭 주요 화면 API 연동 (#195)** |
| `38ab4e6d` | feat(commission): CAP-W01 한도 검증 현황 화면 구현 |
| `698af532` | feat(schedule): 예상 스케줄 목록 화면 통합 |
| `0aa417d3` | feat(contract): 보험계약 등록·수정 화면 연동 |

- SIR-006의 목적은 "2차 React 전환 시 **Ajax 표시된 것부터** 옮긴다"인데,
  Ajax가 더 많아진 건 2차 전환이 **쉬워진** 것이지 손해가 아니다
- **API 계약(경로·메서드·요청·응답·권한)은 한 글자도 바뀌지 않는다**
- 규제·업무 영향 0. 화면 동작도 달라지지 않는다 — 이미 그렇게 돌고 있다

### (b-1) 4-2 `구분`이 정반대 — 11건 ✅

- [x] **IF-API-12** `GET /api/v1/contracts/{id}` — `contract/detail.html:476`(CONT-W02 본문) · `contract-api.js:59`(CONT-W03 수정 진입)
- [x] **IF-API-18** `POST /api/v1/contracts` — `contract-api.js:67`
- [x] **IF-API-19** `PUT /api/v1/contracts/{id}` — `contract-api.js:71`
- [x] **IF-API-20** `GET /api/v1/transactions` — `transaction-list.js:152`
- [x] **IF-API-21** `GET /api/v1/transactions/{id}` — `transaction-form.js:134` **(＋화면 열도 교정, 아래 (e-1))**
- [x] **IF-API-22** `POST /api/v1/transactions` — `transaction-form.js:411`
- [x] **IF-API-23** `PUT /api/v1/transactions/{id}` — `transaction-form.js:411`
- [x] **IF-API-27** `GET /api/v1/schedules` — `schedule-list.js:136`
- [x] **IF-API-28** `GET /api/v1/schedules/{id}` — `schedule-detail.js:56`
- [x] **IF-API-30** `GET /api/v1/cap-checks` — `cap-list.js:371`
- [x] **IF-API-32** `GET /api/v1/arbitrage-checks` — `arbitrage-list.js:129,178`

**IF-API-30** 은 기존 표기가 `MPA(게이지만 Ajax)`인데 "게이지만"이 틀렸다.
`ScreenViewController:57`이 모델 없이 `cap/list`만 돌려주므로 **서버 렌더링 본문 자체가 없고**,
목록 전체를 `cap-list.js`가 그린다.

### (b-2) 한 화면은 MPA, 다른 화면이 같은 API를 Ajax로 재사용 — 2건 ✅

기존 `MPA` 표기를 **지우지 않고 병기**만 했다.

- [x] **IF-API-11** → `MPA · TRAN-W02는 Ajax`
      CONT-W01 본문은 서버 렌더링(`ContractViewController:51`)이지만 TRAN-W02 계약 검색이 부른다(`transaction-form.js:95`)
- [x] **IF-API-46** → `MPA · RECO-W01은 Ajax`
      VRUN-W01 본문은 서버 렌더링(`ValidationRunViewController:94`)이지만 RECO-W01이 [대사 실행] 직전 최신 완료 실행을 찾을 때 부른다(`reco.js:102`)

### (b-3) 5-2 매핑표 — 10행 ✅

develop 의 CSV 내보내기(#249) 내용을 **살린 채** 합쳤다.

| 화면 | 전 | 후 |
|---|---|---|
| CONT-W01 | IF-API-11A (CSV 다운로드) / `[CSV 내보내기]` | 그대로 + `— 목록 본문은 서버 렌더링` |
| CONT-W02 | 13~17·19A·19B | **12**·13~17·19A·19B·**31** |
| CONT-W03 | `없음 (form submit)` | **12·14·18·19** |
| TRAN-W01 | 없음 | **20** |
| TRAN-W02 | 24·25 | **11·21·22·23**·24·25 |
| SCHE-W01 | 27A(CSV) | **27** · 27A(CSV 다운로드) |
| SCHE-W02 | 28B·29·29A | **28·28A**·29·29A · 28B(CSV 다운로드) |
| CAP-W01 | 30 (게이지 부분) | **30·31** (목록 전체가 Ajax) |
| ARB-W01 | 33 | **32**·33 |
| RECO-W01 | 38·40·42 | 38·40·42·**46** |

> **CONT-W03이 가장 명백한 이탈이었다.** 문서가 `없음 (form submit)`이라고 **명시**했는데,
> `contract-form.js:418`이 `event.preventDefault()`로 기본 제출을 막고
> `contract-api.js`의 fetch로 보낸다. form submit이 아니다.

---

## (c) 미구현 — 2건 · 표는 그대로, 각주로만 표시

미구현을 오기로 오인해 지우면 설계 의도가 사라진다.

| IF-API | 화면 | 근거 | 담당 이슈 |
|---|---|---|---|
| 34~37 | LEDG-W01 | `ledger/list.html:17`이 스스로 "[정적 부착 단계]" 명시 | #234 (OPEN) |
| 26 | TRAN-W02 | `POST /api/v1/transactions/{id}/cancel` — 호출부도 엔드포인트도 없다 | 없음 |

> **IF-API-51은 목록에서 빠졌다.** 최초 조사 시점엔 미구현이었으나 develop 을 병합하면서
> 구현이 확인됐다 — `vrun-detail.js:217` 이 `POST /finalize` 를 부르고 이슈 **#233 은 CLOSED** 다.
> 각주에 이 사실을 명시해 뒀다.

---

## (d) 재발 방지 — 구조 개선 ✅

- [x] **4-1 각주** — `화면` 열은 대표 화면이고, 어느 화면이 어떤 API를 부르는지는 5-2·5-3이 기준
- [x] **4-1 각주** — **`다운로드`** 구분 설명 신설. develop 이 #249 로 이 값을 도입했는데 4-1에 정의가 없었다
- [x] **5-3 규칙** — 기준정보 선택지(IF-API-04~08)는 7개 화면 공통이므로 5-2에 반복하지 않고 5-3에 한 번만
- [x] **5-3 인수조건** — 아래 (e-2)에서 강화

---

## (e) AI 리뷰 대응

### (e-1) IF-API-37 화면 매핑 — **지적한 처방은 채택하지 않되, 짚은 냄새는 실재했다**

> 리뷰: "4-2의 IF-API-37 화면 매핑을 VRUN-W02 → LEDG-W01 로 바꿔라"

**채택하지 않는다.** VRUN-W02 는 IF-API-37 과 실제로 관계가 있다 —
`ValidationRunFinalizationServiceImpl:140` 이 확정 체크리스트 조건 2(원장 불균형 0건)의
드릴다운 링크로 `/api/v1/journals/imbalances?validationRunId=` 를 내려주고,
`vrun-detail.js:154` 의 `safeInternalLink()` 가 그걸 앵커로 건다.
VRUN-W02 를 지우면 **실재하는 관계를 지우는 것**이 된다.

다만 리뷰가 짚은 불일치는 맞다 — 4-2는 VRUN-W02를 적는데 5-2 VRUN-W02 행에는 37이 없었다.
**호출이 아니라 링크 참조**라서 `Ajax 엔드포인트` 칸에 넣는 것도 틀리다.
그래서 **5-2 표 아래에 "호출하지 않고 링크로만 참조하는 것" 각주를 신설**해 이 관계를 명시했다.

- [x] 4-2 `LEDG-W01 / VRUN-W02` 유지
- [x] 5-2 각주에 링크 참조 관계 명시

### (e-2) SIR-006 정합 규칙 강화 — **채택** ✅

> 리뷰: "4-2의 각 화면이 5-2에 대응 API를 갖도록 규칙을 강화하라"

기존 규칙은 "5-2 **어딘가에** 있으면 된다"였다. **화면 단위로 강화**했다.

```
| 4-2 ↔ 5-2 정합 | 4-2 `구분`이 `Ajax`·`다운로드` 인 API 는 5-2 에서 그 API 를 실제로 쓰는
화면 행에 나타나야 한다. ① 4-2 `화면` 열은 대표 화면이므로 다른 화면이 부르면
`MPA · {화면}은 Ajax` 로 병기하고 그 화면 행에 적는다. ② 부르지 않고 링크로만 참조하는
관계는 5-2 표 아래 각주에 적는다. ③ 아직 코드가 없으면 "아직 코드가 없는 행" 각주에 적는다. |
```

이 강화된 규칙을 실제로 돌렸더니 **화면 단위 누락 5건**이 나왔고, 그중 실제 결함 1건이 (e-3)이다.

### (e-3) IF-API-21 화면 열 — **강화된 규칙이 새로 잡아낸 결함** ✅

4-2가 `TRAN-W01` 이라고 적었지만 **TRAN-W01 은 이 API 를 부르지 않는다.**
`transaction-list.js:199` 가 행 링크를 `/transactions/new?id=` 로 보내 **TRAN-W02 로 이동**시키고,
거기서 `transaction-form.js:134` 가 부른다. 화면정의서 TRAN-W01 의 데이터 API 에도 21이 없다.

- [x] 4-2 IF-API-21 화면 열 `TRAN-W01` → `TRAN-W02`

---

## develop 병합

PR #249(CSV 내보내기)가 같은 문서를 건드려 충돌이 났다. **develop 판을 기준으로 삼고
이 PR 의 교정을 다시 얹는 방식**으로 해소했다 — CSV 관련 내용(IF-API-11A·27A·28B, 구분 `다운로드`)은
develop 것을 그대로 살렸다.

병합 과정에서 조사 시점이 낡았다는 것도 드러났다 — IF-API-51 이 그 사이 구현됐고((c) 참조),
CSV 3종은 `<a href>` · `location.assign` 내비게이션이라 Ajax 가 아니어서 이 PR 의 규칙과 충돌하지 않는다.

---

## 검증

### 불변식 — 3방향 자동 확인

| 검사 | 결과 |
|---|---|
| 4-2 `구분=Ajax` 46건 → 5-2 본문 또는 각주에 존재 | ✅ |
| 5-2 본문 17행의 엔드포인트 → 4-2 에서 `Ajax` 또는 `다운로드` | ✅ |
| **(신규)** 4-2 Ajax 47건(화면 단위) → 실제 소비 화면 행 또는 각주 | ✅ |

표 열 수 무결: 4-2 59행×10셀 · 5-2 21행×8셀 · 5-3 8행×4셀. 충돌 마커 0건.

### 엔드포인트 실존 대조 (참고)

| 항목 | 결과 |
|---|---|
| 문서 4-2 경로 | 57개 |
| 실제 컨트롤러 매핑 존재 | **56개** |
| 없는 것 | **IF-API-26** 1건 → (c)에 반영 |
| 문서에 없는 `/api/**` 매핑 | 0건 |

`/login`·`/logout`은 컨트롤러가 아니라 `SecurityConfig:149,154`의 formLogin/logout이라 정상.

### 하지 않은 검증

이 PR은 **렌더링 방식 표기**만 다룬다. 다음은 **확인하지 않았고 문서와 다를 수 있다**:
요청 파라미터·응답 필드(4-2의 `요청 핵심`/`응답 핵심` 열) · `역할` 열 vs `@PreAuthorize` ·
3장 오류코드 매핑 · FUN 요구사항 충족 · 업무 로직 · ERD/DB 스키마 · 규제 조문 준수.
→ **출시 전 전수 QA 트래커 #252** 에 13개 이슈로 분리해 뒀다.

### 자동 검사 테스트는 넣지 않았다

표 구조가 바뀌면 검사도 같이 깨진다. 지금까지 어긋난 것은 두 번(#84·#246)이고,
세 번째가 나오면 그때 붙인다.

---

## 이 PR 밖에서 발견한 것 (별도 처리)

- **VRUN-W02 확정 체크리스트 조건 2를 클릭하면 화면이 아니라 raw JSON 이 뜬다.**
  `safeInternalLink()` 가 `/api/...` 도 통과시키는데, 조건 3·4·5 는 화면 경로(`/exceptions?…` ·
  `/transactions?…`)를 쓰고 조건 2만 API 경로다. LEDG-W01 불균형 화면이 없어서 생긴 것이라
  **#234 에서 같이 다루는 게 맞다.** (코드 결함이므로 이 문서 PR 에서 고치지 않았다)

---

## 근거

**SRC-028** (구현 기술표준 — 규제·업무가 아니라 렌더링 방식의 기술 판단, 근거대장 사용 규칙 6).
`근거대장.md`에 "4-2 구분 ↔ 5-2 매핑표 전수 판정" 기록.
vault 사본은 repo 판보다 이미 뒤처져 있어 이번 교정을 넣지 않았다 —
부분 동기화는 어긋난 지점만 늘리므로 전체 재동기화 때 함께 처리한다.

Closes #246
