### PR TITLE
[Refactor] POL-W01 긴 값 표시 및 반응형 보완 (#138)

### DIFF
--- a/src/main/resources/static/css/features/policy.css
+++ b/src/main/resources/static/css/features/policy.css
@@ -49,6 +49,15 @@
 .policy-col-status { width: 6rem; }
 .policy-col-reference { width: 11.5rem; }
 
+.data-table td.policy-disclosure-cell {
+  height: auto;
+  padding-block: var(--space-2);
+  overflow: visible;
+  vertical-align: middle;
+  text-overflow: clip;
+  white-space: normal;
+}
+
 .policy-row {
   cursor: pointer;
 }
@@ -169,6 +178,11 @@
 }
 
 @media (max-width: 47.9375rem) {
+  .policy-page-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
   .policy-date-field {
     width: 100%;
   }

--- a/src/main/resources/static/js/features/policy/policy-list.js
+++ b/src/main/resources/static/js/features/policy/policy-list.js
@@ -14,6 +14,37 @@
     return value == null || value === "" ? "-" : escapeHtml(value);
   }
 
+  function tableCellDisclosure(value, limit, singleLine) {
+    var text = value == null || value === "" ? "-" : String(value);
+    var safeText = escapeHtml(text);
+    if (text.length <= limit) return safeText;
+    return "<div class='table-cell-disclosure'>"
+        + "<span class='table-cell-preview" + (singleLine ? " is-single-line" : "") + "'>" + safeText + "</span>"
+        + "<details class='table-cell-details' hidden><summary>"
+        + "<span class='table-cell-more'>전체 보기</span><span class='table-cell-less'>접기</span>"
+        + "<span class='material-symbols-rounded table-cell-chevron' aria-hidden='true'>expand_more</span>"
+        + "</summary><p class='table-cell-full'>" + safeText + "</p></details></div>";
+  }
+
+  function syncTableCellDisclosures(scope) {
+    (scope || document).querySelectorAll(".table-cell-disclosure").forEach(function (disclosure) {
+      var preview = disclosure.querySelector(".table-cell-preview");
+      var details = disclosure.querySelector(".table-cell-details");
+      if (!preview || !details || preview.clientWidth === 0) return;
+
+      var isTruncated = preview.scrollWidth > preview.clientWidth + 1
+          || preview.scrollHeight > preview.clientHeight + 1;
+      details.hidden = !isTruncated;
+      if (!isTruncated) details.open = false;
+    });
+  }
+
+  function scheduleDisclosureSync(scope) {
+    window.requestAnimationFrame(function () {
+      syncTableCellDisclosures(scope);
+    });
+  }
+
   function formatNumber(value, options) {
     if (value == null || value === "" || (typeof value === "string" && value.trim() === "")) return "-";
     var parsed = Number(value);
@@ -47,7 +78,12 @@
   }
 
   if (typeof module !== "undefined" && module.exports) {
-    module.exports = { formatNumber: formatNumber, formatRate: formatRate, formatRange: formatRange };
+    module.exports = {
+      formatNumber: formatNumber,
+      formatRate: formatRate,
+      formatRange: formatRange,
+      tableCellDisclosure: tableCellDisclosure
+    };
     return;
   }
 
@@ -104,13 +140,13 @@
     var rows = rules.map(function (rule) {
       return "<tr>"
           + "<td>" + escapeHtml(rule.paymentStageLabel) + "</td>"
-          + "<td>" + (rule.insurerName == null ? "전체" : escapeHtml(rule.insurerName)) + "</td>"
-          + "<td>" + (rule.productName == null ? "전체" : escapeHtml(rule.productName)) + "</td>"
+          + "<td class='policy-disclosure-cell'>" + tableCellDisclosure(rule.insurerName == null ? "전체" : rule.insurerName, 24, true) + "</td>"
+          + "<td class='policy-disclosure-cell'>" + tableCellDisclosure(rule.productName == null ? "전체" : rule.productName, 28, false) + "</td>"
           + "<td class='tabular-nums'>" + dash(rule.agentRankCode) + "</td>"
-          + "<td>" + escapeHtml(rule.itemName) + "</td>"
+          + "<td class='policy-disclosure-cell'>" + tableCellDisclosure(rule.itemName, 28, false) + "</td>"
           + "<td class='tabular-nums'>" + formatRange(rule.installmentFrom, rule.installmentTo) + "</td>"
           + "<td>" + escapeHtml(calculationType[rule.calculationType] || rule.calculationType) + "</td>"
-          + "<td class='tabular-nums'>" + escapeHtml(rule.basisCode) + "</td>"
+          + "<td class='tabular-nums policy-disclosure-cell'>" + tableCellDisclosure(rule.basisCode, 20, true) + "</td>"
           + "<td class='is-number tabular-nums'>" + formatRate(rule.ratePct) + "</td>"
           + "<td class='is-number tabular-nums'>" + formatNumber(rule.fixedAmount, { maximumFractionDigits: 0 }) + "</td>"
           + "</tr>";
@@ -137,7 +173,7 @@
           + "<td class='is-number tabular-nums'>" + escapeHtml(set.premiumMultiplier) + "</td>"
           + "<td class='is-number tabular-nums'>" + escapeHtml(set.complianceDeductionPct) + "</td>"
           + "<td class='is-number tabular-nums'>" + escapeHtml(set.warningUsagePct) + "</td>"
-          + "<td class='tabular-nums'>" + escapeHtml(set.refundAdditionCondition) + "</td>"
+          + "<td class='tabular-nums policy-disclosure-cell'>" + tableCellDisclosure(set.refundAdditionCondition, 28, false) + "</td>"
           + "</tr>";
     }).join("");
     var setHeader = "<thead><tr>"
@@ -150,11 +186,11 @@
     result += sets.map(function (set) {
       var itemRows = (set.items || []).map(function (item) {
         return "<tr>"
-            + "<td>" + escapeHtml(item.itemName) + "</td>"
+            + "<td class='policy-disclosure-cell'>" + tableCellDisclosure(item.itemName, 28, false) + "</td>"
             + "<td>" + inclusionBadge(item.inclusionStatus) + "</td>"
-            + "<td class='tabular-nums'>" + dash(item.exclusionType) + "</td>"
-            + "<td class='tabular-nums'>" + escapeHtml(item.attributionMethod) + "</td>"
-            + "<td>" + escapeHtml(item.decisionReason) + "</td>"
+            + "<td class='tabular-nums policy-disclosure-cell'>" + tableCellDisclosure(item.exclusionType, 24, true) + "</td>"
+            + "<td class='tabular-nums policy-disclosure-cell'>" + tableCellDisclosure(item.attributionMethod, 24, true) + "</td>"
+            + "<td class='policy-disclosure-cell'>" + tableCellDisclosure(item.decisionReason, 36, false) + "</td>"
             + "</tr>";
       }).join("");
       if (!itemRows) return "";
@@ -209,6 +245,7 @@
       var body = document.querySelector(target[0]);
       if (body) body.innerHTML = target[1];
     });
+    scheduleDisclosureSync(document.querySelector('[data-policy-panel]:not([hidden])'));
   }
 
   function ensureDetail() {
@@ -294,6 +331,7 @@
     document.querySelectorAll("[data-policy-panel]").forEach(function (panel) {
       panel.hidden = panel.id !== tab.getAttribute("aria-controls");
     });
+    scheduleDisclosureSync(document.getElementById(tab.getAttribute("aria-controls")));
     if (detailTabs.indexOf(tab.getAttribute("aria-controls")) >= 0) ensureDetail();
   }
 
@@ -321,4 +359,24 @@
 
   var firstRow = document.querySelector("[data-policy-row]");
   if (firstRow) selectRow(firstRow);
+  scheduleDisclosureSync(document);
+
+  window.addEventListener("load", function () {
+    syncTableCellDisclosures(document.querySelector('[data-policy-panel]:not([hidden])'));
+  }, { once: true });
+
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(function () {
+      syncTableCellDisclosures(document.querySelector('[data-policy-panel]:not([hidden])'));
+    });
+  }
+
+  var disclosureResizeFrame = null;
+  window.addEventListener("resize", function () {
+    if (disclosureResizeFrame != null) window.cancelAnimationFrame(disclosureResizeFrame);
+    disclosureResizeFrame = window.requestAnimationFrame(function () {
+      disclosureResizeFrame = null;
+      syncTableCellDisclosures(document.querySelector('[data-policy-panel]:not([hidden])'));
+    });
+  });
 })();

--- a/src/main/resources/templates/policy/list.html
+++ b/src/main/resources/templates/policy/list.html
@@ -24,10 +24,6 @@
   <header class="page-header policy-page-header">
     <div class="page-header-copy">
       <h1 class="page-title">정책 · 룰셋 조회</h1>
-      <p class="page-description">
-        수수료를 얼마나 줄지, 무엇을 1,200% 한도에 넣을지를 정해 둔 <strong>규칙표</strong>입니다.
-        계산에 쓰이는 모든 숫자는 코드가 아니라 여기서 읽습니다(COR-004).
-      </p>
     </div>
     <div class="field policy-date-field">
       <label class="field-label" for="as-of">적용 기준일</label>
@@ -81,8 +77,30 @@
                      th:aria-label="|${v.policyName()} v${v.versionNo()} 선택|"
                      data-policy-select>
             </td>
-            <td class="tabular-nums" th:text="${v.policyCode()}">REG-CAP-GA-2026-V1</td>
-            <td th:text="${v.policyName()}">정책 이름</td>
+            <td class="tabular-nums policy-disclosure-cell">
+              <span th:if="${#strings.isEmpty(v.policyCode()) or #strings.length(v.policyCode()) <= 22}"
+                    th:text="${v.policyCode()} ?: '-'">REG-CAP-GA-2026-V1</span>
+              <div class="table-cell-disclosure"
+                   th:if="${!#strings.isEmpty(v.policyCode()) and #strings.length(v.policyCode()) > 22}">
+                <span class="table-cell-preview is-single-line" th:text="${v.policyCode()}">정책코드</span>
+                <details class="table-cell-details" hidden>
+                  <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span><span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                  <p class="table-cell-full" th:text="${v.policyCode()}">정책코드</p>
+                </details>
+              </div>
+            </td>
+            <td class="policy-disclosure-cell">
+              <span th:if="${#strings.isEmpty(v.policyName()) or #strings.length(v.policyName()) <= 28}"
+                    th:text="${v.policyName()} ?: '-'">정책 이름</span>
+              <div class="table-cell-disclosure"
+                   th:if="${!#strings.isEmpty(v.policyName()) and #strings.length(v.policyName()) > 28}">
+                <span class="table-cell-preview" th:text="${v.policyName()}">정책 이름</span>
+                <details class="table-cell-details" hidden>
+                  <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span><span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                  <p class="table-cell-full" th:text="${v.policyName()}">정책 이름</p>
+                </details>
+              </div>
+            </td>
             <td th:text="${v.policyTypeLabel()}">1,200% 한도</td>
             <td><span class="status-badge" th:classappend="${v.sourceClass().badgeClass()}"
                       th:text="${v.sourceClassLabel()}">규제</span></td>
@@ -91,10 +109,18 @@
             <td class="tabular-nums" th:text="${v.effectiveTo()} ?: '계속'">계속</td>
             <td><span class="status-badge" th:classappend="${v.status().badgeClass()}"
                       th:text="${v.statusLabel()}">적용중</span></td>
-            <td>
+            <td class="policy-disclosure-cell" th:with="referenceText=${#strings.listJoin(v.regulationRefs(), ' · ')}">
               <span th:if="${#lists.isEmpty(v.regulationRefs())}" class="status-badge status-badge-neutral">근거 미기재</span>
-              <span th:unless="${#lists.isEmpty(v.regulationRefs())}" class="tabular-nums"
-                    th:text="${#strings.listJoin(v.regulationRefs(), ' · ')}">REG-08 · REG-09</span>
+              <span th:if="${!#lists.isEmpty(v.regulationRefs()) and #strings.length(referenceText) <= 28}"
+                    class="tabular-nums" th:text="${referenceText}">REG-08 · REG-09</span>
+              <div class="table-cell-disclosure"
+                   th:if="${!#lists.isEmpty(v.regulationRefs()) and #strings.length(referenceText) > 28}">
+                <span class="table-cell-preview" th:text="${referenceText}">REG-08 · REG-09</span>
+                <details class="table-cell-details" hidden>
+                  <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span><span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                  <p class="table-cell-full tabular-nums" th:text="${referenceText}">REG-08 · REG-09</p>
+                </details>
+              </div>
             </td>
           </tr>
           <tr class="policy-state-row" th:if="${#lists.isEmpty(policyVersions)}">

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -152,6 +152,8 @@ class PublishingTemplateStructureTest {
     void policyListUsesCommonComponentsWithoutInlinePresentation() throws IOException {
         assertThat(resource("templates/policy/list.html"))
                 .contains("class=\"page-header policy-page-header\"")
+                .doesNotContain("page-description")
+                .doesNotContain("fgc-page-desc")
                 .contains("class=\"field policy-date-field\"")
                 .doesNotContain("class=\"guidance")
                 .contains("class=\"tab-list\"")
@@ -162,6 +164,10 @@ class PublishingTemplateStructureTest {
                 .contains("data-policy-select")
                 .contains("colspan=\"10\"")
                 .contains("class=\"empty-state policy-empty-state\"")
+                .contains("class=\"table-cell-disclosure\"")
+                .contains("class=\"table-cell-details\" hidden")
+                .contains("class=\"table-cell-more\">전체 보기")
+                .contains("class=\"table-cell-less\">접기")
                 .doesNotContain("data-policy-row tabindex=")
                 .doesNotContain("data-policy-row aria-selected=")
                 .doesNotContain("style=")
@@ -173,7 +179,18 @@ class PublishingTemplateStructureTest {
                 .contains("signal: requestController.signal")
                 .contains("detailAbortController.abort()")
                 .contains("selector.addEventListener(\"change\"")
+                .contains("function tableCellDisclosure(")
+                .contains("function syncTableCellDisclosures(")
+                .contains("preview.scrollWidth > preview.clientWidth")
+                .contains("preview.scrollHeight > preview.clientHeight")
+                .contains("document.fonts.ready.then")
+                .contains("policy-disclosure-cell")
                 .doesNotContain("candidate.setAttribute(\"aria-selected\", isSelected");
+
+        assertThat(resource("static/css/common/components.css"))
+                .contains(".table-cell-disclosure")
+                .contains(".table-cell-details[open] .table-cell-less")
+                .contains(".table-cell-full");
 
         assertThat(resource("templates/layout/default.html"))
                 .containsPattern("(?s)<link[^>]*th:if=\"\\$\\{screenId == 'FGC-UI-POL-W01'\\}\"[^>]*th:href=\"@\\{/css/features/policy\\.css\\}\"[^>]*>")
@@ -181,7 +198,8 @@ class PublishingTemplateStructureTest {
 
         assertThat(resource("static/css/features/policy.css"))
                 .contains(".policy-page")
-                .contains(".policy-version-table");
+                .contains(".policy-version-table")
+                .contains(".data-table td.policy-disclosure-cell");
         assertThat(resource("static/js/features/policy/policy-list.js"))
                 .contains("[data-policy-tab]")
                 .contains("[data-detail-body]");

--- a/src/test/js/policy-list.test.cjs
+++ b/src/test/js/policy-list.test.cjs
@@ -1,7 +1,12 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const { formatNumber, formatRate, formatRange } = require("../../main/resources/static/js/features/policy/policy-list.js");
+const {
+  formatNumber,
+  formatRate,
+  formatRange,
+  tableCellDisclosure
+} = require("../../main/resources/static/js/features/policy/policy-list.js");
 
 test("POL-W01 displays rates to four decimal places without rounding", () => {
   assert.equal(formatRate("650.000000"), "650.0000");
@@ -24,4 +29,15 @@ test("POL-W01 renders missing or malformed policy numbers as a dash", () => {
   assert.equal(formatRange(null, null), "-");
   assert.equal(formatRange(null, 12), "- ~ 12회차");
   assert.equal(formatRange(1, null), "1 ~ -회차");
+});
+
+test("POL-W01 only provides full-view disclosure for long escaped values", () => {
+  assert.equal(tableCellDisclosure("짧은 정책명", 20, false), "짧은 정책명");
+
+  const disclosure = tableCellDisclosure("매우 긴 <정책> 이름과 판단 사유", 10, false);
+  assert.match(disclosure, /table-cell-disclosure/);
+  assert.match(disclosure, /table-cell-details' hidden/);
+  assert.match(disclosure, /전체 보기/);
+  assert.match(disclosure, /매우 긴 &lt;정책&gt; 이름과 판단 사유/);
+  assert.doesNotMatch(disclosure, /<정책>/);
 });


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- POL-W01의 불필요한 Page Description을 제거했습니다.
- 실제로 잘린 표 값에만 `전체 보기 / 접기`가 노출되도록 공통 Disclosure를 적용했습니다.
- 모바일 Page Header 정렬과 정책 상세 표의 긴 값 표시를 보완했습니다.

## 🔗 2. 관련 이슈

- Refs #138

## 🛠 3. 구현 내용

- 정책코드, 정책명, 근거, 보험사명, 상품명, 수수료 항목, 기준코드 및 판단 사유 등 긴 표 값을 공통 Table Cell Disclosure로 표시했습니다.
- 단순 문자 수뿐 아니라 실제 렌더링된 `scrollWidth`, `scrollHeight`, `clientWidth`, `clientHeight`를 비교해 값이 잘린 경우에만 `전체 보기`를 노출합니다.
- 웹폰트 로딩 전후의 글자 폭 차이로 잘리지 않은 값에 버튼이 노출되는 문제를 수정했습니다.
- 초기 렌더링에서는 Disclosure 컨트롤을 숨기고, 실제 잘림이 확인된 경우에만 활성화하도록 처리했습니다.
- 탭 전환, 화면 크기 변경, 웹폰트 로딩 완료 시 잘림 여부를 다시 판정합니다.
- 720px 이하에서 Page Header 제목과 적용 기준일을 세로·좌측 정렬하도록 보완했습니다.
- 기존 정책 행 선택, 상세 탭 Lazy Load, 공통 API Client 및 오류 Toast 동작은 유지했습니다.
- Disclosure 렌더링과 HTML Escape 및 퍼블리싱 구조 검증 테스트를 보강했습니다.

## 🧪 4. 테스트 방법

1. 애플리케이션을 실행하고 `/policies`에 접속합니다.

```bash
./gradlew bootRun
```

2. 정책 버전 목록에서 긴 정책코드 및 정책명을 확인합니다.
   - 값이 칸 안에 모두 표시되면 `전체 보기`가 나타나지 않아야 합니다.
   - 실제로 잘린 값에만 `전체 보기 / 접기`가 나타나야 합니다.

3. 정책을 선택한 후 수수료 규칙, 1,200% 룰셋, 예상 해약환급률표 탭을 확인합니다.

4. 1440px, 900px, 720px에서 본문 넘침과 테이블 내부 가로 스크롤을 확인합니다.

5. 아래 테스트를 실행합니다.

```bash
node --check src/main/resources/static/js/features/policy/policy-list.js
node --test src/test/js/policy-list.test.cjs
git diff --check
./gradlew test
```

### 테스트 결과

- JavaScript 문법 검사 통과
- JavaScript 단위 테스트 4건 통과
- POL-W01 Controller 렌더링 테스트 통과
- 퍼블리싱 구조 테스트 통과
- 전체 Gradle 테스트 통과
- 브라우저 콘솔 오류 없음

## 🗄️ 5. DB / Flyway 변경

- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

- 없음

## 📋 6. 리뷰 요구사항

- `GA-ALLOC-COMMON-2026-V1`처럼 칸 안에 전부 표시되는 값에는 `전체 보기`가 나타나지 않는지 확인 부탁드립니다.
- 수수료 규칙과 1,200% 룰셋에서 실제로 잘린 값에는 `전체 보기`가 정상적으로 나타나는지 확인 부탁드립니다.
- 웹폰트 로딩 완료 후 잘림 여부가 다시 판정되는지 확인 부탁드립니다.
- 720px에서 Page Header 제목과 적용 기준일이 좌측 정렬되는지 확인 부탁드립니다.
- BASE-W01 병합 커밋을 반영해 공통 Disclosure CSS 중복이 PR diff에서 제거됐는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

- [x] `develop` 최신 내용을 반영했습니다.
- [x] 로컬 빌드에 성공했습니다.
- [x] 애플리케이션 실행을 확인했습니다.
- [x] 관련 기능을 직접 테스트했습니다.
- [x] 테스트 코드가 필요한 경우 작성했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

- Page Description 제거
- 실제로 잘린 표 값에만 `전체 보기 / 접기` 표시
- 정책 상세 표의 긴 코드·명칭·판단 사유 표시 개선
- 720px 이하 Page Header 정렬 개선

## 💬 9. 참고 사항

- 백엔드 Controller, Service, Mapper, API 및 DB 구조는 변경하지 않았습니다.
- POL-W01은 조회 전용 화면이므로 성공 Toast는 추가하지 않았습니다.
- API 오류는 기존 공통 Toast를 계속 사용합니다.
- BASE-W01 병합 후 최신 `develop`으로 rebase했으며, 공통 Disclosure CSS 중복은 PR diff에서 제거했습니다.