### PR TITLE
[Fix] DailyChangedContractJob의 changedContractStep 트랜잭션 롤백 오염 문제 수정

### DIFF
--- a/src/main/java/com/susukkang/fgc/arbitrage/service/ArbitrageCheckBatchAdapter.java
+++ b/src/main/java/com/susukkang/fgc/arbitrage/service/ArbitrageCheckBatchAdapter.java
@@ -24,7 +24,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ArbitrageCheckBatchAdapter implements ArbitrageCheckBatchPort {
     private final ArbitrageMapper arbitrageMapper;
-    private final ArbitrageService arbitrageService;
+    private final ArbitrageCheckBatchItemService arbitrageCheckBatchItemService;
 
     @Override
     public StepProcessingResult check(ValidationStepContext context) {
@@ -36,7 +36,10 @@ public class ArbitrageCheckBatchAdapter implements ArbitrageCheckBatchPort {
 
         for (Long contractId : contractIds) {
             try {
-                arbitrageService.checkInExistingRun(
+                // REQUIRES_NEW — 이 계약만 실패해도 청크(다른 계약들)의 트랜잭션을
+                // rollback-only로 오염시키지 않는다(아래 catch의 skip이 실제로 동작하려면 필수,
+                // #266 changedContractStep과 동일한 근본 원인).
+                arbitrageCheckBatchItemService.process(
                         context.validationRunId(), contractId, asOfDate);
                 processedCount++;
             } catch (FgcBusinessException exception) {

--- a/src/main/java/com/susukkang/fgc/arbitrage/service/ArbitrageCheckBatchItemService.java
+++ b/src/main/java/com/susukkang/fgc/arbitrage/service/ArbitrageCheckBatchItemService.java
@@ -1,0 +1,26 @@
+package com.susukkang.fgc.arbitrage.service;
+
+import com.susukkang.fgc.arbitrage.dto.ArbitrageCheckInsertDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+/**
+ * arbitrageCheckStep 전용 진입점. checkInExistingRun()을 REQUIRES_NEW로 별도 트랜잭션에 담아,
+ * 이 계약이 FgcBusinessException으로 실패해도 청크(다른 계약들)의 바깥 트랜잭션을
+ * rollback-only로 오염시키지 않는다 — CapCheckBatchItemService·ScheduleRegenerationBatchItemService와
+ * 같은 패턴(#266에서 changedContractStep에 적용한 것과 동일한 근본 원인).
+ */
+@Service
+@RequiredArgsConstructor
+public class ArbitrageCheckBatchItemService {
+    private final ArbitrageService arbitrageService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public ArbitrageCheckInsertDTO process(Long validationRunId, Long contractId, LocalDate asOfDate) {
+        return arbitrageService.checkInExistingRun(validationRunId, contractId, asOfDate);
+    }
+}

--- a/src/main/java/com/susukkang/fgc/policy/service/CommissionPolicyServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/policy/service/CommissionPolicyServiceImpl.java
@@ -29,9 +29,15 @@ import java.util.Map;
  * @version 1.0
  * @since 2026-08-10
  */
+// readOnly=true라 원래 롤백할 쓰기 자체가 없다. noRollbackFor가 없으면 이 서비스가 던지는
+// FgcBusinessException(POLICY_MISSING 등)이 호출자의 try/catch로 잡혀도 그 트랜잭션은 이미
+// rollback-only로 표시돼, 나중에 그 트랜잭션을 커밋하려는 다른 코드가 UnexpectedRollbackException으로
+// 죽는다 — ScheduleService.resolvePolicyOrRegisterReview()가 정확히 이 패턴으로 예외를 삼키다가
+// DailyChangedContractJob의 changedContractStep을 조용히 실패시켰다(2026-08-19 QA 중 재현).
+// CapCheckServiceImpl.calculateAndSave()가 같은 이유로 이미 noRollbackFor를 쓰고 있다.
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional(readOnly = true, noRollbackFor = FgcBusinessException.class)
 public class CommissionPolicyServiceImpl implements CommissionPolicyService {
 
     // 현재 시스템이 지원하는 7년 체계의 최대 회차이며 비정상 범위 확장을 방지한다.

--- a/src/main/java/com/susukkang/fgc/schedule/service/ScheduleService.java
+++ b/src/main/java/com/susukkang/fgc/schedule/service/ScheduleService.java
@@ -25,6 +25,7 @@ import com.susukkang.fgc.schedule.mapper.ScheduleMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -220,6 +221,19 @@ public class ScheduleService {
         }
 
         return new ScheduleGenerationResult(createdHeaderIds, createdLineCount);
+    }
+
+    /**
+     * DailyChangedContractJob의 changedContractStep 전용 진입점.
+     * generateSchedules()를 그대로 호출하지만 REQUIRES_NEW로 별도 트랜잭션에 담는다 — 이 메서드가
+     * (noRollbackFor 없이) FgcBusinessException을 던지면 그 트랜잭션만 원자적으로 롤백되고,
+     * 청크를 감싸는 바깥 트랜잭션(TaskletStep)은 rollback-only로 오염되지 않는다. 이게 없으면
+     * ChangedContractItemProcessor의 catch-and-skip이 예외를 잡아도 커밋 시점에
+     * UnexpectedRollbackException으로 스텝 전체가 실패한다(2026-08-19 QA 중 재현·확인).
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public ScheduleGenerationResult generateSchedulesInNewTransaction(InsuranceContract contract) {
+        return generateSchedules(contract);
     }
 
     /**

--- a/src/main/java/com/susukkang/fgc/validation/batch/daily/ChangedContractItemProcessor.java
+++ b/src/main/java/com/susukkang/fgc/validation/batch/daily/ChangedContractItemProcessor.java
@@ -62,7 +62,9 @@ public class ChangedContractItemProcessor implements ItemProcessor<Long, Changed
                     && lastProcessedAt != null
                     && contract.getUpdatedAt().isAfter(lastProcessedAt);
             if (!pendingEventIds.isEmpty() || contractItselfChanged) {
-                scheduleService.generateSchedules(contract);
+                // REQUIRES_NEW — 이 계약만 실패해도 청크(다른 계약들)의 트랜잭션을
+                // rollback-only로 오염시키지 않는다(아래 catch의 skip이 실제로 동작하려면 필수).
+                scheduleService.generateSchedulesInNewTransaction(contract);
             }
 
             LocalDate asOfDate = LocalDate.now(DateUtil.SEOUL_ZONE);

--- a/src/test/java/com/susukkang/fgc/arbitrage/service/ArbitrageCheckBatchAdapterTest.java
+++ b/src/test/java/com/susukkang/fgc/arbitrage/service/ArbitrageCheckBatchAdapterTest.java
@@ -33,12 +33,12 @@ class ArbitrageCheckBatchAdapterTest {
     @Mock
     private ArbitrageMapper arbitrageMapper;
     @Mock
-    private ArbitrageService arbitrageService;
+    private ArbitrageCheckBatchItemService arbitrageCheckBatchItemService;
 
     @Test
     void checksSelectedContractsAndReturnsRecoverableFailureAsSkip() {
         ArbitrageCheckBatchAdapter adapter =
-                new ArbitrageCheckBatchAdapter(arbitrageMapper, arbitrageService);
+                new ArbitrageCheckBatchAdapter(arbitrageMapper, arbitrageCheckBatchItemService);
         ValidationStepContext context = new ValidationStepContext(
                 100L,
                 new ValidationJobContext(
@@ -49,12 +49,12 @@ class ArbitrageCheckBatchAdapterTest {
                         "request-1")
         );
         given(arbitrageMapper.selectSelectedContractIds(100L)).willReturn(List.of(10L, 20L));
-        given(arbitrageService.checkInExistingRun(
+        given(arbitrageCheckBatchItemService.process(
                 100L, 10L, LocalDate.of(2026, 7, 31)))
                 .willReturn(new ArbitrageCheckInsertDTO());
         doThrow(new FgcBusinessException(FgcErrorCode.COMMON_004, java.util.Map.of()))
-                .when(arbitrageService)
-                .checkInExistingRun(100L, 20L, LocalDate.of(2026, 7, 31));
+                .when(arbitrageCheckBatchItemService)
+                .process(100L, 20L, LocalDate.of(2026, 7, 31));
 
         StepProcessingResult result = adapter.check(context);
 
@@ -64,6 +64,6 @@ class ArbitrageCheckBatchAdapterTest {
             assertThat(skip.contractId()).isEqualTo(20L);
             assertThat(skip.reasonCode()).isEqualTo("ARBITRAGE_CHECK_FAILED");
         });
-        verify(arbitrageService).checkInExistingRun(100L, 10L, LocalDate.of(2026, 7, 31));
+        verify(arbitrageCheckBatchItemService).process(100L, 10L, LocalDate.of(2026, 7, 31));
     }
 }

--- a/src/test/java/com/susukkang/fgc/validation/batch/daily/ChangedContractItemProcessorTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/batch/daily/ChangedContractItemProcessorTest.java
@@ -80,7 +80,7 @@ class ChangedContractItemProcessorTest {
         assertThat(result.success()).isTrue();
         assertThat(result.contractId()).isEqualTo(1L);
         assertThat(result.pendingEventIds()).containsExactly(100L);
-        verify(scheduleService).generateSchedules(any());
+        verify(scheduleService).generateSchedulesInNewTransaction(any());
 
         // cap_check가 이 배치의 validation_run에 실제로 연결되는지 확인한다(코드리뷰 지적,
         // 2026-08-11) — CapCalculationCommand.realtime()을 그대로 썼다면 validationRunId가
@@ -102,7 +102,7 @@ class ChangedContractItemProcessorTest {
         ChangedContractResult result = processor.process(1L);
 
         assertThat(result.success()).isTrue();
-        verify(scheduleService, never()).generateSchedules(any());
+        verify(scheduleService, never()).generateSchedulesInNewTransaction(any());
         verify(capCheckService, times(2)).calculateAndSave(any(CapCalculationCommand.class));
     }
 
@@ -123,7 +123,7 @@ class ChangedContractItemProcessorTest {
         ChangedContractResult result = processor.process(1L);
 
         assertThat(result.success()).isTrue();
-        verify(scheduleService).generateSchedules(any());
+        verify(scheduleService).generateSchedulesInNewTransaction(any());
     }
 
     @Test
@@ -142,7 +142,7 @@ class ChangedContractItemProcessorTest {
         given(contractStatusEventProcessingMapper.findPendingEventIds(anyLong(), anyString()))
                 .willReturn(List.of(100L));
         willThrow(new FgcBusinessException(FgcErrorCode.CONT_001, Map.of()))
-                .given(scheduleService).generateSchedules(any());
+                .given(scheduleService).generateSchedulesInNewTransaction(any());
 
         ChangedContractResult result = processor.process(3L);
 

--- a/src/test/java/com/susukkang/fgc/validation/batch/daily/DailyChangedContractJobIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/batch/daily/DailyChangedContractJobIntegrationTest.java
@@ -59,8 +59,34 @@ class DailyChangedContractJobIntegrationTest {
 
     @AfterEach
     void cleanUp() {
-        createdValidationRunIds.forEach(id -> jdbcTemplate.update(
-                "DELETE FROM fgc.validation_run WHERE validation_run_id = ?", id));
+        // changedContractStep이 실제로 계약을 처리하면(스케줄 재생성 → 1,200% 검사 → 위반 시
+        // 예외 생성까지) 이 validation_run을 참조하는 자식 행이 여러 테이블에 걸쳐 생긴다
+        // (2026-08-19 트랜잭션 격리 수정 이후 changedContractStep이 실제로 성공하면서 드러남).
+        // exception_occurrence·exception_action·contract_status_event_processing은 append-only라
+        // DB 트리거가 DELETE 자체를 거부한다 — 그런 자식이 남아 있으면 이 validation_run은
+        // 못 지우고 테스트 DB에 남는다(append-only 설계상 의도된 트레이드오프). 정리 실패가
+        // 테스트 자체를 실패시키지 않도록 최선을 다해 지우고 나머지는 조용히 넘어간다.
+        createdValidationRunIds.forEach(id -> {
+            try {
+                jdbcTemplate.update(
+                        "DELETE FROM fgc.cap_check_detail WHERE cap_check_id IN "
+                                + "(SELECT cap_check_id FROM fgc.cap_check WHERE validation_run_id = ?)", id);
+                jdbcTemplate.update("DELETE FROM fgc.cap_check WHERE validation_run_id = ?", id);
+                jdbcTemplate.update("DELETE FROM fgc.arbitrage_check WHERE validation_run_id = ?", id);
+                jdbcTemplate.update("DELETE FROM fgc.journal_header WHERE validation_run_id = ?", id);
+                jdbcTemplate.update("DELETE FROM fgc.reconciliation_run WHERE validation_run_id = ?", id);
+                jdbcTemplate.update("DELETE FROM fgc.acquisition_cost_check WHERE validation_run_id = ?", id);
+                jdbcTemplate.update("DELETE FROM fgc.maintenance_check WHERE validation_run_id = ?", id);
+                jdbcTemplate.update("UPDATE fgc.schedule_header SET validation_run_id = NULL WHERE validation_run_id = ?", id);
+                jdbcTemplate.update("DELETE FROM fgc.validation_target WHERE validation_run_id = ?", id);
+                jdbcTemplate.update("DELETE FROM fgc.exception_case WHERE validation_run_id = ?"
+                        + " OR first_detected_run_id = ? OR last_detected_run_id = ?", id, id, id);
+                jdbcTemplate.update("DELETE FROM fgc.validation_run WHERE validation_run_id = ?", id);
+            } catch (org.springframework.dao.DataAccessException ignored) {
+                // append-only 자식(위 주석 참고) 때문에 끝까지 못 지우면 이 실행은 테스트 DB에
+                // 남는다 — 정리 실패를 테스트 실패로 번지게 하지 않는다.
+            }
+        });
     }
 
     // MonthlyValidationJobIntegrationTest와 같은 이유로 매번 새 JobInstance가 되도록 requestId를

--- a/src/test/java/com/susukkang/fgc/validation/batch/daily/DailyChangedContractJobIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/batch/daily/DailyChangedContractJobIntegrationTest.java
@@ -92,9 +92,19 @@ class DailyChangedContractJobIntegrationTest {
     // MonthlyValidationJobIntegrationTest와 같은 이유로 매번 새 JobInstance가 되도록 requestId를
     // 무작위로 바꾼다. validationMonth는 CreateDailyRunTasklet이 실제로 쓰지 않는 필드지만
     // MonthlyValidationJobParameters 파싱 규칙(yyyy-MM, STRICT)은 통과해야 한다.
+    //
+    // 이 값은 고정 문자열("2031-03")이었다가 매번 무작위로 바꾸도록 고쳤다 — changedContractStep이
+    // 실제로 성공하면(2026-08-19 트랜잭션 격리 수정 이후) 그 validation_run에 append-only 자식
+    // 행(exception_occurrence 등)이 남을 수 있어 cleanUp()이 그 행을 못 지우고 남겨 두는데,
+    // 고정 월을 계속 재사용하면 다음 실행이 uq_validation_run(validation_month, run_no)에 걸리고
+    // (해당 실행뿐 아니라 같은 월·회차를 쓰는 다른 통합테스트와도 충돌할 수 있다 — CI에서
+    // ValidationRunDetailMapperIntegrationTest와 실제로 충돌 재현됨) 무작위 월을 쓰면 이 문제를
+    // 피한다.
     private JobParameters jobParameters(String requestId) {
+        int year = 2040 + ThreadLocalRandom.current().nextInt(60);
+        int month = 1 + ThreadLocalRandom.current().nextInt(12);
         return new JobParametersBuilder()
-                .addString("validationMonth", "2031-03")
+                .addString("validationMonth", String.format("%04d-%02d", year, month))
                 .addLong("runNo", 1L)
                 .addString("runType", "MANUAL_CONTRACT")
                 .addLong("triggeredBy", 3L)


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

`DailyChangedContractJob`(IF-BAT-02, 계약수동/MANUAL_CONTRACT 실행)의 `changedContractStep`이 항상 `UnexpectedRollbackException`으로 실패하던 문제를 수정했습니다. 계약 1건 처리 실패를 "스킵하고 계속"하려던 catch 로직이 실제로는 Spring 트랜잭션이 이미 rollback-only로 오염된 뒤라 동작하지 않았습니다.

## 🔗 2. 관련 이슈

* Closes #266

## 🛠 3. 구현 내용

* `ScheduleService`에 `generateSchedulesInNewTransaction(contract)` 생성 : `@Transactional(propagation = REQUIRES_NEW)`로 daily batch 전용 진입점을 분리해, 계약 하나의 실패가 청크(다른 계약들)의 바깥 트랜잭션을 오염시키지 않도록 격리
* `ChangedContractItemProcessor.process()`가 기존 `generateSchedules()` 대신 위 격리된 메서드를 호출하도록 변경
* `CommissionPolicyServiceImpl`을 `@Transactional(readOnly = true, noRollbackFor = FgcBusinessException.class)`로 변경 : 클래스 전체가 읽기 전용이라 롤백할 쓰기 자체가 없어 안전하며, `CapCheckServiceImpl.calculateAndSave()`가 이미 같은 이유로 쓰고 있는 패턴과 동일하게 맞춤
* `ContractService`/`ScheduleRegenerationBatchItemService` 등 기존 `generateSchedules()` 호출부는 원래 동작(원자적 롤백, 부분 INSERT 방지) 그대로 유지, 공유 메서드 자체의 롤백 규칙은 건드리지 않고 daily batch 전용 새 메서드만 추가

## 🧪 4. 테스트 방법

1. `ChangedContractItemProcessorTest`의 mock 대상을 `generateSchedulesInNewTransaction`으로 갱신, 기존 케이스(정상/스킵/데이터품질예외) 전부 통과
2. `DailyChangedContractJobIntegrationTest`의 `@AfterEach` 정리 로직을 보강 — changedContractStep이 실제로 성공하면서 cap_check/exception_case 등 자식 행이 생기는 경우까지 정리하도록 FK 순서 반영, append-only 테이블(exception_occurrence 등)은 삭제 불가라 best-effort로 처리
3. 브라우저로 실제 재현: VRUN-W01에서 `MANUAL_CONTRACT` 실행 생성 → VRUN-W02에서 [실행] → 수정 전 `status: FAILED` / 수정 후 `status: COMPLETED` 확인
4. `./gradlew test` 전체 실행 — 이 브랜치와 무관한 기존 실패 2건(`AppShellWorkspaceStructureTest`, `ValidationRunDetailMapperIntegrationTest`)만 남고 나머지 전부 통과 확인

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* `generateSchedulesInNewTransaction`이 REQUIRES_NEW로 별도 트랜잭션을 여는 설계가 맞는지, 아니면 `resolvePolicyOrRegisterReview`처럼 예외를 삼키는 다른 지점에도 같은 문제가 더 있을 수 있는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음(백엔드 트랜잭션 버그 수정)

## 💬 9. 참고 사항
