### PR TITLE
[Refactor] AUDT-W01 감사로그 조회 UX 개선

### DIFF
--- a/src/main/resources/static/css/features/audit.css
+++ b/src/main/resources/static/css/features/audit.css
@@ -4,38 +4,6 @@
   gap: var(--space-4);
 }
 
-.audit-notice {
-  display: grid;
-  grid-template-columns: 1.25rem minmax(0, 1fr);
-  gap: var(--space-3);
-  align-items: start;
-  padding: var(--space-3) var(--space-4);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-8);
-  color: var(--color-text-secondary);
-  background: var(--color-bg-subtle);
-}
-
-.audit-notice-icon {
-  margin-top: 0.125rem;
-  color: var(--color-icon-secondary);
-  font-size: 1.125rem;
-}
-
-.audit-notice-title {
-  color: var(--color-text-primary);
-  font-size: 0.8125rem;
-  font-weight: 700;
-  line-height: 1.25rem;
-}
-
-.audit-notice-copy {
-  margin-top: var(--space-1);
-  font-size: 0.75rem;
-  line-height: 1.25rem;
-  text-wrap: pretty;
-}
-
 .audit-filter-bar {
   align-items: flex-end;
 }
@@ -115,6 +83,15 @@
   text-decoration-color: currentcolor;
 }
 
+.audit-log-row {
+  cursor: pointer;
+}
+
+.audit-log-row:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: -2px;
+}
+
 .audit-state-row:hover {
   background: var(--color-bg-surface);
 }
@@ -122,6 +99,15 @@
 .audit-state-row td {
   height: auto;
   padding: 0;
+  white-space: normal;
+}
+
+.data-table td.audit-disclosure-cell {
+  height: auto;
+  padding-block: var(--space-2);
+  overflow: visible;
+  vertical-align: top;
+  text-overflow: clip;
   white-space: normal;
 }
 

--- a/src/main/resources/static/js/features/audit/audit-list.js
+++ b/src/main/resources/static/js/features/audit/audit-list.js
@@ -1,0 +1,53 @@
+(function () {
+  "use strict";
+
+  var rows = Array.from(document.querySelectorAll("[data-audit-detail-href]"));
+
+  function isInteractiveTarget(target) {
+    return target instanceof Element
+        && target.closest("a, button, input, select, textarea, summary, details") !== null;
+  }
+
+  function openDetail(row) {
+    var href = row.dataset.auditDetailHref;
+    if (href) window.location.assign(href);
+  }
+
+  function syncTableCellDisclosures() {
+    document.querySelectorAll(".table-cell-disclosure").forEach(function (disclosure) {
+      var preview = disclosure.querySelector(".table-cell-preview");
+      var details = disclosure.querySelector(".table-cell-details");
+      if (!preview || !details || preview.clientWidth === 0) return;
+
+      var isTruncated = preview.scrollWidth > preview.clientWidth + 1
+          || preview.scrollHeight > preview.clientHeight + 1;
+      details.hidden = !isTruncated;
+      if (!isTruncated) details.open = false;
+    });
+  }
+
+  function scheduleDisclosureSync() {
+    window.requestAnimationFrame(syncTableCellDisclosures);
+  }
+
+  rows.forEach(function (row) {
+    row.addEventListener("click", function (event) {
+      if (isInteractiveTarget(event.target)) return;
+      openDetail(row);
+    });
+
+    row.addEventListener("keydown", function (event) {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      if (event.target !== row) return;
+      event.preventDefault();
+      openDetail(row);
+    });
+  });
+
+  scheduleDisclosureSync();
+  window.addEventListener("load", scheduleDisclosureSync, { once: true });
+  window.addEventListener("resize", scheduleDisclosureSync);
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(scheduleDisclosureSync);
+  }
+})();

--- a/src/main/resources/templates/audit/list.html
+++ b/src/main/resources/templates/audit/list.html
@@ -10,7 +10,7 @@
   [막을 것] 수정 · 삭제 버튼 자체를 만들지 않습니다.
             감사로그를 고칠 수 있으면 감사로그가 아닙니다.
   [주의] before_value / after_value 는 JSON 입니다.
-         전부 늘어놓지 말고 바뀐 칸만 노랗게 강조합니다 (DiffEntry.changed).
+         서버가 계산한 DiffEntry를 변경 전·후 표로 표시합니다.
   행 선택은 selected 파라미터로 같은 검색조건을 유지한 채 재요청합니다 (§4-1 공통 규칙 7).
 -->
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-AUDT-W01', '감사로그 조회', null, null)}"
@@ -20,24 +20,8 @@
   <header class="page-header">
     <div class="page-header-copy">
       <h1 class="page-title">감사로그 조회</h1>
-      <p class="page-description">
-        누가 · 언제 · 무엇을 · 왜 바꿨는지 기록입니다.
-        <strong>기록만 쌓이고 고치거나 지울 수 없습니다.</strong>
-      </p>
     </div>
   </header>
-
-  <aside class="audit-notice" aria-labelledby="audit-notice-title">
-    <span class="material-symbols-rounded audit-notice-icon" aria-hidden="true">lock</span>
-    <div>
-      <h2 id="audit-notice-title" class="audit-notice-title">수정하거나 삭제할 수 없는 기록입니다</h2>
-      <p class="audit-notice-copy">
-        이 화면에는 <strong>수정·삭제 버튼이 없습니다.</strong> DB에서도
-        <span class="tabular-nums">audit_log</span> 테이블의 UPDATE·DELETE를 트리거가 거부합니다.
-        지급기준을 몰래 바꾸거나 소급 적용하는 것을 막기 위한 장치입니다(REG-22).
-      </p>
-    </div>
-  </aside>
 
   <!-- 검색조건은 GET 파라미터로 유지한다 (§4-1 공통 규칙 7). -->
   <form class="filter-bar audit-filter-bar" method="get" th:action="@{/audit-logs}">
@@ -135,6 +119,10 @@
           </tr>
           <tr class="audit-log-row"
               th:each="row : ${logs.content}"
+              tabindex="0"
+              aria-controls="diff-body"
+              th:attr="aria-selected=${selectedLog != null and row.auditLogId == selectedLog.auditLogId} ? 'true' : 'false'"
+              th:data-audit-detail-href="@{/audit-logs(entityType=${form.entityType},entityId=${form.entityId},userId=${form.userId},action=${form.action},from=${form.from},to=${form.to},page=${logs.page},selected=${row.auditLogId})}"
               th:classappend="${selectedLog != null and row.auditLogId == selectedLog.auditLogId} ? 'is-selected'">
             <td>
               <a class="audit-log-link tabular-nums"
@@ -143,12 +131,60 @@
                  th:text="${#temporals.format(row.occurredAt, 'yyyy-MM-dd HH:mm:ss')}">2026-08-16 10:00:00</a>
             </td>
             <td th:text="${row.userLoginId} ?: 'BATCH'">settle01</td>
-            <td class="tabular-nums" th:text="${row.actionCode}">PAYMENT_CONFIRMED</td>
-            <td class="tabular-nums" th:text="${row.entityType}">COMMISSION_PAYMENT</td>
-            <td class="tabular-nums" th:text="${row.entityId}">42</td>
-            <td th:text="${row.reason}"></td>
-            <td class="tabular-nums" th:text="${row.policyVersionId}"></td>
-            <td class="tabular-nums" th:text="${row.requestId}">20260816-1a2b3c</td>
+            <td class="tabular-nums audit-disclosure-cell">
+              <div class="table-cell-disclosure">
+                <span class="table-cell-preview is-single-line" th:text="${row.actionCode} ?: '-'">PAYMENT_CONFIRMED</span>
+                <details class="table-cell-details" hidden>
+                  <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span><span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                  <p class="table-cell-full" th:text="${row.actionCode} ?: '-'">PAYMENT_CONFIRMED</p>
+                </details>
+              </div>
+            </td>
+            <td class="tabular-nums audit-disclosure-cell">
+              <div class="table-cell-disclosure">
+                <span class="table-cell-preview is-single-line" th:text="${row.entityType} ?: '-'">COMMISSION_PAYMENT</span>
+                <details class="table-cell-details" hidden>
+                  <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span><span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                  <p class="table-cell-full" th:text="${row.entityType} ?: '-'">COMMISSION_PAYMENT</p>
+                </details>
+              </div>
+            </td>
+            <td class="tabular-nums audit-disclosure-cell">
+              <div class="table-cell-disclosure">
+                <span class="table-cell-preview is-single-line" th:text="${row.entityId} ?: '-'">42</span>
+                <details class="table-cell-details" hidden>
+                  <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span><span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                  <p class="table-cell-full" th:text="${row.entityId} ?: '-'">42</p>
+                </details>
+              </div>
+            </td>
+            <td class="audit-disclosure-cell">
+              <div class="table-cell-disclosure">
+                <span class="table-cell-preview" th:text="${row.reason} ?: '-'">-</span>
+                <details class="table-cell-details" hidden>
+                  <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span><span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                  <p class="table-cell-full" th:text="${row.reason} ?: '-'">-</p>
+                </details>
+              </div>
+            </td>
+            <td class="tabular-nums audit-disclosure-cell">
+              <div class="table-cell-disclosure">
+                <span class="table-cell-preview is-single-line" th:text="${row.policyVersionId} ?: '-'">-</span>
+                <details class="table-cell-details" hidden>
+                  <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span><span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                  <p class="table-cell-full" th:text="${row.policyVersionId} ?: '-'">-</p>
+                </details>
+              </div>
+            </td>
+            <td class="tabular-nums audit-disclosure-cell">
+              <div class="table-cell-disclosure">
+                <span class="table-cell-preview is-single-line" th:text="${row.requestId} ?: '-'">20260816-1a2b3c</span>
+                <details class="table-cell-details" hidden>
+                  <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span><span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                  <p class="table-cell-full" th:text="${row.requestId} ?: '-'">20260816-1a2b3c</p>
+                </details>
+              </div>
+            </td>
           </tr>
           </tbody>
         </table>
@@ -181,7 +217,6 @@
     <section class="surface audit-diff-panel" aria-labelledby="audit-diff-title">
       <header class="surface-header audit-panel-header">
         <h2 id="audit-diff-title" class="surface-title">변경 내용 비교</h2>
-        <p class="audit-panel-caption">바뀐 칸만 노랗게 표시</p>
       </header>
       <div class="surface-body audit-diff-body" id="diff-body">
         <p class="audit-diff-prompt" th:if="${selectedLog == null}">왼쪽 목록에서 한 건을 고르세요.</p>

--- a/src/main/resources/templates/layout/default.html
+++ b/src/main/resources/templates/layout/default.html
@@ -44,6 +44,7 @@
   <script th:src="@{/js/common/modal.js}" defer></script>
   <script th:src="@{/js/common/toast.js}" defer></script>
   <script th:src="@{/js/common/api-client.js}" defer></script>
+  <script th:if="${screenId == 'FGC-UI-AUDT-W01'}" th:src="@{/js/features/audit/audit-list.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-BASE-W01'}" th:src="@{/js/features/base/base-api.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-BASE-W01'}" th:src="@{/js/features/base/base-list.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-DASH-W01'}" th:src="@{/js/features/dashboard/dashboard.js}" defer></script>

--- a/src/test/java/com/susukkang/fgc/audit/controller/AuditLogViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/audit/controller/AuditLogViewControllerTest.java
@@ -172,10 +172,40 @@ class AuditLogViewControllerTest {
         stubSearch(List.of(log(1L, "settle01", null, null)));
         mvc.perform(get("/audit-logs").with(user(complianceUser())))
                 .andExpect(status().isOk())
+                .andExpect(content().string(containsString("data-audit-detail-href")))
+                .andExpect(content().string(containsString("aria-controls=\"diff-body\"")))
                 .andExpect(content().string(containsString("PAYMENT_CONFIRMED")))
                 .andExpect(content().string(containsString("settle01")))
                 .andExpect(content().string(containsString("20260816-1a2b3c")))
                 .andExpect(content().string(containsString("확정 처리")));
+    }
+
+    @Test
+    void renders_long_values_with_disclosure_markup() throws Exception {
+        String reason = "Transaction rolled back because the validation run failed while persisting the final result.";
+        AuditLogResponse longValueLog = new AuditLogResponse(
+                2L,
+                OffsetDateTime.parse("2026-08-16T10:00:00+09:00"),
+                null,
+                null,
+                "VALIDATION_RUN_FAILED",
+                "VALIDATION_RUN",
+                "202607-VALIDATION-0001",
+                null,
+                null,
+                reason,
+                "20260816-validation-run-failure-request",
+                null
+        );
+        stubSearch(List.of(longValueLog));
+
+        mvc.perform(get("/audit-logs").with(user(complianceUser())))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("VALIDATION_RUN_FAILED")))
+                .andExpect(content().string(containsString("table-cell-disclosure")))
+                .andExpect(content().string(containsString("table-cell-details")))
+                .andExpect(content().string(containsString("전체 보기")))
+                .andExpect(content().string(containsString(reason)));
     }
 
     /** 배치 발 감사행(user_id NULL)은 행위자를 "BATCH" 로 표기한다 — 화면정의서 :1517. */
@@ -245,13 +275,12 @@ class AuditLogViewControllerTest {
                 .andExpect(content().string(containsString("[1,2,3]")));
     }
 
-    /** 화면정의서 "막아야 할 것": 수정·삭제 버튼 자체를 만들지 않는다 — 안내 배너만 있고 버튼은 없다. */
+    /** 화면정의서 "막아야 할 것": 별도 안내 문구와 무관하게 수정·삭제 버튼 자체를 만들지 않는다. */
     @Test
     void never_renders_mutation_buttons() throws Exception {
         stubSearch(List.of(log(1L, "settle01", null, null)));
         mvc.perform(get("/audit-logs").with(user(complianceUser())))
                 .andExpect(content().string(not(containsString("삭제</button>"))))
-                .andExpect(content().string(not(containsString("수정</button>"))))
-                .andExpect(content().string(containsString("수정·삭제 버튼이 없습니다")));
+                .andExpect(content().string(not(containsString("수정</button>"))));
     }
 }

--- a/src/test/java/com/susukkang/fgc/ui/AuditTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/AuditTemplateStructureTest.java
@@ -1,0 +1,61 @@
+package com.susukkang.fgc.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuditTemplateStructureTest {
+
+    @Test
+    void auditListUsesSharedDisclosureAndAccessibleRowSelection() throws IOException {
+        assertThat(resource("templates/audit/list.html"))
+                .doesNotContain("class=\"audit-notice\"")
+                .doesNotContain("class=\"page-description\"")
+                .doesNotContain("바뀐 칸만 노랗게 표시")
+                .contains("tabindex=\"0\"")
+                .contains("aria-controls=\"diff-body\"")
+                .contains("th:data-audit-detail-href")
+                .contains("class=\"table-cell-disclosure\"")
+                .contains("class=\"table-cell-details\" hidden")
+                .contains("전체 보기")
+                .contains("접기");
+
+        assertThat(resource("static/css/features/audit.css"))
+                .doesNotContain(".audit-notice")
+                .contains(".audit-log-row:focus-visible")
+                .contains(".data-table td.audit-disclosure-cell");
+
+        assertThat(resource("static/css/common/components.css"))
+                .contains(".table-cell-disclosure")
+                .contains(".table-cell-preview.is-single-line")
+                .contains(".table-cell-details summary:focus-visible")
+                .contains(".table-cell-details[open] .table-cell-less");
+
+        assertThat(resource("templates/layout/default.html"))
+                .contains("/js/features/audit/audit-list.js");
+
+        assertThat(resource("static/js/features/audit/audit-list.js"))
+                .contains("[data-audit-detail-href]")
+                .contains("row.addEventListener(\"click\"")
+                .contains("row.addEventListener(\"keydown\"")
+                .contains("event.key !== \"Enter\"")
+                .contains("event.target !== row")
+                .contains("a, button, input, select, textarea, summary, details")
+                .contains("window.location.assign(href)")
+                .contains("preview.scrollWidth > preview.clientWidth")
+                .contains("preview.scrollHeight > preview.clientHeight")
+                .contains("document.fonts.ready");
+    }
+
+    private String resource(String path) throws IOException {
+        try (var input = getClass().getClassLoader().getResourceAsStream(path)) {
+            if (input == null) {
+                throw new IOException("Resource not found: " + path);
+            }
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- AUDT-W01의 불필요한 Guidance와 Page Description을 제거했습니다.
- 긴 감사로그 값의 가독성과 감사 기록 행 선택 UX를 개선했습니다.

## 🔗 2. 관련 이슈

- Refs #138

## 🛠 3. 구현 내용

- 감사로그 상단 Guidance 배너 및 안내 문구 제거
- Page Header의 `page-description` 제거
- 행위 코드, 대상 종류, 대상 ID, 사유, 정책버전, 요청 ID에 공통 Table Cell Disclosure 적용
- 실제 렌더링 크기를 측정해 잘린 셀에만 `전체 보기/접기` 기능 적용
- 감사 기록 행 전체를 클릭하여 변경 내용 조회 가능하도록 개선
- `Enter`와 `Space`를 이용한 키보드 행 선택 지원
- 사유 펼침, 링크 등 내부 인터랙션 클릭 시 행 이동이 발생하지 않도록 분리
- 선택 행의 `aria-selected` 상태 및 키보드 포커스 표시 적용
- 기존 검색조건, 페이징, `selected` 파라미터, 서버 렌더링 구조 유지

## 🧪 4. 테스트 방법

1. `audit01 / fgc1234!` 계정으로 로그인합니다.
2. `/audit-logs`에 접속합니다.
3. 감사 기록의 발생시각 링크가 아닌 일반 셀을 클릭합니다.
4. 선택 행 표시와 우측 변경 내용 갱신을 확인합니다.
5. `VALIDATION_RUN_FAILED` 행의 긴 사유에서 `전체 보기/접기`를 확인합니다.
6. 행에 포커스한 뒤 `Enter` 또는 `Space`로 선택되는지 확인합니다.

실행한 테스트:

```bash
./gradlew test \
  --tests com.susukkang.fgc.ui.AuditTemplateStructureTest \
  --tests com.susukkang.fgc.audit.controller.AuditLogViewControllerTest \
  --tests com.susukkang.fgc.ui.PublishingTemplateStructureTest
```

- 타깃 테스트 및 전체 Gradle 테스트: `BUILD SUCCESSFUL`
- 실제 로컬 DB의 `VALIDATION_RUN_FAILED` 감사 기록으로 브라우저 QA 완료

## 🗄️ 5. DB / Flyway 변경

- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

- 없음

## 📋 6. 리뷰 요구사항

- 행 전체 클릭과 기존 발생시각 링크가 함께 정상 동작하는지 확인 부탁드립니다.
- 잘린 셀의 `전체 보기/접기`가 행 선택 이벤트와 충돌하지 않는지 확인 부탁드립니다.
- `layout/default.html`에 추가한 AUDT 전용 JavaScript 로딩 조건을 확인 부탁드립니다.
- 기존 검색조건과 페이지 번호가 행 선택 후에도 유지되는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

- [x] `develop` 최신 내용을 반영했습니다.
- [x] 관련 타깃 테스트에 성공했습니다.
- [x] 애플리케이션 실행을 확인했습니다.
- [x] 관련 기능을 직접 테스트했습니다.
- [x] 필요한 구조 및 렌더링 테스트를 작성했습니다.
- [x] 기존 조회 기능에 영향이 없는지 확인했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

- AUDT-W01 상단 Guidance 및 Page Description 제거
- 실제로 잘린 코드·ID·사유에만 `전체 보기/접기` 표시
- 감사 기록 행 전체 선택 및 키보드 포커스 상태 추가

## 💬 9. 참고 사항

- 백엔드 API, DTO, Service, Mapper 및 DB 구조는 변경하지 않았습니다.
- 감사로그의 기존 append-only 정책과 변경 전·후 Diff 계산 방식은 유지합니다.
- 감사로그 화면의 추가적인 레이아웃 UX 개선은 전체 공통 UI 전환 완료 후 별도 작업으로 진행할 예정입니다.