### PR TITLE
[Refactor] BASE-W01 긴 값 표시 및 반응형 보완 (#138)

### DIFF
--- a/src/main/resources/static/css/common/components.css
+++ b/src/main/resources/static/css/common/components.css
@@ -573,6 +573,85 @@ a.kpi-card:active {
   background: var(--color-action-subtle);
 }
 
+.table-cell-disclosure {
+  min-width: 0;
+  white-space: normal;
+}
+
+.table-cell-preview,
+.table-cell-full {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.table-cell-preview {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.table-cell-preview.is-single-line {
+  -webkit-line-clamp: 1;
+}
+
+.table-cell-details {
+  margin-top: var(--space-1);
+}
+
+.table-cell-details summary {
+  display: inline-flex;
+  min-height: 1.5rem;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--color-text-link);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  list-style: none;
+}
+
+.table-cell-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.table-cell-details summary:focus-visible {
+  border-radius: var(--radius-4);
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+}
+
+.table-cell-less {
+  display: none;
+}
+
+.table-cell-chevron {
+  font-size: 1rem;
+  transition: transform var(--transition-fast);
+}
+
+.table-cell-details[open] .table-cell-more {
+  display: none;
+}
+
+.table-cell-details[open] .table-cell-less {
+  display: inline;
+}
+
+.table-cell-details[open] .table-cell-chevron {
+  transform: rotate(180deg);
+}
+
+.table-cell-full {
+  margin-top: var(--space-1);
+  padding: var(--space-2);
+  border-radius: var(--radius-4);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-subtle);
+  line-height: 1.25rem;
+  white-space: pre-wrap;
+}
+
 .pagination-controls {
   display: flex;
   align-items: center;

--- a/src/main/resources/static/css/features/base.css
+++ b/src/main/resources/static/css/features/base.css
@@ -109,6 +109,14 @@
   margin-inline: var(--space-6);
 }
 
+.data-table td.base-disclosure-cell {
+  padding-block: var(--space-2);
+  overflow: visible;
+  vertical-align: middle;
+  text-overflow: clip;
+  white-space: normal;
+}
+
 .base-code-label,
 .base-secondary-line {
   display: block;
@@ -142,6 +150,18 @@
   white-space: normal;
 }
 
+@media (max-width: 63.9375rem) {
+  .base-filter-form .field {
+    width: 100%;
+    flex: none;
+  }
+
+  .base-filter-actions {
+    width: 100%;
+    margin-left: 0;
+  }
+}
+
 @media (max-width: 47.9375rem) {
   .base-page-header {
     align-items: flex-start;
@@ -168,7 +188,6 @@
   }
 
   .base-filter-form .field,
-  .base-filter-actions,
   .base-filter-actions .button {
     width: 100%;
   }

--- a/src/main/resources/static/js/features/base/base-list.js
+++ b/src/main/resources/static/js/features/base/base-list.js
@@ -54,6 +54,18 @@
     return value === null || value === undefined || value === "" ? (fallback || "—") : escapeHtml(value);
   }
 
+  function tableCellDisclosure(value, limit, singleLine) {
+    var text = value === null || value === undefined || value === "" ? "—" : String(value);
+    var safeText = escapeHtml(text);
+    if (text.length <= limit) return safeText;
+    return '<div class="table-cell-disclosure">' +
+      '<span class="table-cell-preview' + (singleLine ? " is-single-line" : "") + '">' + safeText + "</span>" +
+      '<details class="table-cell-details"><summary>' +
+      '<span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span>' +
+      '<span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span>' +
+      '</summary><p class="table-cell-full">' + safeText + "</p></details></div>";
+  }
+
   function booleanLabel(value) {
     return value === true ? "예" : value === false ? "아니오" : "—";
   }
@@ -127,10 +139,10 @@
 
   function organizationRow(item) {
     return "<tr>" +
-      '<td class="tabular-nums">' + display(item.organizationCode) + "</td>" +
-      "<td>" + display(item.organizationName) + "</td>" +
+      '<td class="tabular-nums base-disclosure-cell">' + tableCellDisclosure(item.organizationCode, 20, true) + "</td>" +
+      '<td class="base-disclosure-cell">' + tableCellDisclosure(item.organizationName, 24, true) + "</td>" +
       "<td>" + display(item.organizationTypeLabel) + ' <span class="base-code-label">' + display(item.organizationType) + "</span></td>" +
-      "<td>" + display(item.parentName) + "</td>" +
+      '<td class="base-disclosure-cell">' + tableCellDisclosure(item.parentName, 24, true) + "</td>" +
       '<td class="tabular-nums">' + display(item.effectiveFrom) + "</td>" +
       '<td class="tabular-nums">' + display(item.effectiveTo) + "</td>" +
       "<td>" + statusBadge(item.activeYn, "사용", "사용중지") + "</td></tr>";
@@ -138,8 +150,8 @@
 
   function insurerRow(item) {
     return "<tr>" +
-      '<td class="tabular-nums">' + display(item.insurerCode) + "</td>" +
-      "<td>" + display(item.insurerName) + "</td>" +
+      '<td class="tabular-nums base-disclosure-cell">' + tableCellDisclosure(item.insurerCode, 20, true) + "</td>" +
+      '<td class="base-disclosure-cell">' + tableCellDisclosure(item.insurerName, 24, true) + "</td>" +
       "<td>" + display(item.insurerTypeLabel) + ' <span class="base-code-label">' + display(item.insurerType) + "</span></td>" +
       "<td>" + statusBadge(item.activeYn, "사용", "사용중지") + "</td></tr>";
   }
@@ -148,9 +160,9 @@
     var salesPeriod = display(item.salesStartDate) + " ~ " + display(item.salesEndDate, "현재");
     var documentVersion = display(item.basicDocumentVersion) + '<span class="base-secondary-line">' + display(item.basicDocumentDate) + "</span>";
     return "<tr>" +
-      '<td class="tabular-nums">' + display(item.insurerProductCode) + "</td>" +
-      "<td>" + display(item.productName) + "</td>" +
-      '<td class="tabular-nums">' + display(item.standardProductCode) + "</td>" +
+      '<td class="tabular-nums base-disclosure-cell">' + tableCellDisclosure(item.insurerProductCode, 20, true) + "</td>" +
+      '<td class="base-disclosure-cell">' + tableCellDisclosure(item.productName, 28, false) + "</td>" +
+      '<td class="tabular-nums base-disclosure-cell">' + tableCellDisclosure(item.standardProductCode, 20, true) + "</td>" +
       "<td>" + display(item.productGroupCode) + "</td>" +
       '<td class="tabular-nums">' + display(item.offeringVersion) + "</td>" +
       '<td class="tabular-nums">' + salesPeriod + "</td>" +
@@ -170,10 +182,10 @@
       ? '<span class="status-badge status-badge-warning">대상</span><span class="base-secondary-line">' + display(item.newcomerSupportEndDate) + "까지</span>"
       : '<span class="status-badge status-badge-neutral">비대상</span>';
     return "<tr>" +
-      '<td class="tabular-nums">' + display(item.agentCode) + "</td>" +
+      '<td class="tabular-nums base-disclosure-cell">' + tableCellDisclosure(item.agentCode, 20, true) + "</td>" +
       "<td>" + display(item.agentName) + "</td>" +
       "<td>" + display(item.rankLabel) + ' <span class="base-code-label">' + display(item.rankCode) + "</span></td>" +
-      "<td>" + display(item.organizationName) + '<span class="base-secondary-line tabular-nums">' + display(item.organizationCode) + "</span></td>" +
+      '<td class="base-disclosure-cell">' + tableCellDisclosure(item.organizationName, 24, true) + '<span class="base-secondary-line tabular-nums">' + display(item.organizationCode) + "</span></td>" +
       '<td class="tabular-nums">' + display(item.appointmentDate) + "</td>" +
       '<td class="tabular-nums">' + display(item.terminationDate) + "</td>" +
       "<td>" + statusBadge(isActiveStatus, item.agentStatusLabel || "활동", item.agentStatusLabel || "비활동") +
@@ -185,8 +197,8 @@
 
   function commissionItemRow(item) {
     return "<tr>" +
-      '<td class="tabular-nums">' + display(item.itemCode) + "</td>" +
-      "<td>" + display(item.itemName) + "</td>" +
+      '<td class="tabular-nums base-disclosure-cell">' + tableCellDisclosure(item.itemCode, 18, true) + "</td>" +
+      '<td class="base-disclosure-cell">' + tableCellDisclosure(item.itemName, 28, false) + "</td>" +
       "<td>" + cashflowBadge(item.cashflowType) + "</td>" +
       "<td>" + display(commissionItemCategory(item)) + "</td>" +
       '<td class="tabular-nums">' + display(item.effectiveFrom) + "</td>" +

--- a/src/main/resources/templates/base/index.html
+++ b/src/main/resources/templates/base/index.html
@@ -12,10 +12,6 @@
   <header class="page-header base-page-header">
     <div class="page-header-copy">
       <h1 class="page-title">기준정보 조회</h1>
-      <p class="page-description">
-        계약·지급을 등록할 때 사용하는 조직, 보험회사, 상품 판매버전, 설계사 정보를 조회합니다.
-        1차에서는 조회만 제공하며 등록·수정 기능은 제공하지 않습니다.
-      </p>
     </div>
     <p class="base-as-of-summary">
       기본 조회 기준일
@@ -198,8 +194,38 @@
             <thead><tr><th scope="col">항목코드</th><th scope="col">항목명</th><th scope="col">지급/차감</th><th scope="col">분류</th><th scope="col">적용 시작일</th><th scope="col">적용 종료일</th></tr></thead>
             <tbody data-base-body="commission-item">
             <tr th:each="item : ${commissionItems}">
-              <td class="tabular-nums" th:text="${item.itemCode()}">BASE_COMMISSION</td>
-              <td th:text="${item.itemName()}">FC 기본수수료</td>
+              <td class="tabular-nums base-disclosure-cell">
+                <span th:if="${#strings.isEmpty(item.itemCode()) or #strings.length(item.itemCode()) <= 18}"
+                      th:text="${item.itemCode()} ?: '-'">BASE_COMMISSION</span>
+                <div class="table-cell-disclosure"
+                     th:if="${!#strings.isEmpty(item.itemCode()) and #strings.length(item.itemCode()) > 18}">
+                  <span class="table-cell-preview is-single-line" th:text="${item.itemCode()}">COMMISSION_ITEM_CODE</span>
+                  <details class="table-cell-details">
+                    <summary>
+                      <span class="table-cell-more">전체 보기</span>
+                      <span class="table-cell-less">접기</span>
+                      <span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span>
+                    </summary>
+                    <p class="table-cell-full" th:text="${item.itemCode()}">COMMISSION_ITEM_CODE</p>
+                  </details>
+                </div>
+              </td>
+              <td class="base-disclosure-cell">
+                <span th:if="${#strings.isEmpty(item.itemName()) or #strings.length(item.itemName()) <= 28}"
+                      th:text="${item.itemName()} ?: '-'">FC 기본수수료</span>
+                <div class="table-cell-disclosure"
+                     th:if="${!#strings.isEmpty(item.itemName()) and #strings.length(item.itemName()) > 28}">
+                  <span class="table-cell-preview" th:text="${item.itemName()}">수수료 항목명</span>
+                  <details class="table-cell-details">
+                    <summary>
+                      <span class="table-cell-more">전체 보기</span>
+                      <span class="table-cell-less">접기</span>
+                      <span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span>
+                    </summary>
+                    <p class="table-cell-full" th:text="${item.itemName()}">수수료 항목명</p>
+                  </details>
+                </div>
+              </td>
               <td><span class="status-badge"
                         th:classappend="${item.cashflowType() == 'PAYMENT' ? ' status-badge-success' : (item.cashflowType() == 'DEDUCTION' ? ' status-badge-warning' : ' status-badge-neutral')}"
                         th:text="${item.cashflowType() == 'PAYMENT' ? '지급' : (item.cashflowType() == 'DEDUCTION' ? '차감' : item.cashflowType())}">지급</span></td>

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -234,6 +234,8 @@ class PublishingTemplateStructureTest {
     void baseReferenceScreenUsesSeparatedApiAndPageScripts() throws IOException {
         assertThat(resource("templates/base/index.html"))
                 .contains("class=\"page-header base-page-header\"")
+                .doesNotContain("page-description")
+                .doesNotContain("fgc-page-desc")
                 .doesNotContain("class=\"guidance")
                 .contains("class=\"tab-list\"")
                 .contains("class=\"tab-panel base-panel\"")
@@ -251,6 +253,9 @@ class PublishingTemplateStructureTest {
                 .contains("적용 시작일")
                 .contains("적용 종료일")
                 .contains("status-badge-success")
+                .contains("class=\"table-cell-disclosure\"")
+                .contains("class=\"table-cell-more\">전체 보기")
+                .contains("class=\"table-cell-less\">접기")
                 .doesNotContain("class=\"surface tab-panel base-panel\"")
                 .doesNotContain("base-panel-note")
                 .doesNotContain("<script>")
@@ -274,8 +279,17 @@ class PublishingTemplateStructureTest {
                 .contains("DEDUCTION: [\"차감\", \"status-badge-warning\"]")
                 .contains("SETTLEMENT_SUPPORT: \"정착지원\"")
                 .contains("NEWCOMER_SUPPORT: \"신인지원\"")
+                .contains("function tableCellDisclosure(")
+                .contains("tableCellDisclosure(item.itemCode, 18, true)")
+                .contains("table-cell-preview")
+                .contains("base-disclosure-cell")
                 .contains("aria-busy")
                 .doesNotContain("fetch(");
+
+        assertThat(resource("static/css/common/components.css"))
+                .contains(".table-cell-disclosure")
+                .contains(".table-cell-details[open] .table-cell-less")
+                .contains(".table-cell-full");
 
         assertThat(resource("templates/layout/default.html"))
                 .contains("/css/features/base.css")
@@ -284,6 +298,7 @@ class PublishingTemplateStructureTest {
 
         assertThat(resource("static/css/features/base.css"))
                 .contains(".base-page")
+                .contains(".data-table td.base-disclosure-cell")
                 .contains("@media (max-width: 47.9375rem)")
                 .doesNotContain(".base-information-banner")
                 .doesNotContain(".base-panel-note");


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- BASE-W01의 불필요한 Page Description을 제거했습니다.
- 표의 긴 코드와 명칭을 `전체 보기 / 접기` 방식으로 확인할 수 있도록 공통 disclosure 구조를 적용했습니다.
- 900px 이하에서 조회 조건 영역이 과도하게 늘어나는 반응형 레이아웃을 보완했습니다.

## 🔗 2. 관련 이슈

- Refs #138

## 🛠 3. 구현 내용

- 조직·보험회사·상품·설계사·수수료 항목의 긴 코드 및 명칭에 공통 Table Cell Disclosure를 적용했습니다.
- 짧은 값은 기존처럼 바로 표시하고, 긴 값에만 `전체 보기 / 접기` 컨트롤이 나타나도록 처리했습니다.
- 수수료 항목의 서버 렌더링과 API 재조회 렌더링에서 동일한 표시 구조를 사용하도록 맞췄습니다.
- 1024px 이하에서 BASE 전용 `flex-basis`가 세로 높이로 적용되던 문제를 범위 한정 CSS로 수정했습니다.
- 기존 Thymeleaf 바인딩, 조회 API, 필터, 페이징 및 Status Badge 동작은 유지했습니다.
- 퍼블리싱 구조 테스트에 Page Description 제거, Disclosure 구조 및 공통 스타일 검증을 추가했습니다.

## 🧪 4. 테스트 방법

1. `./gradlew bootRun --args='--server.port=18083'`으로 애플리케이션을 실행합니다.
2. `/base`에 접속해 조직·보험회사·상품·설계사·수수료 항목 탭의 조회 및 초기화 동작을 확인합니다.
3. 수수료 항목의 `MAINTENANCE_COMMISSION`, `MANAGEMENT_COMMISSION`에서 `전체 보기 / 접기` 동작을 확인합니다.
4. 1440px, 900px, 720px에서 본문 가로 넘침과 Filter Bar 및 테이블 내부 스크롤을 확인합니다.
5. 아래 검증 명령을 실행합니다.

```bash
node --check src/main/resources/static/js/features/base/base-list.js
git diff --check
./gradlew test
```

## 🗄️ 5. DB / Flyway 변경

- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

- 없음

## 📋 6. 리뷰 요구사항

- 긴 값에만 `전체 보기 / 접기`가 노출되고 짧은 값에는 불필요한 컨트롤이 표시되지 않는지 확인 부탁드립니다.
- 900px 이하에서 조회 조건 영역이 과도하게 늘어나지 않는지 확인 부탁드립니다.
- 공통 `.table-cell-disclosure` 스타일이 다른 화면의 동일 컴포넌트와 일관된지 확인 부탁드립니다.
- EXCP 관련 PR에도 동일 공통 스타일 변경이 포함됐다면, 먼저 병합되는 PR을 기준으로 중복 변경을 정리해야 합니다.

## ✅ 7. 체크리스트

- [x] `develop` 최신 내용을 반영했습니다.
- [x] 로컬 빌드에 성공했습니다.
- [x] 애플리케이션 실행을 확인했습니다.
- [x] 관련 기능을 직접 테스트했습니다.
- [x] 테스트 코드가 필요한 경우 작성했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

- BASE-W01 Page Description 제거
- 긴 코드·명칭의 `전체 보기 / 접기` UI 추가
- 900px·720px 조회 조건 및 테이블 반응형 레이아웃 보완

## 💬 9. 참고 사항

- 백엔드 Controller, Service, Mapper, API 및 DB 구조는 변경하지 않았습니다.
- BASE-W01은 조회 전용 화면이므로 동작 성공 Toast는 추가하지 않았습니다.
- `./gradlew test` 전체 테스트가 통과했습니다.