### PR TITLE
[Chore] UI 구조 테스트 4종에 개행 정규화 추가 + 인터페이스정의서 미구현 목록 갱신 (#251)

### DIFF
--- a/docs/05_인터페이스정의서_v2_0.md
+++ b/docs/05_인터페이스정의서_v2_0.md
@@ -406,9 +406,15 @@ DB가 던진 제약 이름(`uq_contract_no` 등)을 오류코드로 바꾸는 �
 > 채운다. 화면마다 반복하면 표가 안 읽히므로 5-3 규칙으로 한 번만 적는다.
 >
 > **아직 코드가 없는 행** — 설계는 유효하므로 표는 그대로 두되, 지금 구현되어 있지 않다는 것만 밝힌다.
-> LEDG-W01 의 IF-API-34~37(`ledger/list.html` 이 정적 골격 단계 · 이슈 #234) ·
-> TRAN-W02 의 IF-API-26(지급 건 취소 · 호출부도 엔드포인트도 없다 · 담당 이슈 없음).
-> VRUN-W02 의 IF-API-51 은 2026-08-19 구현되어 여기서 빠졌다(`vrun-detail.js:217` · 이슈 #233 완료).
+> TRAN-W02 의 IF-API-26(지급 건 취소)만 남았다 — 호출부도 엔드포인트도 없다. 담당 이슈 없음.
+> 취소는 운영정책서 제42조상 예외 해결조치(`CANCEL`)이기도 한데, 지금 `ExceptionCaseService.action()` 은
+> `exception_action` 만 기록하고 `commission_transaction.status` 를 바꾸지 않는다. 두 경로를 어떻게
+> 만나게 할지부터 정해야 한다.
+>
+> 아래 두 건은 2026-08-19 구현되어 이 목록에서 빠졌다 —
+> VRUN-W02 의 IF-API-51(`vrun-detail.js:217` · 이슈 #233) ·
+> LEDG-W01 의 IF-API-34~37(목록 본문은 `JournalViewController:65` 서버 렌더링, 상세·역분개·불균형은
+> `ledger.js:121,170,207` Ajax · 이슈 #234 · PR #240).
 >
 > **호출하지 않고 링크로만 참조하는 것** — VRUN-W02 는 IF-API-37 을 스스로 부르지 않는다.
 > IF-API-50 확정 체크리스트의 조건 2(원장 불균형 0건)가 `/api/v1/journals/imbalances?validationRunId=`

--- a/src/test/java/com/susukkang/fgc/ui/GlobalMonthSelectorStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/GlobalMonthSelectorStructureTest.java
@@ -84,7 +84,7 @@ class GlobalMonthSelectorStructureTest {
     private static String resource(String path) throws IOException {
         try (var input = GlobalMonthSelectorStructureTest.class.getClassLoader().getResourceAsStream(path)) {
             assertThat(input).as(path).isNotNull();
-            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8).replace("\r\n", "\n");
         }
     }
 }

--- a/src/test/java/com/susukkang/fgc/ui/PendingActionButtonStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PendingActionButtonStructureTest.java
@@ -69,7 +69,7 @@ class PendingActionButtonStructureTest {
     private static String resource(String path) throws IOException {
         try (var input = PendingActionButtonStructureTest.class.getClassLoader().getResourceAsStream(path)) {
             assertThat(input).as(path).isNotNull();
-            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8).replace("\r\n", "\n");
         }
     }
 }

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -292,7 +292,7 @@ class PublishingTemplateStructureTest {
     private static String resource(String path) throws IOException {
         try (var input = PublishingTemplateStructureTest.class.getClassLoader().getResourceAsStream(path)) {
             assertThat(input).as(path).isNotNull();
-            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8).replace("\r\n", "\n");
         }
     }
 }

--- a/src/test/java/com/susukkang/fgc/ui/SidebarSectionStateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/SidebarSectionStateStructureTest.java
@@ -74,7 +74,7 @@ class SidebarSectionStateStructureTest {
     private static String resource(String path) throws IOException {
         try (var input = SidebarSectionStateStructureTest.class.getClassLoader().getResourceAsStream(path)) {
             assertThat(input).as(path).isNotNull();
-            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8).replace("\r\n", "\n");
         }
     }
 }


### PR DESCRIPTION
Closes #251

## 무엇을 했나

### 1. UI 구조 테스트 4종에 개행 정규화 추가 (#251)

`resource()` 헬퍼를 쓰는 UI 구조 테스트는 5개인데, 개행 정규화가 들어간 것은
#244 에서 고친 `AppShellWorkspaceStructureTest` 1개뿐이었다. 나머지 4개에도
`.replace("\r\n", "\n")` 를 한 줄씩 넣어 5종을 같은 모양으로 맞췄다.

| 테스트 | 이전 | 이후 |
|---|---|---|
| `ui/AppShellWorkspaceStructureTest` | ✅ (#244) | ✅ |
| `ui/GlobalMonthSelectorStructureTest` | ❌ | ✅ |
| `ui/PendingActionButtonStructureTest` | ❌ | ✅ |
| `ui/PublishingTemplateStructureTest` | ❌ | ✅ |
| `ui/SidebarSectionStateStructureTest` | ❌ | ✅ |

지금은 4종의 `contains` 가 전부 한 줄짜리라 CRLF 체크아웃에서도 통과한다.
다만 `.gitattributes` 가 소스 개행을 정규화하지 않아(`gradlew`·`*.bat`·`*.jar` 만 지정)
체크아웃 개행이 개발자의 `core.autocrlf` 설정에 따라 갈리므로, 여러 줄 assertion 이
추가되는 순간 #244 와 같은 사고가 재발한다. 사고 나기 전에 막아 둔다.

**`.gitattributes` 에 `* text=auto eol=lf` 는 넣지 않았다** — 정석이지만 전원
재체크아웃이 필요하고 diff 가 크게 뜬다. 이슈 본문 권고대로 발표(2026-08-24) 이후로 미룬다.

### 2. 인터페이스정의서 "아직 코드가 없는 행" 갱신

2026-08-19 기준으로 구현이 끝난 두 건을 목록에서 뺐다 —
VRUN-W02 의 IF-API-51(`vrun-detail.js:217` · #233), LEDG-W01 의
IF-API-34~37(`JournalViewController:65` 서버 렌더링 + `ledger.js:121,170,207` Ajax · #234 · PR #240).

남은 것은 TRAN-W02 의 IF-API-26(지급 건 취소) 하나뿐이다. 이 건은 운영정책서
제42조상 예외 해결조치(`CANCEL`) 와도 겹치는데, 지금 `ExceptionCaseService.action()` 은
`exception_action` 만 기록하고 `commission_transaction.status` 를 바꾸지 않는다.
두 경로를 어떻게 만나게 할지부터 정해야 한다는 점을 문서에 남겼다.

## 검증

```
./gradlew test --tests 'com.susukkang.fgc.ui.*StructureTest'
```

`build/test-results/test/**.xml` 원본 기준 — **22개 / 실패 0 / 에러 0**
(AppShell 3 · GlobalMonthSelector 4 · PendingActionButton 2 · PublishingTemplate 10 · SidebarSectionState 3).

기준 커밋: `b85ddb8d` (origin/develop 최신으로 rebase 후 작업).

## 발표 차단 요소 아님

#251 은 P2 다. 트래커 #252 의 "선행 조건" 에서 내려도 된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
