### PR TITLE
[Fix] QA-05 시연 점검 중 발견한 차익거래 검토대상 불일치 수정

### DIFF
--- a/src/main/java/com/susukkang/fgc/dashboard/mapper/DashboardMapper.java
+++ b/src/main/java/com/susukkang/fgc/dashboard/mapper/DashboardMapper.java
@@ -33,10 +33,14 @@ public interface DashboardMapper {
     /**
      * 차익거래 검토대상 건수
      * 원본: arbitrage_check WHERE result_status = 'CANDIDATE'
-     * 월 필터: 없음 — 존재하는 행 전부
-     * 중복 처리: 없음 — 계약당 여러 번 재검증됐어도 dedup하지 않고 행 개수 그대로 카운트
+     * 월 필터: 있음 — as_of_date가 month가 속한 달에 포함되는 행만
+     * 중복 처리: 계약·지급단계별 "이번 달 안에서" 최신 판정만. uq_arbitrage_check에
+     *   validation_run_id가 들어 있어 같은 달을 재실행하면 같은 계약의 행이 새로 쌓인다
+     *   (수동 재검증 IF-API-33도 MANUAL_CONTRACT run을 새로 만든다). 접지 않으면 재실행
+     *   횟수만큼 부풀어, 예외 키가 월·계약·지급단계 UNIQUE인 예외함 카드와 어긋난다.
+     *   countCapViolation과 같은 이유로 월 필터를 먼저 적용한 뒤 그 안에서 dedup한다.
      */
-    long countArbitrageCandidate();
+    long countArbitrageCandidate(@Param("month") LocalDate month);
 
     /**
      * 대사 불일치 건수

--- a/src/main/java/com/susukkang/fgc/dashboard/service/DashboardServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/dashboard/service/DashboardServiceImpl.java
@@ -33,7 +33,7 @@ public class DashboardServiceImpl implements DashboardService {
         // 카드 6장 + 최근 목록 2개를 하나의 읽기 전용 트랜잭션에서 조회
         long capVilation = dashboardMapper.countCapViolation(month);
         long capWarning = dashboardMapper.countCapWarning(month);
-        long arbitrageCandidate = dashboardMapper.countArbitrageCandidate();
+        long arbitrageCandidate = dashboardMapper.countArbitrageCandidate(month);
         long reconciliationMismatch = dashboardMapper.countReconciliationMismatch(month);
         long journalImbalance = dashboardMapper.countJournalImbalance();
         long openException = dashboardMapper.countOpenException();

--- a/src/main/resources/db/migration/V33__arbitrage_check_month_latest_index.sql
+++ b/src/main/resources/db/migration/V33__arbitrage_check_month_latest_index.sql
@@ -1,0 +1,24 @@
+-- #257 시연 점검에서 대시보드 "차익거래 검토대상" 10건과 예외함 ARBITRAGE_CANDIDATE 5건이
+-- 어긋났다. 원인은 판정을 쌓는 쪽이 아니라 읽는 쪽이었다 — uq_arbitrage_check가
+-- (validation_run_id, contract_id, payment_stage, as_of_date)라 같은 달을 두 번 검증하면
+-- (run_no 1·2) 같은 계약의 행이 하나 더 쌓이는데(설계대로다. 인터페이스정의서 7-5 단계표,
+-- IF-API-33 수동 재검증도 MANUAL_CONTRACT run을 새로 만든다), DashboardMapper의
+-- countArbitrageCandidate가 월 필터도 dedup도 없이 행 수를 그대로 셌다.
+-- 예외 키(ARBITRAGE_CANDIDATE:월:CONTRACT:계약:지급단계)는 재실행해도 하나만 남으므로
+-- (화면정의서 EXCP-W01 "재실행해도 하나만 생깁니다") 예외함 쪽이 맞고, KPI는
+-- 화면정의서 DASH-W01 KPI 표대로 "이번 달 CANDIDATE 계약 수"가 되어야 한다.
+--
+-- 쿼리를 월 필터 + 계약·지급단계별 최신 1건으로 바꿨으니 인덱스도 그 모양에 맞춘다.
+-- WHERE절과 DISTINCT ON의 ORDER BY를 인덱스 컬럼 순서에 그대로 맞춰 필터링과 정렬을
+-- 한 번에 인덱스로 해결한다(별도 Sort 노드 불필요) — V23에서 cap_check에 한 것과 같다.
+-- as_of_date::timestamp 캐스팅은 DashboardMapper.xml의 countArbitrageCandidate 쿼리와
+-- 문자 그대로 일치해야 플래너가 이 인덱스를 쓴다. 캐스팅 없이 date_trunc(text, date)를
+-- 쓰면 PostgreSQL이 STABLE인 timestamptz 오버로드를 골라
+-- "functions in index expression must be marked IMMUTABLE" 오류가 난다.
+CREATE INDEX ix_arbitrage_check_month_latest
+  ON fgc.arbitrage_check (date_trunc('month', as_of_date::timestamp),
+                          contract_id, payment_stage, as_of_date DESC, arbitrage_check_id DESC);
+
+-- V23의 ix_arbitrage_check_candidate는 "월 필터가 전혀 없는 카운트"를 전제로 만든
+-- 부분 인덱스였다. 이제 월 필터가 붙어 위 인덱스가 그 역할을 대신하므로 남겨 둘 이유가 없다.
+DROP INDEX IF EXISTS fgc.ix_arbitrage_check_candidate;

--- a/src/main/resources/mapper/arbitrage/ArbitrageMapper.xml
+++ b/src/main/resources/mapper/arbitrage/ArbitrageMapper.xml
@@ -28,6 +28,24 @@
         <result property="decisionReason" column="decision_reason"/>
     </resultMap>
 
+    <!--
+      uq_arbitrage_check가 (validation_run_id, contract_id, payment_stage, as_of_date)라
+      같은 계약·지급단계·기준일이라도 검증을 다시 돌리면 행이 새로 쌓인다(인터페이스정의서
+      7-5 단계표. 게다가 IF-API-33 수동 재검증은 MANUAL_CONTRACT run을 새로 만들어 붙이므로
+      [이 계약만 다시 검증]을 누를 때마다 한 줄씩 늘어난다). 이력은 감사용으로 그대로 두되,
+      ARB-W01은 화면정의서상 계약번호·지급단계·기준일이 한 줄이고 회차 컬럼이 없으므로
+      읽을 때 그 단위의 최신 1건으로 접는다(#257 — 검토대상 10건인데 예외함은 5건이었다).
+      as_of_date가 접기 키에 들어 있어 월 필터를 나중에 걸어도 다른 달 판정에 가려지지
+      않는다 — vw_latest_cap_check가 전체 기간 최신을 먼저 골라 겪던 문제를 피한다.
+      as_of_date·contract_id 조건은 접기 키라 서브쿼리 안으로 밀려 들어가고,
+      result_status·보험사 조건은 (당연히) 접은 뒤에 걸린다.
+    -->
+    <sql id="latestArbitrageCheck">
+        (SELECT DISTINCT ON (contract_id, payment_stage, as_of_date) *
+           FROM arbitrage_check
+          ORDER BY contract_id, payment_stage, as_of_date, arbitrage_check_id DESC)
+    </sql>
+
     <!-- 목록과 요약 조회에 동일한 검색 조건을 적용한다. -->
     <sql id="arbitrageSearchCondition">
         <where>
@@ -70,7 +88,7 @@
             ac.result_status,
             ac.calculation_snapshot ->> 'decisionReason' AS decision_reason
         FROM
-            arbitrage_check ac
+            <include refid="latestArbitrageCheck"/> ac
         JOIN
             insurance_contract c
         ON
@@ -90,7 +108,7 @@
             COUNT(*) FILTER (WHERE ac.result_status = 'CANDIDATE') AS candidate_count,
             COUNT(*) FILTER (WHERE ac.result_status = 'REVIEW_REQUIRED') AS review_required_count
         FROM
-            arbitrage_check ac
+            <include refid="latestArbitrageCheck"/> ac
         JOIN
             insurance_contract c
         ON
@@ -101,7 +119,7 @@
     <!-- 검색 조건에 해당하는 목록 페이징용 전체 건수를 조회한다. -->
     <select id="countByCondition" resultType="long">
         SELECT COUNT(*)
-        FROM arbitrage_check ac
+        FROM <include refid="latestArbitrageCheck"/> ac
         JOIN insurance_contract c
           ON c.contract_id = ac.contract_id
         <include refid="arbitrageSearchCondition"/>
@@ -326,7 +344,7 @@
             ac.result_status,
             ac.calculation_snapshot ->> 'decisionReason' AS decision_reason
         FROM
-            arbitrage_check ac
+            <include refid="latestArbitrageCheck"/> ac
         JOIN
             insurance_contract c
         ON

--- a/src/main/resources/mapper/dashboard/DashboardMapper.xml
+++ b/src/main/resources/mapper/dashboard/DashboardMapper.xml
@@ -37,9 +37,28 @@
          WHERE result_status = 'WARNING'
     </select>
 
+    <!--
+      차익거래 KPI도 1,200%와 같은 규칙을 따른다 — 화면정의서 DASH-W01 KPI 표가
+      "`CANDIDATE` 계약 수"라고 못박고, 같은 절의 버튼 표가 "기준월 변경 → 6장 카드를
+      다시 계산"이라고 쓴다. 예전 구현은 월 필터도 dedup도 없어 arbitrage_check 전체
+      행 수를 셌고, 한 달을 두 번 검증하면(run_no 1·2) 같은 계약이 두 번 세어져
+      예외함의 ARBITRAGE_CANDIDATE 카드와 숫자가 어긋났다(#257, 10건 vs 5건).
+      uq_arbitrage_check가 (validation_run_id, contract_id, payment_stage, as_of_date)라
+      재실행마다 행이 새로 쌓이는 것 자체는 설계대로다(인터페이스정의서 7-5 단계표,
+      IF-API-33 수동 재검증도 MANUAL_CONTRACT run을 새로 만들어 붙인다). 이력은 그대로
+      쌓아 두고 읽을 때 계약·지급단계별 최신 1건으로 접는다 — 예외 키
+      (ARBITRAGE_CANDIDATE:월:CONTRACT:계약:지급단계)와 같은 단위라 예외함과 항상 맞는다.
+      as_of_date::timestamp 캐스팅과 ORDER BY 컬럼 순서는 ix_arbitrage_check_month_latest
+      (V33) 정의와 문자 그대로 일치해야 플래너가 그 인덱스를 쓴다 — cap 쪽과 같은 이유다.
+    -->
     <select id="countArbitrageCandidate" resultType="long">
         SELECT COUNT(*)
-          FROM fgc.arbitrage_check
+          FROM (
+              SELECT DISTINCT ON (contract_id, payment_stage) result_status
+                FROM fgc.arbitrage_check
+               WHERE date_trunc('month', as_of_date::timestamp) = date_trunc('month', #{month}::date::timestamp)
+               ORDER BY contract_id, payment_stage, as_of_date DESC, arbitrage_check_id DESC
+          ) AS latest_in_month
          WHERE result_status = 'CANDIDATE'
     </select>
 

--- a/src/test/java/com/susukkang/fgc/arbitrage/mapper/ArbitrageMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/arbitrage/mapper/ArbitrageMapperIntegrationTest.java
@@ -108,6 +108,62 @@ class ArbitrageMapperIntegrationTest {
         assertThat(summary.getReviewRequiredCount()).isZero();
     }
 
+    /**
+     * 설명 : 같은 달을 다시 검증해도 계약·지급단계·기준일당 한 줄만 보이고,
+     *        요약 건수도 늘지 않는지 검증한다(#257 — ARB-W01 검토대상과 예외함 카드의 불일치).
+     *        uq_arbitrage_check에 validation_run_id가 들어 있어 재실행마다 행은 새로 쌓이지만,
+     *        화면정의서 ARB-W01 목록에는 회차 컬럼이 없다.
+     *
+     * @since 2026-08-19
+     */
+    @Test
+    void collapsesRerunsToLatestCheckPerContractStageAndAsOfDate() {
+        TestReference reference = testReference();
+        LocalDate asOfDate = LocalDate.of(2098, 11, 20);
+        insertArbitrageCheck(insertValidationRun(), reference.contractId(), asOfDate,
+                PaymentStage.GA_TO_FC, ArbitrageCheckStatus.CANDIDATE, "1회차 판정");
+        insertArbitrageCheck(insertValidationRun(), reference.contractId(), asOfDate,
+                PaymentStage.GA_TO_FC, ArbitrageCheckStatus.CANDIDATE, "2회차 판정");
+
+        ArbitrageCheckSearchCondition condition = condition(
+                TEST_MONTH, null, PaymentStage.GA_TO_FC, reference.insurerId());
+        condition.setContractNo(reference.contractNo());
+
+        List<ArbitrageCheckView> items = arbitrageMapper.selectByCondition(condition, 0, 20);
+        ArbitrageCheckSummary summary = arbitrageMapper.arbitrageCheckSummary(condition);
+
+        assertThat(items).singleElement()
+                .extracting(ArbitrageCheckView::getDecisionReason)
+                .isEqualTo("2회차 판정");
+        assertThat(arbitrageMapper.countByCondition(condition)).isEqualTo(1);
+        assertThat(summary.getCandidateCount()).isEqualTo(1);
+    }
+
+    /**
+     * 설명 : 재실행에서 판정이 뒤집히면 최신 판정만 남는지 검증한다 —
+     *        옛 행을 고르면 이미 해소된 검토대상이 목록에 남는다.
+     *
+     * @since 2026-08-19
+     */
+    @Test
+    void keepsLatestResultWhenRerunChangesJudgement() {
+        TestReference reference = testReference();
+        LocalDate asOfDate = LocalDate.of(2098, 11, 21);
+        insertArbitrageCheck(insertValidationRun(), reference.contractId(), asOfDate,
+                PaymentStage.GA_TO_FC, ArbitrageCheckStatus.CANDIDATE, "1회차 검토대상");
+        insertArbitrageCheck(insertValidationRun(), reference.contractId(), asOfDate,
+                PaymentStage.GA_TO_FC, ArbitrageCheckStatus.CLEAR, "2회차 이상없음");
+
+        ArbitrageCheckSearchCondition condition = condition(
+                TEST_MONTH, null, PaymentStage.GA_TO_FC, reference.insurerId());
+        condition.setContractNo(reference.contractNo());
+
+        ArbitrageCheckSummary summary = arbitrageMapper.arbitrageCheckSummary(condition);
+
+        assertThat(summary.getCandidateCount()).isZero();
+        assertThat(summary.getClearCount()).isEqualTo(1);
+    }
+
     private ArbitrageCheckSearchCondition condition(
             YearMonth month,
             ArbitrageCheckStatus status,

--- a/src/test/java/com/susukkang/fgc/dashboard/DashboardServiceIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/dashboard/DashboardServiceIntegrationTest.java
@@ -183,21 +183,43 @@ class DashboardServiceIntegrationTest {
         assertThat(augustResult.kpis().capViolation()).isEqualTo(0);
     }
 
-    // 2. 차익거래 검토대상: 월 필터 없음, dedup 없음(전부 카운트)
+    // 2. 차익거래 검토대상: 이번 달만, 계약·지급단계별 최신 1건만(#257)
     @Test
-    void summarizeCountsAllArbitrageCandidatesAcrossMonthsWithoutDedup() {
+    void summarizeCountsArbitrageCandidatesInMonthAndCollapsesReruns() {
         Long id = contractId("FGC-FGL01-202607-0003");
-        Long run1 = insertValidationRun(LocalDate.of(2026, 6, 1), 1, "COMPLETED",
+        Long juneRun = insertValidationRun(LocalDate.of(2026, 6, 1), 1, "COMPLETED",
                 OffsetDateTime.parse("2026-06-30T09:00:00+09:00"));
-        Long run2 = insertValidationRun(LocalDate.of(2026, 7, 1), 1, "COMPLETED",
+        Long julyRun1 = insertValidationRun(LocalDate.of(2026, 7, 1), 1, "COMPLETED",
                 OffsetDateTime.parse("2026-07-31T09:00:00+09:00"));
-        // 같은 계약이라도 dedup 없이 둘 다, 월도 다르지만 둘 다 잡혀야 한다(월 필터 없음).
-        insertArbitrageCheck(run1, id, LocalDate.of(2026, 6, 30), "CANDIDATE");
-        insertArbitrageCheck(run2, id, LocalDate.of(2026, 7, 31), "CANDIDATE");
+        Long julyRun2 = insertValidationRun(LocalDate.of(2026, 7, 1), 2, "COMPLETED",
+                OffsetDateTime.parse("2026-08-01T09:00:00+09:00"));
+        // 6월 판정은 7월 카드에 들어오면 안 된다(기준월 변경 시 카드를 다시 계산한다).
+        insertArbitrageCheck(juneRun, id, LocalDate.of(2026, 6, 30), "CANDIDATE");
+        // 7월을 두 번 돌렸다 — uq_arbitrage_check에 validation_run_id가 있어 행은 둘이지만
+        // 같은 계약·지급단계라 카드에는 1건으로 보여야 한다(예외함 카드와 같은 단위).
+        insertArbitrageCheck(julyRun1, id, LocalDate.of(2026, 7, 31), "CANDIDATE");
+        insertArbitrageCheck(julyRun2, id, LocalDate.of(2026, 7, 31), "CANDIDATE");
 
         DashboardSummaryResult result = dashboardService.summarize(LocalDate.of(2026, 7, 1));
 
-        assertThat(result.kpis().arbitrageCandidate()).isEqualTo(2);
+        assertThat(result.kpis().arbitrageCandidate()).isEqualTo(1);
+    }
+
+    // 재실행에서 판정이 뒤집히면 카드는 최신 판정을 따라야 한다 — 접을 때 옛 행을
+    // 고르면 이미 해소된 검토대상이 카드에 남는다.
+    @Test
+    void summarizeUsesLatestRunResultWhenRerunClearsCandidate() {
+        Long id = contractId("FGC-FGL01-202607-0004");
+        Long julyRun1 = insertValidationRun(LocalDate.of(2026, 7, 1), 3, "COMPLETED",
+                OffsetDateTime.parse("2026-07-31T09:00:00+09:00"));
+        Long julyRun2 = insertValidationRun(LocalDate.of(2026, 7, 1), 4, "COMPLETED",
+                OffsetDateTime.parse("2026-08-01T09:00:00+09:00"));
+        insertArbitrageCheck(julyRun1, id, LocalDate.of(2026, 7, 31), "CANDIDATE");
+        insertArbitrageCheck(julyRun2, id, LocalDate.of(2026, 7, 31), "CLEAR");
+
+        DashboardSummaryResult result = dashboardService.summarize(LocalDate.of(2026, 7, 1));
+
+        assertThat(result.kpis().arbitrageCandidate()).isEqualTo(0);
     }
 
     // 3. 대사 불일치: 정산월·지급단계·보험사별 최신 run만, MATCHED 제외
@@ -249,10 +271,10 @@ class DashboardServiceIntegrationTest {
         assertThat(result.kpis().openException()).isEqualTo(2);
     }
 
-    // 6. 월 필터가 있는 KPI(1,200%·대사불일치)는 미래월(2099-01)에 0이어야 한다.
-    // journalImbalance/arbitrageCandidate/openException/recentExceptions/recentValidationRuns는
+    // 6. 월 필터가 있는 KPI(1,200%·차익거래·대사불일치)는 미래월(2099-01)에 0이어야 한다.
+    // journalImbalance/openException/recentExceptions/recentValidationRuns는
     // 설계상 월 필터가 없어(각 Mapper 주석 참고 — "월 필터: 없음") 로컬 dev DB에 이미
-    // 존재하는 시드 데이터(예: arbitrage_check의 CANDIDATE 5건)를 그대로 반영한다 — 그래서
+    // 존재하는 시드 데이터를 그대로 반영한다 — 그래서
     // journalImbalance는 이 테스트에서 단언하지 않는다(월과 무관하게 vw_journal_imbalance
     // 전체를 세므로, "미래월이라 0"이라는 근거가 없다. 실제로 0건인지는 4번
     // summarizeCountsJournalImbalance()가 별도로 검증한다). 리스트도 "비어 있다"를
@@ -266,6 +288,7 @@ class DashboardServiceIntegrationTest {
 
         assertThat(result.kpis().capViolation()).isEqualTo(0);
         assertThat(result.kpis().capWarning()).isEqualTo(0);
+        assertThat(result.kpis().arbitrageCandidate()).isEqualTo(0);
         assertThat(result.kpis().reconciliationMismatch()).isEqualTo(0);
         assertThat(result.recentExceptions()).isNotNull();
         assertThat(result.recentValidationRuns()).isNotNull();

--- a/src/test/java/com/susukkang/fgc/dashboard/service/DashboardServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/dashboard/service/DashboardServiceImplTest.java
@@ -40,7 +40,7 @@ class DashboardServiceImplTest {
         // 6개 값을 서로 다르게 줘서, 조립 순서가 하나라도 틀리면 바로 드러나게 함
         when(dashboardMapper.countCapViolation(month)).thenReturn(1L);
         when(dashboardMapper.countCapWarning(month)).thenReturn(2L);
-        when(dashboardMapper.countArbitrageCandidate()).thenReturn(3L);
+        when(dashboardMapper.countArbitrageCandidate(month)).thenReturn(3L);
         when(dashboardMapper.countReconciliationMismatch(month)).thenReturn(4L);
         when(dashboardMapper.countJournalImbalance()).thenReturn(5L);
         when(dashboardMapper.countOpenException()).thenReturn(6L);
@@ -60,7 +60,9 @@ class DashboardServiceImplTest {
         assertThat(result.recentValidationRuns()).isEmpty();
     }
 
-    // arbitrageCandidate/journalImbalance/openException은 월과 무관해야함
+    // journalImbalance/openException은 월과 무관해야함.
+    // arbitrageCandidate는 화면정의서 DASH-W01 KPI 표가 "기준월 변경 → 6장 카드를 다시 계산"
+    // 이라고 못박으므로 1,200%·대사불일치와 같이 기준월을 받아야 한다(#257).
     @Test
     void summarizeCallsMonthIndependentCountsWithoutMonthParameter() {
         LocalDate month = LocalDate.of(2026, 7, 1);
@@ -69,11 +71,11 @@ class DashboardServiceImplTest {
 
         dashboardService.summarize(month);
 
-        org.mockito.Mockito.verify(dashboardMapper).countArbitrageCandidate();
         org.mockito.Mockito.verify(dashboardMapper).countJournalImbalance();
         org.mockito.Mockito.verify(dashboardMapper).countOpenException();
         org.mockito.Mockito.verify(dashboardMapper).countCapViolation(month);
         org.mockito.Mockito.verify(dashboardMapper).countCapWarning(month);
+        org.mockito.Mockito.verify(dashboardMapper).countArbitrageCandidate(month);
         org.mockito.Mockito.verify(dashboardMapper).countReconciliationMismatch(month);
     }
 


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* QA-05 시연 점검 중 발견한 차익거래 검토대상 10건/5건 불일치 수정.
* 대시보드와 ARB-W01이 재실행 행을 중복으로 세던 것이 원인.

## 🔗 2. 관련 이슈

* Closes #275 

## 🛠 3. 구현 내용

* 고친 것:
  * DashboardMapper — 월 필터 + DISTINCT ON (contract_id, payment_stage) 최신 1건. countArbitrageCandidate(month) 로 시그니처 변경, DashboardServiceImpl 배선. 
  * ArbitrageMapper — <sql id="latestArbitrageCheck"> 하나 만들어 목록·요약·페이징·계약별 시계열 4곳에 적용. as_of_date 를 접기 키에 넣어, vw_latest_cap_check 가 겪던 "전체 기간 최신을 먼저 골라 이번 달 판정이 사라지는" 함정을 피했습니다. 
  * V33__arbitrage_check_month_latest_index.sql — 쿼리 모양에 맞춘 인덱스. 월 필터 없음을 전제로 만들었던 ix_arbitrage_check_candidate 는 DROP. 
  * 테스트 — ...WithoutDedup(2건 단언)은 잘못된 동작을 고정하고 있어 명세대로 다시 썼고, 재실행 접기 + 판정 뒤집힘 케이스 4개를 추가했습니다. 
* 검증 (실 DB): 대시보드 5 / ARB-W01 검토대상 5 · 자료부족 1 / 예외함 5 — 전부 일치. --tests '*rbitrage*' '*ashboard*' '*ExceptionCase*' BUILD SUCCESSFUL.

부수 발견 하나: src/test/resources/application-test.yml 은 jdbc:tc: (Testcontainers) 인데 ./gradlew test 가 로컬 dev DB(fgc-db)에 V33 을 적용했습니다. 일부 통합 테스트가 test 프로파일을 안 타고 로컬 DB를 직접 쓰고 있다는 뜻입니다 — QA-05 범위 밖이라 건드리지 않았지만, 별도 이슈로 볼 만합니다.

## 🗄️ 4. DB / Flyway 변경

* [ ] DB 변경 없음
* [x] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [x] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## ✅ 5. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [x] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음

