### PR TITLE
test: 통합테스트 센티넬 월 충돌로 인한 flaky 실패 제거

### DIFF
--- a/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunMapperIntegrationTest.java
@@ -228,9 +228,12 @@ class ValidationRunMapperIntegrationTest {
     }
 
     @Test
-    // 조건에 맞는 실행이 없으면 빈 리스트(에러 아님)
+    // 조건에 맞는 실행이 없으면 빈 리스트(에러 아님).
+    // "아무 실행도 없는 월"이어야 하므로 다른 테스트가 커밋해 두는 월을 쓰면 안 된다 —
+    // 2099-01은 ReconciliationRunIntegrationTest가 실제로 커밋하는 월이라 실행 순서에 따라
+    // 비어 있지 않을 수 있었다(CI 2026-08-19 bee042b4). 아무도 안 쓰는 월로 옮긴다.
     void searchReturnsEmptyListWhenNoMatch() {
-        List<ValidationRunListRow> rows = validationRunMapper.search(LocalDate.of(2099, 1, 1), null, 0, 20);
+        List<ValidationRunListRow> rows = validationRunMapper.search(LocalDate.of(2094, 1, 1), null, 0, 20);
 
         assertThat(rows).isEmpty();
     }

--- a/src/test/java/com/susukkang/fgc/validation/service/ValidationRunBatchLifecycleServiceImplIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ValidationRunBatchLifecycleServiceImplIntegrationTest.java
@@ -43,7 +43,10 @@ class ValidationRunBatchLifecycleServiceImplIntegrationTest {
     // demo 시드가 만드는 user_id는 한 자릿수라 이 값과 절대 겹치지 않는다.
     private static final long NON_EXISTENT_USER_ID = 999_999_999L;
 
-    private static final LocalDate TEST_MONTH = LocalDate.of(2026, 9, 1);
+    // cleanUp()이 이 월을 통째로 지우므로(@Transactional 없이 실제 커밋한다) 이 클래스 전용 월이어야
+    // 한다 — 다른 테스트와 공유하는 월을 쓰면 남의 행까지 지우려다 FK 위반으로 DELETE가 통째로
+    // 실패하고, 그 뒤로 남은 행이 다른 테스트를 무너뜨린다(2099-01에서 실제로 발생, bee042b4).
+    private static final LocalDate TEST_MONTH = LocalDate.of(2093, 1, 1);
 
     @Autowired
     private ValidationRunBatchLifecycleService lifecycleService;

--- a/src/test/java/com/susukkang/fgc/validation/service/ValidationRunCreateServiceImplIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ValidationRunCreateServiceImplIntegrationTest.java
@@ -43,6 +43,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 class ValidationRunCreateServiceImplIntegrationTest {
 
+    // 이 클래스는 @Transactional 없이 실제 커밋하고, 아래 cleanUp()이 "월 통째로" 지운다.
+    // 그래서 센티넬 월은 이 클래스 전용이어야 한다 — 2099-01은 ReconciliationRunIntegrationTest도
+    // 쓰는 월이라, 남이 만든 실행(자식 exception_case가 달린)까지 지우려다 FK 위반으로 DELETE가
+    // 통째로 실패했다. 그러면 이 클래스가 만든 활성 MANUAL_CONTRACT 행이 남고,
+    // uq_validation_run_active_manual_contract는 월과 무관한 전역 1건 제약이라 뒤따르는 테스트가
+    // 줄줄이 무너진다(CI 2026-08-19 bee042b4에서 5건 실패). 아무도 안 쓰는 월로 옮긴다.
+    private static final LocalDate MONTHLY_MONTH = LocalDate.of(2095, 1, 1);
+    private static final LocalDate NON_MONTHLY_MONTH = LocalDate.of(2095, 2, 1);
+
     @Autowired
     private ValidationRunCreateService validationRunCreateService;
     @Autowired
@@ -51,7 +60,7 @@ class ValidationRunCreateServiceImplIntegrationTest {
     @AfterEach
     void cleanUp() {
         jdbcTemplate.update("DELETE FROM fgc.validation_run WHERE validation_month IN (?, ?)",
-                LocalDate.of(2099, 1, 1), LocalDate.of(2099, 2, 1));
+                MONTHLY_MONTH, NON_MONTHLY_MONTH);
     }
 
     private Callable<ValidationRunRow> createTask(LocalDate month, ValidationRunType runType) {
@@ -61,7 +70,7 @@ class ValidationRunCreateServiceImplIntegrationTest {
 
     @Test
     void concurrentMonthlyRunsResultInExactlyOneSuccessAndOneAlreadyRunningConflict() throws InterruptedException {
-        LocalDate month = LocalDate.of(2099, 1, 1);
+        LocalDate month = MONTHLY_MONTH;
         ExecutorService executor = Executors.newFixedThreadPool(2);
         try {
             List<Future<ValidationRunRow>> futures = executor.invokeAll(List.of(
@@ -98,7 +107,7 @@ class ValidationRunCreateServiceImplIntegrationTest {
         // 풀리면 둘 다 성공해야 한다. MANUAL_CONTRACT는 V9부터 이 시나리오가 성립하지 않으므로
         // (아래 concurrentManualContractRunsResultInExactlyOneSuccessAndOneActiveConflict 참고)
         // PRE_CONFIRM으로 이 케이스를 대신 검증한다.
-        LocalDate month = LocalDate.of(2099, 2, 1);
+        LocalDate month = NON_MONTHLY_MONTH;
         ExecutorService executor = Executors.newFixedThreadPool(2);
         try {
             List<Future<ValidationRunRow>> futures = executor.invokeAll(List.of(
@@ -130,7 +139,7 @@ class ValidationRunCreateServiceImplIntegrationTest {
     // 사전 확인이 MONTHLY와 같은 패턴으로 이를 FgcBusinessException(VRUN_001)으로 앞서 걸러낸다.
     @Test
     void concurrentManualContractRunsResultInExactlyOneSuccessAndOneActiveConflict() throws InterruptedException {
-        LocalDate month = LocalDate.of(2099, 2, 1);
+        LocalDate month = NON_MONTHLY_MONTH;
         ExecutorService executor = Executors.newFixedThreadPool(2);
         try {
             List<Future<ValidationRunRow>> futures = executor.invokeAll(List.of(


### PR DESCRIPTION
## 왜

`bee042b4`(#269 머지) CI 가 `ValidationRun*IntegrationTest` 5건으로 실패했습니다.
그런데 바로 다음 커밋 `97283829`(#270) 는 초록이고, 실패한 테스트와 #269 의 변경 파일
(CSS·JS·HTML) 은 겹치는 게 없습니다. 즉 **#269 의 회귀가 아니라 실행 순서에 따라 터지는
테스트 격리 문제**입니다.

## 원인 (CI 아티팩트의 Postgres 메시지)

```
ERROR: update or delete on table "validation_run" violates foreign key constraint
       "exception_case_validation_run_id_fkey" on table "exception_case"
Detail: Key (validation_run_id)=(42) is still referenced from table "exception_case".

ERROR: duplicate key value violates unique constraint "uq_validation_run_active_manual_contract"
Detail: Key (run_type)=(MANUAL_CONTRACT) already exists.
```

연쇄 구조 — 원인은 하나입니다.

1. `ValidationRunCreateServiceImplIntegrationTest` 는 경합 재현을 위해 `@Transactional` 을
   안 쓰고 실제 커밋한 뒤, `@AfterEach` 에서 `validation_month IN (2099-01, 2099-02)` 로
   **월을 통째로** 지웁니다.
2. 그런데 `2099-01` 은 `ReconciliationRunIntegrationTest`(비트랜잭션, 실제 커밋) 도 쓰는 월입니다.
3. 남의 실행에 `exception_case` 자식이 달려 있으면 FK 위반으로 **DELETE 가 통째로 실패** →
   자기 행도 안 지워집니다.
4. 남은 활성 `MANUAL_CONTRACT` 행이 `uq_validation_run_active_manual_contract`
   (`ON validation_run (run_type) WHERE run_type='MANUAL_CONTRACT' AND status IN ('CREATED','RUNNING')`
   — **월과 무관한 전역 1건** 제약) 를 점유 → 이후 MANUAL_CONTRACT 삽입이 전부 막힙니다.
5. 남은 `2099-01` 행 때문에 `searchReturnsEmptyListWhenNoMatch` 의 "빈 리스트" 단정도 깨집니다.

## 무엇을

이 저장소에는 이미 **통합테스트 클래스마다 자기 미래월을 하나씩 소유**하는 관행이 있습니다
(2087·2088·2091·2096·2097·2098…). 그 관행을 어긴 세 지점을 맞춥니다.

| 파일 | 변경 |
|---|---|
| `ValidationRunCreateServiceImplIntegrationTest` | `2099-01/02` → `2095-01/02` 전용월. 인라인 4곳을 `MONTHLY_MONTH` / `NON_MONTHLY_MONTH` 상수로 |
| `ValidationRunMapperIntegrationTest` | "빈 결과" 단정 월 `2099-01` → `2094-01` (아무 테스트도 커밋하지 않는 월) |
| `ValidationRunBatchLifecycleServiceImplIntegrationTest` | `TEST_MONTH` `2026-09` → `2093-01`. 비트랜잭션 + 월 통째 삭제라는 **같은 패턴의 잠재 충돌** 선제 제거 |

세 곳 모두 왜 전용월이어야 하는지를 제약명·실패 사례(`bee042b4`)까지 주석으로 남겨,
다음에 월을 재사용하려는 사람이 걸리도록 했습니다.

`ValidationRunRetryAuditTrailIntegrationTest` 는 `@Transactional` 이라 롤백됩니다 —
피해자였을 뿐이라 손대지 않았습니다.

## 검증

- 로컬 전체 스위트: **1104 tests, 0 failed, 0 errors** (`BUILD SUCCESSFUL in 2m 29s`)
- 충돌하던 4개 클래스(`Create` / `Mapper` / `RetryAudit` / `ReconciliationRun`) 동시 실행도 통과

## 범위

**운영 코드 변경 없음** — 테스트 3개 파일뿐입니다.

관련: #252 (출시 전 전수 검증 트래커), #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
