### PR TITLE
[Refactor] RECO-W01 공통 UI 컴포넌트 전환

### DIFF
--- a/src/main/resources/static/css/features/reco.css
+++ b/src/main/resources/static/css/features/reco.css
@@ -95,7 +95,7 @@
 .reco-col-amount { width: 7rem; }
 .reco-col-result { width: 8.5rem; }
 .reco-col-reason { width: 10rem; }
-.reco-col-action { width: 6rem; }
+.reco-col-action { width: 7rem; }
 
 .data-table td.reco-disclosure-cell {
   padding-block: var(--space-2);

--- a/src/main/resources/static/css/features/reco.css
+++ b/src/main/resources/static/css/features/reco.css
@@ -1,0 +1,226 @@
+.reco-page {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-4);
+}
+
+.reco-run-panel,
+.reco-panel {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.reco-panel-header {
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.reco-filter-bar {
+  border: 0;
+  border-radius: 0;
+}
+
+.reco-filter-fields {
+  flex: 1 1 auto;
+}
+
+.reco-filter-month {
+  width: 9rem;
+}
+
+.reco-filter-stage {
+  width: 10.5rem;
+}
+
+.reco-filter-insurer {
+  width: 13rem;
+}
+
+.reco-filter-actions {
+  flex: 0 0 auto;
+}
+
+.reco-permission-note {
+  margin: 0 var(--space-3) var(--space-3);
+  color: var(--color-status-warning-text);
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+}
+
+.reco-summary-grid {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.reco-content-grid {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-4);
+}
+
+.reco-result-controls {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.reco-result-type {
+  width: 11rem;
+}
+
+.reco-checkbox {
+  display: inline-flex;
+  min-height: var(--control-height-sm);
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.reco-checkbox input {
+  accent-color: var(--color-action-primary);
+}
+
+.reco-result-table {
+  min-width: 82rem;
+}
+
+.reco-col-contract { width: 7rem; }
+.reco-col-item { width: 9rem; }
+.reco-col-installment { width: 4rem; }
+.reco-col-agent { width: 8.5rem; }
+.reco-col-amount { width: 7rem; }
+.reco-col-result { width: 8.5rem; }
+.reco-col-reason { width: 10rem; }
+.reco-col-action { width: 6rem; }
+
+.data-table td.reco-disclosure-cell {
+  padding-block: var(--space-2);
+  overflow: visible;
+  vertical-align: middle;
+  text-overflow: clip;
+  white-space: normal;
+}
+
+.reco-agent-mismatch,
+.reco-amount-error {
+  color: var(--color-status-error-text);
+  font-weight: 600;
+}
+
+.reco-result-table tfoot td {
+  border-top: 1px solid var(--color-border-strong);
+  border-bottom: 0;
+  background: var(--color-bg-subtle);
+  font-weight: 600;
+}
+
+.reco-state-row:hover {
+  background: var(--color-bg-surface);
+}
+
+.reco-state-row td {
+  height: auto;
+  padding: 0;
+  white-space: normal;
+}
+
+.reco-history-table {
+  min-width: 72rem;
+}
+
+.reco-history-col-id { width: 5rem; }
+.reco-history-col-month { width: 6rem; }
+.reco-history-col-stage { width: 7rem; }
+.reco-history-col-insurer { width: 8rem; }
+.reco-history-col-status { width: 6rem; }
+.reco-history-col-count { width: 4.5rem; }
+.reco-history-col-rate { width: 5.5rem; }
+.reco-history-col-diff { width: 7rem; }
+.reco-history-col-period { width: 11rem; }
+
+.reco-history-row {
+  cursor: pointer;
+}
+
+.reco-history-row:focus-visible {
+  outline: 2px solid var(--color-action-primary);
+  outline-offset: -2px;
+}
+
+.reco-history-row.is-selected {
+  background: var(--color-action-subtle);
+}
+
+.reco-pagination {
+  display: flex;
+  min-height: 3.5rem;
+  align-items: center;
+  justify-content: flex-end;
+  padding: var(--space-2) var(--space-4);
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.reco-pagination-nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.reco-pagination-status {
+  min-width: 4.5rem;
+  color: var(--color-text-tertiary);
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+@media (max-width: 63.9375rem) {
+  .reco-summary-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .reco-filter-bar {
+    align-items: stretch;
+  }
+
+  .reco-filter-actions {
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width: 47.9375rem) {
+  .reco-summary-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .reco-filter-month,
+  .reco-filter-stage,
+  .reco-filter-insurer {
+    width: 100%;
+  }
+
+  .reco-filter-actions .button {
+    flex: 1 1 0;
+  }
+
+  .reco-panel-header {
+    align-items: stretch;
+    flex-direction: column;
+    padding-block: var(--space-2);
+  }
+
+  .reco-result-controls {
+    justify-content: flex-start;
+  }
+
+  .reco-result-type {
+    width: min(100%, 14rem);
+  }
+
+  .reco-pagination {
+    justify-content: center;
+  }
+}

--- a/src/main/resources/static/js/features/reco/reco.js
+++ b/src/main/resources/static/js/features/reco/reco.js
@@ -60,6 +60,23 @@
       .replace(/'/g, "&#039;");
   }
 
+  function syncTableCellDisclosures() {
+    el.resultBody.querySelectorAll(".table-cell-disclosure").forEach(function (disclosure) {
+      var preview = disclosure.querySelector(".table-cell-preview");
+      var details = disclosure.querySelector(".table-cell-details");
+      if (!preview || !details || preview.clientWidth === 0) return;
+
+      var isTruncated = preview.scrollWidth > preview.clientWidth + 1
+        || preview.scrollHeight > preview.clientHeight + 1;
+      details.hidden = !isTruncated;
+      if (!isTruncated) details.open = false;
+    });
+  }
+
+  function scheduleDisclosureSync() {
+    window.requestAnimationFrame(syncTableCellDisclosures);
+  }
+
   function addOption(select, value, label) {
     var option = document.createElement("option");
     option.value = value == null ? "" : String(value);
@@ -161,13 +178,12 @@
     return '<span class="status-badge ' + tone + '">' + escapeHtml(item.resultTypeLabel) + "</span>";
   }
 
-  function tableCellDisclosure(value, limit, singleLine) {
+  function tableCellDisclosure(value, singleLine) {
     var text = String(value == null || value === "" ? "—" : value);
     var safeText = escapeHtml(text);
-    if (text.length <= limit) return safeText;
     return '<div class="table-cell-disclosure">' +
       '<span class="table-cell-preview' + (singleLine ? " is-single-line" : "") + '">' + safeText + "</span>" +
-      '<details class="table-cell-details"><summary>' +
+      '<details class="table-cell-details" hidden><summary>' +
       '<span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span>' +
       '<span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span>' +
       '</summary><p class="table-cell-full">' + safeText + "</p></details></div>";
@@ -185,8 +201,8 @@
       .map(function (reason) { return reason.label; })
       .join(", ") || "—";
     return "<tr>" +
-      '<td class="reco-disclosure-cell tabular-nums">' + tableCellDisclosure(item.contractNo, 18, true) + "</td>" +
-      '<td class="reco-disclosure-cell">' + tableCellDisclosure(item.commissionItemName, 22, false) + "</td>" +
+      '<td class="reco-disclosure-cell tabular-nums">' + tableCellDisclosure(item.contractNo, true) + "</td>" +
+      '<td class="reco-disclosure-cell">' + tableCellDisclosure(item.commissionItemName, false) + "</td>" +
       '<td class="is-center tabular-nums">' + escapeHtml(item.installmentNo) + "</td>" +
       "<td" + agentClass + ">" + escapeHtml(expectedAgentName) + "</td>" +
       "<td" + agentClass + ">" + escapeHtml(actualAgentName) + "</td>" +
@@ -194,8 +210,8 @@
       '<td class="is-number tabular-nums">' + won(item.actualTotalAmount) + "</td>" +
       "<td" + diffClass + ">" + won(item.differenceAmount) + "</td>" +
       "<td>" + resultTypeBadge(item) + "</td>" +
-      '<td class="reco-disclosure-cell">' + tableCellDisclosure((item.primaryReason && item.primaryReason.label) || "—", 24, false) + "</td>" +
-      '<td class="reco-disclosure-cell">' + tableCellDisclosure(secondaryReasons, 24, false) + "</td>" +
+      '<td class="reco-disclosure-cell">' + tableCellDisclosure((item.primaryReason && item.primaryReason.label) || "—", false) + "</td>" +
+      '<td class="reco-disclosure-cell">' + tableCellDisclosure(secondaryReasons, false) + "</td>" +
       '<td><button class="button button-ghost" type="button" data-reco-compare-id="' +
         escapeHtml(item.reconciliationResultId) + '">비교 상세</button></td>' +
       "</tr>";
@@ -244,6 +260,7 @@
       return;
     }
     el.resultBody.innerHTML = rows.map(resultRow).join("");
+    scheduleDisclosureSync();
     if (noFilter) {
       var summary = data.summary || {};
       el.sumExpected.textContent = number(summary.expectedTotal);
@@ -460,6 +477,11 @@
   updateRunButtonState();
   updateBulkButtonState();
   loadInsurers();
+  window.addEventListener("load", scheduleDisclosureSync, { once: true });
+  window.addEventListener("resize", scheduleDisclosureSync);
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(scheduleDisclosureSync);
+  }
 
   var autoSelectRunId = window.sessionStorage.getItem("reco.autoSelectRunId");
   if (autoSelectRunId) {

--- a/src/main/resources/static/js/features/reco/reco.js
+++ b/src/main/resources/static/js/features/reco/reco.js
@@ -2,7 +2,7 @@
   "use strict";
 
   var apiClient = window.FgcUi && window.FgcUi.apiClient;
-  var main = document.querySelector(".publishing-page-reconciliation");
+  var main = document.querySelector(".reco-page");
   if (!apiClient || !main) return;
 
   var canProcess = main.dataset.canProcess === "true";
@@ -22,6 +22,8 @@
     sumException: document.getElementById("sum-exception"),
     sumRate: document.getElementById("sum-rate"),
     sumDiffTotal: document.getElementById("sum-diff-total"),
+    sumRateCard: document.getElementById("sum-rate-card"),
+    sumDiffCard: document.getElementById("sum-diff-card"),
     sumExpected: document.getElementById("sum-expected"),
     sumActual: document.getElementById("sum-actual"),
     sumDiff: document.getElementById("sum-diff"),
@@ -159,28 +161,42 @@
     return '<span class="status-badge ' + tone + '">' + escapeHtml(item.resultTypeLabel) + "</span>";
   }
 
+  function tableCellDisclosure(value, limit, singleLine) {
+    var text = String(value == null || value === "" ? "—" : value);
+    var safeText = escapeHtml(text);
+    if (text.length <= limit) return safeText;
+    return '<div class="table-cell-disclosure">' +
+      '<span class="table-cell-preview' + (singleLine ? " is-single-line" : "") + '">' + safeText + "</span>" +
+      '<details class="table-cell-details"><summary>' +
+      '<span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span>' +
+      '<span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span>' +
+      '</summary><p class="table-cell-full">' + safeText + "</p></details></div>";
+  }
+
   function resultRow(item) {
     var expectedAgentName = (item.expectedAgent && item.expectedAgent.agentName) || "실제 없음";
     var actualAgentName = (item.actualAgent && item.actualAgent.agentName) || "실제 없음";
     var agentMismatch = expectedAgentName !== actualAgentName;
-    var agentClass = agentMismatch ? ' class="fgc-error"' : "";
-    var diffClass = Number(item.differenceAmount || 0) !== 0 ? ' class="fgc-th-num fgc-error"' : ' class="fgc-th-num"';
+    var agentClass = agentMismatch ? ' class="reco-agent-mismatch"' : "";
+    var diffClass = Number(item.differenceAmount || 0) !== 0
+      ? ' class="is-number tabular-nums reco-amount-error"'
+      : ' class="is-number tabular-nums"';
     var secondaryReasons = (item.secondaryReasons || [])
       .map(function (reason) { return reason.label; })
       .join(", ") || "—";
     return "<tr>" +
-      "<td>" + escapeHtml(item.contractNo) + "</td>" +
-      "<td>" + escapeHtml(item.commissionItemName) + "</td>" +
-      "<td>" + escapeHtml(item.installmentNo) + "</td>" +
+      '<td class="reco-disclosure-cell tabular-nums">' + tableCellDisclosure(item.contractNo, 18, true) + "</td>" +
+      '<td class="reco-disclosure-cell">' + tableCellDisclosure(item.commissionItemName, 22, false) + "</td>" +
+      '<td class="is-center tabular-nums">' + escapeHtml(item.installmentNo) + "</td>" +
       "<td" + agentClass + ">" + escapeHtml(expectedAgentName) + "</td>" +
       "<td" + agentClass + ">" + escapeHtml(actualAgentName) + "</td>" +
-      '<td class="fgc-th-num">' + won(item.expectedTotalAmount) + "</td>" +
-      '<td class="fgc-th-num">' + won(item.actualTotalAmount) + "</td>" +
+      '<td class="is-number tabular-nums">' + won(item.expectedTotalAmount) + "</td>" +
+      '<td class="is-number tabular-nums">' + won(item.actualTotalAmount) + "</td>" +
       "<td" + diffClass + ">" + won(item.differenceAmount) + "</td>" +
       "<td>" + resultTypeBadge(item) + "</td>" +
-      "<td>" + escapeHtml((item.primaryReason && item.primaryReason.label) || "—") + "</td>" +
-      "<td>" + escapeHtml(secondaryReasons) + "</td>" +
-      '<td><button class="fgc-btn fgc-btn--ghost" type="button" data-reco-compare-id="' +
+      '<td class="reco-disclosure-cell">' + tableCellDisclosure((item.primaryReason && item.primaryReason.label) || "—", 24, false) + "</td>" +
+      '<td class="reco-disclosure-cell">' + tableCellDisclosure(secondaryReasons, 24, false) + "</td>" +
+      '<td><button class="button button-ghost" type="button" data-reco-compare-id="' +
         escapeHtml(item.reconciliationResultId) + '">비교 상세</button></td>' +
       "</tr>";
   }
@@ -191,8 +207,13 @@
     el.sumMatched.textContent = number(summary.matchedCount);
     el.sumException.textContent = number(summary.exceptionCount);
     var rate = summary.resultCount ? (summary.matchedCount / summary.resultCount * 100).toFixed(1) : null;
-    el.sumRate.textContent = rate == null ? "—" : rate + "%";
-    el.sumDiffTotal.textContent = won(summary.differenceTotal);
+    var differenceTotal = Number(summary.differenceTotal || 0);
+    el.sumRate.textContent = rate == null ? "—" : rate;
+    el.sumDiffTotal.textContent = number(differenceTotal);
+    el.sumRateCard.classList.toggle("kpi-card-success", rate === "100.0");
+    el.sumRateCard.classList.toggle("kpi-card-warning", rate !== "100.0");
+    el.sumDiffCard.classList.toggle("kpi-card-success", differenceTotal === 0);
+    el.sumDiffCard.classList.toggle("kpi-card-error", differenceTotal !== 0);
   }
 
   function renderResultPagination(items) {
@@ -215,7 +236,7 @@
     var noFilter = !el.typeFilter.value && !el.mismatchOnly.checked;
     el.resultSumLabel.textContent = noFilter ? "합계" : "이 페이지 합계";
     if (!rows.length) {
-      el.resultBody.innerHTML = '<tr><td colspan="12"><div class="fgc-empty">조건에 맞는 자료가 없습니다.</div></td></tr>';
+      el.resultBody.innerHTML = '<tr class="reco-state-row"><td colspan="12"><div class="empty-state">조건에 맞는 자료가 없습니다.</div></td></tr>';
       el.sumExpected.textContent = "0";
       el.sumActual.textContent = "0";
       el.sumDiff.textContent = "0";
@@ -278,7 +299,9 @@
     updateBulkButtonState();
     loadResults(1);
     document.querySelectorAll(".reco-history-row").forEach(function (row) {
-      row.classList.toggle("is-selected", row.dataset.reconciliationRunId === String(reconciliationRunId));
+      var isSelected = row.dataset.reconciliationRunId === String(reconciliationRunId);
+      row.classList.toggle("is-selected", isSelected);
+      row.setAttribute("aria-selected", String(isSelected));
     });
   }
 
@@ -424,6 +447,14 @@
   el.runBody.addEventListener("click", function (event) {
     var row = event.target.closest(".reco-history-row");
     if (row) selectRun(row.dataset.reconciliationRunId);
+  });
+  el.runBody.addEventListener("keydown", function (event) {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    if (event.target.closest("a, button, details, input, select, textarea")) return;
+    var row = event.target.closest(".reco-history-row");
+    if (!row) return;
+    event.preventDefault();
+    selectRun(row.dataset.reconciliationRunId);
   });
 
   updateRunButtonState();

--- a/src/main/resources/templates/layout/default.html
+++ b/src/main/resources/templates/layout/default.html
@@ -24,6 +24,7 @@
   <link rel="stylesheet" th:if="${#strings.startsWith(screenId, 'FGC-UI-SCHE-')}" th:href="@{/css/features/schedule.css}">
   <link rel="stylesheet" th:if="${#strings.startsWith(screenId, 'FGC-UI-CAP-') or screenId == 'FGC-UI-CONT-W02'}" th:href="@{/css/features/cap.css}">
   <link rel="stylesheet" th:if="${screenId == 'FGC-UI-POL-W01'}" th:href="@{/css/features/policy.css}">
+  <link rel="stylesheet" th:if="${screenId == 'FGC-UI-RECO-W01'}" th:href="@{/css/features/reco.css}">
   <link rel="stylesheet" th:if="${screenId == 'FGC-UI-EXCP-W01'}" th:href="@{/css/features/exception.css}">
 </head>
 <body class="app-shell" th:attr="data-workspace-tab-id=${screenId},data-workspace-tab-title=${title},data-workspace-tab-icon=${screenId == 'FGC-UI-DASH-W01' ? 'dashboard' : 'description'}">

--- a/src/main/resources/templates/reco/list.html
+++ b/src/main/resources/templates/reco/list.html
@@ -28,90 +28,97 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-RECO-W01', '대사 실행·결과', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-reconciliation"
+<main id="main-content" class="page-content publishing-page publishing-page-list reco-page"
       data-reco-run-url="/api/v1/reconciliations"
       th:data-can-process="${canProcess}"
       th:data-deep-linked-result-id="${deepLinkedResultId}">
 
-  <h1 class="fgc-page-title">대사 실행 · 결과</h1>
-  <p class="fgc-page-desc">
-    <strong>대사(對査)</strong>란 서로 다른 두 자료를 나란히 놓고 금액이 맞는지 확인하는 것입니다.
-    FGC는 <strong>줄 예정이던 돈(예상 스케줄)</strong>과 <strong>실제로 준 돈</strong>을 맞춰 봅니다.
-  </p>
-
-  <div class="fgc-banner fgc-banner--warn" style="margin-top:12px">
-    <span class="material-symbols-outlined" style="font-size:18px">straighten</span>
-    <span>
-      <strong id="notice-tolerance">1차 허용오차 0원 — 1원만 달라도 불일치입니다.</strong>
-      회차와 지급예정일도 정확히 맞아야 일치로 봅니다. (2차에서 허용오차 정책을 도입합니다)
-    </span>
-  </div>
+  <header class="page-header">
+    <div class="page-header-copy">
+      <h1 class="page-title">대사 실행 · 결과</h1>
+    </div>
+  </header>
 
   <!-- ① 실행 영역 — 정산월·지급단계는 ④ 실행 이력 조회 조건도 겸한다(조회 버튼 = GET 재조회) -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__head"><span class="fgc-card__title">① 대사 실행</span></div>
-    <form class="fgc-card__body fgc-toolbar" id="reco-filter-form" method="get" th:action="@{/reconciliations}">
-      <div class="fgc-field" style="min-width:140px">
-        <label class="fgc-label fgc-label--required" for="r-month">정산월</label>
-        <input class="fgc-input" id="r-month" name="month" type="month" th:value="${month}" required>
+  <section class="surface reco-run-panel" aria-labelledby="reco-run-title">
+    <header class="surface-header reco-panel-header">
+      <h2 class="surface-title" id="reco-run-title">① 대사 실행</h2>
+    </header>
+    <form class="filter-bar reco-filter-bar" id="reco-filter-form" method="get" th:action="@{/reconciliations}">
+      <div class="filter-fields reco-filter-fields">
+        <div class="filter-field reco-filter-month">
+          <label class="filter-field-label" for="r-month">정산월 <span class="field-required" aria-hidden="true">*</span></label>
+          <input class="field-control" id="r-month" name="month" type="month" th:value="${month}" required>
+        </div>
+        <div class="filter-field reco-filter-stage">
+          <label class="filter-field-label" for="r-stage">지급단계 <span class="field-required" aria-hidden="true">*</span></label>
+          <select class="select-control" id="r-stage" name="stage">
+            <option value="" th:selected="${stageFilter == null}">전체</option>
+            <option th:each="stage : ${stageOptions}"
+                    th:value="${stage.name()}" th:text="${stage.label()}"
+                    th:selected="${stage.name() == stageFilter}">GA→설계사</option>
+          </select>
+        </div>
+        <div class="filter-field reco-filter-insurer">
+          <label class="filter-field-label" for="r-insurer">보험회사</label>
+          <select class="select-control" id="r-insurer" disabled><option value="">전체</option></select>
+        </div>
       </div>
-      <div class="fgc-field" style="min-width:170px">
-        <label class="fgc-label fgc-label--required" for="r-stage">지급단계</label>
-        <select class="fgc-select" id="r-stage" name="stage">
-          <option value="" th:selected="${stageFilter == null}">전체</option>
-          <option th:each="stage : ${stageOptions}"
-                  th:value="${stage.name()}" th:text="${stage.label()}"
-                  th:selected="${stage.name() == stageFilter}">GA→설계사</option>
-        </select>
+      <div class="filter-actions reco-filter-actions">
+        <button class="button button-secondary" type="submit">
+          <span class="material-symbols-rounded" aria-hidden="true">search</span> 조회
+        </button>
+        <!-- 실행(IF-API-38)·일괄 생성(IF-API-42)은 SETTLEMENT — GA_ADMIN 도 비활성이어야 한다 -->
+        <button class="button button-primary" id="btn-run" type="button" data-fgc-action="reconcile"
+                th:disabled="${!canProcess}"
+                th:attr="aria-describedby=${canProcess} ? null : 'reconciliation-actions-pending'">
+          <span class="material-symbols-rounded" aria-hidden="true">play_arrow</span> 대사 실행
+        </button>
+        <button class="button button-secondary" id="btn-bulk-exception" type="button" data-fgc-action="bulk"
+                th:disabled="${!canProcess}"
+                th:attr="aria-describedby=${canProcess} ? null : 'reconciliation-actions-pending'">
+          <span class="material-symbols-rounded" aria-hidden="true">playlist_add</span> 불일치 예외 일괄 생성
+        </button>
       </div>
-      <div class="fgc-field" style="min-width:150px">
-        <label class="fgc-label" for="r-insurer">보험회사</label>
-        <select class="fgc-select" id="r-insurer" disabled><option value="">전체</option></select>
-      </div>
-      <button class="fgc-btn fgc-btn--ghost" type="submit">
-        <span class="material-symbols-outlined" style="font-size:18px">search</span> 조회
-      </button>
-      <!-- 실행(IF-API-38)·일괄 생성(IF-API-42)은 SETTLEMENT — GA_ADMIN 도 비활성이어야 한다 -->
-      <button class="fgc-btn fgc-btn--primary" id="btn-run" type="button" data-fgc-action="reconcile"
-              th:disabled="${!canProcess}"
-              th:attr="aria-describedby=${canProcess} ? null : 'reconciliation-actions-pending'">
-        <span class="material-symbols-outlined" style="font-size:18px">play_arrow</span> 대사 실행
-      </button>
-      <button class="fgc-btn fgc-btn--ghost" id="btn-bulk-exception" type="button" data-fgc-action="bulk"
-              th:disabled="${!canProcess}"
-              th:attr="aria-describedby=${canProcess} ? null : 'reconciliation-actions-pending'">
-        <span class="material-symbols-outlined" style="font-size:18px">playlist_add</span> 불일치 예외 일괄 생성
-      </button>
     </form>
-    <div class="fgc-card__body" style="padding-top:0" th:if="${!canProcess}">
-      <p class="fgc-help" id="reconciliation-actions-pending">
-        대사 실행과 불일치 예외 일괄 생성은 SETTLEMENT 권한이 필요합니다.<br>
-        같은 정산월 · 지급단계 · 보험회사 · 검증실행 조합으로는 실행을 2건 만들 수 없습니다.
-        다시 돌려도 결과가 중복으로 쌓이지 않습니다
-        (<span class="fgc-mono">UNIQUE(reconciliation_run_id, match_group_key)</span>).
-      </p>
-    </div>
+    <p class="reco-permission-note" id="reconciliation-actions-pending" th:if="${!canProcess}">
+      대사 실행과 불일치 예외 일괄 생성은 SETTLEMENT 권한이 필요합니다.
+    </p>
   </section>
 
   <!-- ② 실행 요약 — [대사 실행] Ajax 응답으로 채운다 -->
-  <section style="margin-top:16px;display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:10px"
-           id="summary-cards">
-    <div class="fgc-kpi"><div class="fgc-kpi__label">대상</div><div class="fgc-kpi__value" id="sum-target">—</div></div>
-    <div class="fgc-kpi fgc-kpi--success"><div class="fgc-kpi__label">일치</div><div class="fgc-kpi__value" id="sum-matched">—</div></div>
-    <div class="fgc-kpi fgc-kpi--danger"><div class="fgc-kpi__label">불일치</div><div class="fgc-kpi__value" id="sum-exception">—</div></div>
-    <div class="fgc-kpi fgc-kpi--warning"><div class="fgc-kpi__label">일치율</div><div class="fgc-kpi__value" id="sum-rate">—</div></div>
-    <div class="fgc-kpi"><div class="fgc-kpi__label">차액 합계</div><div class="fgc-kpi__value" id="sum-diff-total">—</div></div>
+  <section class="kpi-grid reco-summary-grid" id="summary-cards" aria-label="대사 실행 요약" aria-live="polite">
+    <article class="kpi-card">
+      <div class="kpi-card-header"><span class="kpi-label">대상</span></div>
+      <div class="kpi-value-row"><strong class="kpi-value" id="sum-target">—</strong><span class="kpi-unit">건</span></div>
+    </article>
+    <article class="kpi-card kpi-card-success">
+      <div class="kpi-card-header"><span class="kpi-label">일치</span></div>
+      <div class="kpi-value-row"><strong class="kpi-value" id="sum-matched">—</strong><span class="kpi-unit">건</span></div>
+    </article>
+    <article class="kpi-card kpi-card-error">
+      <div class="kpi-card-header"><span class="kpi-label">불일치</span></div>
+      <div class="kpi-value-row"><strong class="kpi-value" id="sum-exception">—</strong><span class="kpi-unit">건</span></div>
+    </article>
+    <article class="kpi-card kpi-card-warning" id="sum-rate-card">
+      <div class="kpi-card-header"><span class="kpi-label">일치율</span></div>
+      <div class="kpi-value-row"><strong class="kpi-value" id="sum-rate">—</strong><span class="kpi-unit">%</span></div>
+    </article>
+    <article class="kpi-card kpi-card-error" id="sum-diff-card">
+      <div class="kpi-card-header"><span class="kpi-label">차액 합계</span></div>
+      <div class="kpi-value-row"><strong class="kpi-value" id="sum-diff-total">—</strong><span class="kpi-unit">원</span></div>
+    </article>
   </section>
 
-  <div class="fgc-responsive-split" style="margin-top:16px;display:grid;grid-template-columns:1fr;gap:16px">
+  <div class="reco-content-grid">
 
     <!-- ③ 결과 목록 -->
-    <section class="fgc-card">
-      <div class="fgc-card__head">
-        <span class="fgc-card__title">③ 대사 결과</span>
-        <div class="publishing-inline-controls" style="display:flex;gap:8px;align-items:center">
-          <label class="fgc-label" for="f-type" style="margin:0">결과 유형</label>
-          <select class="fgc-select" id="f-type" style="padding:4px 8px">
+    <section class="surface reco-panel reco-result-panel" aria-labelledby="reco-result-title">
+      <header class="surface-header reco-panel-header">
+        <h2 class="surface-title" id="reco-result-title">③ 대사 결과</h2>
+        <div class="reco-result-controls">
+          <label class="filter-field-label" for="f-type">결과 유형</label>
+          <select class="select-control reco-result-type" id="f-type">
             <option value="">전체 (11종)</option>
             <option value="MATCHED">일치</option>
             <option value="AMOUNT_DIFFERENCE">금액 차이</option>
@@ -125,93 +132,103 @@
             <option value="JOURNAL_IMBALANCE">분개 불균형</option>
             <option value="REVIEW_REQUIRED">검토 필요</option>
           </select>
-          <label style="display:flex;gap:4px;align-items:center;font-size:12px" title="현재 페이지 안에서만 걸러집니다.">
+          <label class="reco-checkbox" title="현재 페이지 안에서만 걸러집니다.">
             <input type="checkbox" id="f-mismatch"> 불일치만
           </label>
         </div>
-      </div>
-      <div style="overflow-x:auto">
-        <table class="fgc-table" style="min-width:1080px">
+      </header>
+      <div class="data-table-viewport">
+        <table class="data-table reco-result-table">
+          <caption class="visually-hidden">선택한 대사 실행의 계약별 결과</caption>
+          <colgroup>
+            <col class="reco-col-contract"><col class="reco-col-item"><col class="reco-col-installment">
+            <col class="reco-col-agent"><col class="reco-col-agent"><col class="reco-col-amount">
+            <col class="reco-col-amount"><col class="reco-col-amount"><col class="reco-col-result">
+            <col class="reco-col-reason"><col class="reco-col-reason"><col class="reco-col-action">
+          </colgroup>
           <thead>
             <tr>
-              <th style="width:66px">계약</th>
-              <th style="width:130px">수수료 항목</th>
-              <th style="width:52px">회차</th>
-              <th style="width:130px">예상 설계사</th>
-              <th style="width:130px">실제 설계사</th>
-              <th class="fgc-th-num" style="width:100px">예상 금액</th>
-              <th class="fgc-th-num" style="width:100px">실제 금액</th>
-              <th class="fgc-th-num" style="width:100px">차액</th>
-              <th style="width:130px">결과 유형</th>
-              <th style="width:150px">주 원인</th>
-              <th style="width:150px">보조 원인</th>
-              <th style="width:80px"></th>
+              <th scope="col">계약</th><th scope="col">수수료 항목</th><th scope="col" class="is-center">회차</th>
+              <th scope="col">예상 설계사</th><th scope="col">실제 설계사</th>
+              <th scope="col" class="is-number">예상 금액</th><th scope="col" class="is-number">실제 금액</th>
+              <th scope="col" class="is-number">차액</th><th scope="col">결과 유형</th>
+              <th scope="col">주 원인</th><th scope="col">보조 원인</th><th scope="col">상세</th>
             </tr>
           </thead>
           <tbody id="result-body">
-            <tr><td colspan="12"><div class="fgc-empty" id="result-empty" th:text="#{info.common.empty}">대사를 실행하면 결과가 여기 표시됩니다.</div></td></tr>
+            <tr class="reco-state-row"><td colspan="12"><div class="empty-state" id="result-empty" th:text="#{info.common.empty}">대사를 실행하면 결과가 여기 표시됩니다.</div></td></tr>
           </tbody>
           <tfoot>
             <tr>
               <td colspan="5" id="result-sum-label">합계</td>
-              <td class="fgc-td-num"><span class="fgc-amount" id="sum-expected">0</span></td>
-              <td class="fgc-td-num"><span class="fgc-amount" id="sum-actual">0</span></td>
-              <td class="fgc-td-num"><span class="fgc-amount" id="sum-diff">0</span></td>
+              <td class="is-number tabular-nums"><span id="sum-expected">0</span></td>
+              <td class="is-number tabular-nums"><span id="sum-actual">0</span></td>
+              <td class="is-number tabular-nums"><span id="sum-diff">0</span></td>
               <td colspan="4"></td>
             </tr>
           </tfoot>
         </table>
       </div>
-      <footer class="fgc-pagination" id="result-pagination" hidden>
-        <nav aria-label="대사 결과 페이지 이동" style="display:flex;gap:8px;align-items:center;justify-content:flex-end;margin-top:8px">
-          <button class="fgc-btn fgc-btn--ghost" id="result-page-prev" type="button">이전</button>
-          <span class="tabular-nums" id="result-page-indicator">1 / 1</span>
-          <button class="fgc-btn fgc-btn--ghost" id="result-page-next" type="button">다음</button>
+      <footer class="reco-pagination" id="result-pagination" hidden>
+        <nav class="reco-pagination-nav" aria-label="대사 결과 페이지 이동">
+          <button class="button button-secondary" id="result-page-prev" type="button">이전</button>
+          <span class="reco-pagination-status tabular-nums" id="result-page-indicator" aria-live="polite">1 / 1</span>
+          <button class="button button-secondary" id="result-page-next" type="button">다음</button>
         </nav>
       </footer>
     </section>
 
     <!-- ④ 실행 이력 — IF-API-39, 서버 렌더링(MPA) -->
-    <section class="fgc-card">
-      <div class="fgc-card__head"><span class="fgc-card__title">④ 실행 이력</span></div>
-      <div style="overflow-x:auto">
-        <table class="fgc-table">
+    <section class="surface reco-panel reco-history-panel" aria-labelledby="reco-history-title">
+      <header class="surface-header reco-panel-header"><h2 class="surface-title" id="reco-history-title">④ 실행 이력</h2></header>
+      <div class="data-table-viewport">
+        <table class="data-table reco-history-table">
+          <caption class="visually-hidden">검색조건에 해당하는 대사 실행 이력</caption>
+          <colgroup>
+            <col class="reco-history-col-id"><col class="reco-history-col-month"><col class="reco-history-col-stage">
+            <col class="reco-history-col-insurer"><col class="reco-history-col-status"><col class="reco-history-col-count">
+            <col class="reco-history-col-count"><col class="reco-history-col-count"><col class="reco-history-col-rate">
+            <col class="reco-history-col-diff"><col class="reco-history-col-period">
+          </colgroup>
           <thead>
             <tr>
-              <th>실행 ID</th><th>정산월</th><th>지급단계</th><th>보험회사</th>
-              <th>상태</th><th class="fgc-th-num">대상</th><th class="fgc-th-num">일치</th>
-              <th class="fgc-th-num">불일치</th><th class="fgc-th-num">일치율</th>
-              <th class="fgc-th-num">차액 합계</th><th>시작 · 완료</th>
+              <th scope="col">실행 ID</th><th scope="col">정산월</th><th scope="col">지급단계</th><th scope="col">보험회사</th>
+              <th scope="col">상태</th><th scope="col" class="is-number">대상</th><th scope="col" class="is-number">일치</th>
+              <th scope="col" class="is-number">불일치</th><th scope="col" class="is-number">일치율</th>
+              <th scope="col" class="is-number">차액 합계</th><th scope="col">시작 · 완료</th>
             </tr>
           </thead>
           <tbody id="run-body">
             <tr th:if="${history.content.empty}">
-              <td colspan="11"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td>
+              <td colspan="11"><div class="empty-state" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td>
             </tr>
             <tr th:each="run : ${history.content}" th:data-reconciliation-run-id="${run.reconciliationRunId}"
-                style="cursor:pointer" class="reco-history-row">
-              <td class="fgc-mono" th:text="${run.reconciliationRunId}">41</td>
-              <td th:text="${#temporals.format(run.settlementMonth, 'yyyy-MM')}">2026-07</td>
+                class="reco-history-row" tabindex="0" aria-selected="false"
+                th:attr="aria-label=|대사 실행 ${run.reconciliationRunId} 결과 보기|">
+              <td class="tabular-nums" th:text="${run.reconciliationRunId}">41</td>
+              <td class="tabular-nums" th:text="${#temporals.format(run.settlementMonth, 'yyyy-MM')}">2026-07</td>
               <td th:text="${run.paymentStageLabel}">GA→설계사</td>
               <td th:text="${run.insurerName ?: '—'}">—</td>
-              <td><span class="fgc-badge" th:text="${run.statusLabel}">계산완료</span></td>
-              <td class="fgc-th-num" th:text="${run.targetCount}">0</td>
-              <td class="fgc-th-num" th:text="${run.matchedCount}">0</td>
-              <td class="fgc-th-num" th:text="${run.exceptionCount}">0</td>
-              <td class="fgc-th-num" th:text="${run.matchRatePct != null ? run.matchRatePct + '%' : '—'}">—</td>
-              <td class="fgc-th-num" th:text="${run.differenceTotal}">0</td>
-              <td th:text="${(run.startedAt != null ? #temporals.format(run.startedAt, 'MM-dd HH:mm') : '—')
+              <td><span class="status-badge"
+                        th:classappend="${run.status == 'COMPLETED' or run.status == 'FINALIZED'} ? ' status-badge-success' : (${run.status == 'RUNNING'} ? ' status-badge-info' : (${run.status == 'FAILED'} ? ' status-badge-error' : ' status-badge-neutral'))"
+                        th:title="${run.status}" th:text="${run.statusLabel}">계산완료</span></td>
+              <td class="is-number tabular-nums" th:text="${run.targetCount}">0</td>
+              <td class="is-number tabular-nums" th:text="${run.matchedCount}">0</td>
+              <td class="is-number tabular-nums" th:text="${run.exceptionCount}">0</td>
+              <td class="is-number tabular-nums" th:text="${run.matchRatePct != null ? run.matchRatePct + '%' : '—'}">—</td>
+              <td class="is-number tabular-nums" th:text="${run.differenceTotal}">0</td>
+              <td class="tabular-nums" th:text="${(run.startedAt != null ? #temporals.format(run.startedAt, 'MM-dd HH:mm') : '—')
                              + ' · ' + (run.completedAt != null ? #temporals.format(run.completedAt, 'MM-dd HH:mm') : '—')}">— · —</td>
             </tr>
           </tbody>
         </table>
       </div>
-      <footer class="fgc-pagination" th:if="${history.totalPages > 1}">
-        <nav aria-label="실행 이력 페이지 이동" style="display:flex;gap:8px;align-items:center;justify-content:flex-end;margin-top:8px">
-          <a class="fgc-btn fgc-btn--ghost" th:if="${history.page > 1}"
+      <footer class="reco-pagination" th:if="${history.totalPages > 1}">
+        <nav class="reco-pagination-nav" aria-label="실행 이력 페이지 이동">
+          <a class="button button-secondary" th:if="${history.page > 1}"
              th:href="@{/reconciliations(month=${month},stage=${stageFilter},page=${history.page - 1})}">이전</a>
-          <span class="tabular-nums" th:text="${history.page} + ' / ' + ${history.totalPages}">1 / 1</span>
-          <a class="fgc-btn fgc-btn--ghost" th:if="${history.page < history.totalPages}"
+          <span class="reco-pagination-status tabular-nums" th:text="${history.page} + ' / ' + ${history.totalPages}">1 / 1</span>
+          <a class="button button-secondary" th:if="${history.page < history.totalPages}"
              th:href="@{/reconciliations(month=${month},stage=${stageFilter},page=${history.page + 1})}">다음</a>
         </nav>
       </footer>

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -311,14 +311,20 @@ class PublishingTemplateStructureTest {
                 .contains(".reco-summary-grid")
                 .contains("grid-template-columns: repeat(5, minmax(0, 1fr))")
                 .contains(".reco-result-table")
+                .contains(".reco-col-action { width: 7rem; }")
                 .contains("@media (max-width: 47.9375rem)");
 
         assertThat(resource("static/js/features/reco/reco.js"))
                 .contains("tableCellDisclosure")
+                .contains("class=\"table-cell-details\" hidden")
                 .contains("table-cell-more\">전체 보기")
+                .contains("preview.scrollWidth > preview.clientWidth")
+                .contains("preview.scrollHeight > preview.clientHeight")
+                .contains("document.fonts.ready")
                 .contains("window.FgcUi.toast(")
                 .contains("\"success\"")
                 .contains("event.key !== \"Enter\" && event.key !== \" \"")
+                .doesNotContain("text.length <= limit")
                 .doesNotContain("fetch(");
     }
 

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -288,6 +288,41 @@ class PublishingTemplateStructureTest {
     }
 
     @Test
+    void reconciliationListUsesCommonComponentsAndProductionToast() throws IOException {
+        assertThat(resource("templates/reco/list.html"))
+                .contains("class=\"page-header\"")
+                .contains("class=\"filter-bar reco-filter-bar\"")
+                .contains("class=\"kpi-grid reco-summary-grid\"")
+                .contains("class=\"kpi-card kpi-card-success\"")
+                .contains("class=\"surface reco-panel reco-result-panel\"")
+                .contains("class=\"data-table reco-result-table\"")
+                .contains("class=\"data-table reco-history-table\"")
+                .contains("class=\"status-badge\"")
+                .contains("class=\"reco-history-row\" tabindex=\"0\"")
+                .doesNotContain("class=\"fgc-page-desc\"")
+                .doesNotContain("class=\"fgc-banner")
+                .doesNotContain("class=\"fgc-kpi")
+                .doesNotContain("style=");
+
+        assertThat(resource("templates/layout/default.html"))
+                .contains("/css/features/reco.css");
+
+        assertThat(resource("static/css/features/reco.css"))
+                .contains(".reco-summary-grid")
+                .contains("grid-template-columns: repeat(5, minmax(0, 1fr))")
+                .contains(".reco-result-table")
+                .contains("@media (max-width: 47.9375rem)");
+
+        assertThat(resource("static/js/features/reco/reco.js"))
+                .contains("tableCellDisclosure")
+                .contains("table-cell-more\">전체 보기")
+                .contains("window.FgcUi.toast(")
+                .contains("\"success\"")
+                .contains("event.key !== \"Enter\" && event.key !== \" \"")
+                .doesNotContain("fetch(");
+    }
+
+    @Test
     void contractFormUsesSeparatedApiAndPageScriptsWithoutInlineBehavior() throws IOException {
         assertThat(resource("templates/contract/form.html"))
                 .contains("name=\"premiumPerCycleAmount\"")


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- RECO-W01 대사 실행·결과 화면을 공통 UI 컴포넌트 구조로 전환했습니다.
- 불필요한 Guidance와 화면 설명을 제거하고, 요약 카드·검색 조건·테이블·버튼 디자인을 통일했습니다.
- 불일치 예외 일괄 생성 결과를 EXCP-W01과 동일한 공통 우상단 Toast로 표시하도록 정리했습니다.

## 🔗 2. 관련 이슈

- Refs #138

## 🛠 3. 구현 내용

- 실행 조건을 공통 Filter·Field·Button 컴포넌트로 전환
- 실행 요약 5개를 공통 `kpi-grid`, `kpi-card` 구조로 전환
- 일치율과 차액 값에 따라 KPI 상태 색상 동적 적용
- 대사 결과와 실행 이력을 공통 Surface·Data Table 구조로 전환
- 테이블 Header와 Row가 동일한 `colgroup` 정의를 사용하도록 정리
- 긴 계약번호·수수료 항목·주 원인·보조 원인에 `전체 보기/접기` 적용
- 수수료 항목과 원인 셀의 수직 중앙 정렬 적용
- 실행 상태를 공통 `status-badge`로 전환
- 실행 이력 행에 Enter·Space 키보드 선택 기능 추가
- RECO-W01 전용 CSS를 `features/reco.css`로 분리
- RECO-W01 템플릿의 인라인 스타일 제거
- 기존 API 요청, Thymeleaf 바인딩 및 RECO-W02 팝업 구조 유지

## 🧪 4. 테스트 방법

1. 애플리케이션을 실행하고 `/reconciliations`에 SETTLEMENT 계정으로 접속합니다.
2. 실행 이력 행을 마우스 또는 Enter·Space로 선택하여 대사 결과가 조회되는지 확인합니다.
3. 결과 유형, 불일치 필터, 페이지 이동, 비교 상세 팝업을 확인합니다.
4. 테스트 DB에서 불일치 예외 일괄 생성을 실행하고 우측 상단 Toast를 확인합니다.
5. 1440px, 900px, 720px에서 본문 가로 넘침과 테이블 내부 스크롤을 확인합니다.

실행한 자동 테스트:

```bash
node --check src/main/resources/static/js/features/reco/reco.js
./gradlew test
```

- 전체 Gradle 테스트 통과
- 브라우저 콘솔 오류 없음
- 1440px, 900px, 720px 본문 가로 넘침 없음

## 🗄️ 5. DB / Flyway 변경

- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

- 없음

## 📋 6. 리뷰 요구사항

- RECO-W01의 공통 Surface·Field·KPI·Table 구조가 다른 업무 화면과 일관적인지 확인 부탁드립니다.
- 대사 결과의 긴 값 `전체 보기/접기`와 셀 수직 정렬을 확인 부탁드립니다.
- RECO-W02가 별도 Workspace Tab이 아닌 기존 팝업 방식으로 유지되는지 확인 부탁드립니다.
- 불일치 예외 일괄 생성 성공·오류 알림이 공통 우상단 Toast로 표시되는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

- [ ] `develop` 최신 내용을 반영했습니다.
- [x] 로컬 빌드에 성공했습니다.
- [x] 애플리케이션 실행을 확인했습니다.
- [x] 관련 기능을 직접 테스트했습니다.
- [x] 테스트 코드가 필요한 경우 작성했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

- Guidance 및 페이지 설명 제거
- 검색 조건 공통 컴포넌트 전환
- 실행 요약 카드 공통 KPI 디자인 적용
- 대사 결과·실행 이력 공통 Table 디자인 적용
- 실행 상태 공통 Status Badge 적용
- 긴 테이블 데이터 `전체 보기/접기` 적용
- 불일치 예외 일괄 생성 알림을 우측 상단 공통 Toast로 변경
- 1440px, 900px, 720px 반응형 레이아웃 정리

## 💬 9. 참고 사항

- 백엔드 Controller, Service, Mapper, DTO 및 DB 구조는 변경하지 않았습니다.
- 기존 `/api/v1/reconciliations/**` 요청 구조와 Thymeleaf 바인딩을 유지했습니다.
- RECO-W02는 기존 결정대로 팝업 구조를 유지합니다.
- 본 브랜치는 EXCP-W01 공통 Toast 작업 커밋을 기반으로 합니다. EXCP 관련 PR을 먼저 `develop`에 병합한 후 최신 `develop`을 반영해 주세요.