### PR TITLE
[Refactor] RECO-W02 대사 비교 상세 UI 정리

### DIFF
--- a/src/main/resources/static/css/features/reco.css
+++ b/src/main/resources/static/css/features/reco.css
@@ -177,6 +177,341 @@
   text-align: center;
 }
 
+.reco-compare-modal {
+  width: min(65rem, calc(100vw - var(--layout-sidebar-current-width) - 3rem));
+  height: min(53.75rem, calc(100dvh - 3rem));
+  border-radius: var(--radius-16);
+  transform: translateX(calc(var(--layout-sidebar-current-width) / 2));
+}
+
+.reco-compare-modal-header,
+.reco-compare-header-actions,
+.reco-compare-links,
+.reco-compare-related-row,
+.reco-compare-formula-row,
+.reco-compare-footer {
+  display: flex;
+  align-items: center;
+}
+
+.reco-compare-modal-header {
+  min-height: 4.75rem;
+  min-width: 0;
+  padding-block: var(--space-3);
+}
+
+.reco-compare-heading {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: end;
+  column-gap: var(--space-6);
+}
+
+.reco-compare-eyebrow {
+  grid-column: 1 / -1;
+  margin: 0 0 var(--space-1);
+  color: var(--color-text-link);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  line-height: 1.125rem;
+}
+
+.reco-compare-modal .modal-title {
+  font-size: 1.3125rem;
+  line-height: 1.6875rem;
+}
+
+.reco-compare-description {
+  min-width: 0;
+  margin: 0 0 0.125rem;
+  overflow: hidden;
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reco-compare-header-actions {
+  flex: 0 0 auto;
+  gap: var(--space-2);
+}
+
+.reco-compare-content {
+  display: grid;
+  min-height: 0;
+  grid-auto-rows: max-content;
+  align-content: start;
+  padding: var(--space-3) var(--space-6);
+  gap: var(--space-4);
+}
+
+.reco-compare-state {
+  min-height: 16rem;
+}
+
+.reco-compare-state.is-error {
+  color: var(--color-status-error-text);
+}
+
+.reco-compare-summary {
+  display: grid;
+  min-height: 5rem;
+  grid-template-columns: minmax(15rem, 2fr) repeat(3, minmax(7rem, 1fr)) minmax(12rem, 1.45fr);
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-12);
+  background: var(--color-bg-surface);
+}
+
+.reco-compare-summary-item {
+  display: grid;
+  min-width: 0;
+  align-content: center;
+  padding: var(--space-3) var(--space-4);
+}
+
+.reco-compare-summary-item dt {
+  margin-bottom: var(--space-1);
+  color: var(--color-text-tertiary);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  line-height: 1rem;
+}
+
+.reco-compare-summary-item dd {
+  margin: 0;
+  overflow: hidden;
+  color: var(--color-text-primary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.125rem;
+  overflow-wrap: anywhere;
+}
+
+.reco-compare-context-value {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 0.125rem var(--space-1);
+  font-size: 0.875rem;
+  line-height: 1.375rem;
+}
+
+.reco-compare-context-segment {
+  display: inline-flex;
+  gap: var(--space-1);
+  white-space: nowrap;
+}
+
+.reco-compare-match-key {
+  text-align: right;
+}
+
+.reco-compare-summary-item .reco-compare-summary-amount,
+.reco-compare-diff-grid .reco-amount-error,
+.reco-compare-diff-grid .reco-compare-reason {
+  color: var(--color-status-error-text);
+}
+
+.reco-compare-grid {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.reco-compare-side,
+.reco-compare-panel {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.reco-compare-side {
+  min-height: 21.875rem;
+  border-color: var(--color-border-subtle);
+  border-radius: var(--radius-12);
+}
+
+.reco-compare-side-header {
+  min-height: 3.25rem;
+  padding-inline: var(--space-4);
+}
+
+.reco-compare-side-expected .reco-compare-side-header {
+  background: var(--color-status-info-bg);
+}
+
+.reco-compare-side-actual .reco-compare-side-header {
+  background: var(--color-bg-subtle);
+}
+
+.reco-compare-source-id,
+.reco-compare-source-note,
+.reco-compare-related-note,
+.reco-compare-footer p {
+  color: var(--color-text-tertiary);
+  font-size: 0.6875rem;
+  line-height: 1.125rem;
+}
+
+.reco-compare-source-id {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reco-compare-empty {
+  min-height: 18rem;
+  padding: var(--space-4);
+  white-space: normal;
+}
+
+.reco-compare-source-entry + .reco-compare-source-entry {
+  border-top: var(--space-2) solid var(--color-bg-subtle);
+}
+
+.reco-compare-source-entry-title {
+  margin: 0;
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border-subtle);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-subtle);
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+}
+
+.reco-compare-source-fields {
+  margin: 0;
+  padding-inline: var(--space-4);
+}
+
+.reco-compare-source-row {
+  display: grid;
+  min-height: 2.5rem;
+  grid-template-columns: minmax(7rem, 1fr) minmax(0, 1.75fr);
+  align-items: center;
+  gap: var(--space-3);
+  border-bottom: 1px solid var(--color-border-subtle);
+  font-size: 0.6875rem;
+  line-height: 1.125rem;
+}
+
+.reco-compare-source-row dt {
+  color: var(--color-text-secondary);
+}
+
+.reco-compare-source-row dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-weight: 500;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.reco-compare-source-note {
+  margin: 0;
+  padding: 0 var(--space-4);
+}
+
+.reco-compare-diff-body {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+}
+
+.reco-compare-diff-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(7rem, 1fr)) minmax(6rem, 0.7fr) repeat(2, minmax(7rem, 1fr));
+  align-items: end;
+  gap: var(--space-3);
+  margin: 0;
+}
+
+.reco-compare-diff-grid dt {
+  margin-bottom: 0.125rem;
+  color: var(--color-text-tertiary);
+  font-size: 0.6875rem;
+  line-height: 1.125rem;
+}
+
+.reco-compare-diff-grid dd {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--color-text-primary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.25rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reco-compare-diff-grid > div:nth-child(-n + 3) dd {
+  font-size: 0.875rem;
+}
+
+.reco-compare-result-badge {
+  align-self: center;
+}
+
+.reco-compare-formula-row {
+  min-width: 0;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.reco-compare-formula,
+.reco-tolerance-note {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  line-height: 1.125rem;
+}
+
+.reco-compare-formula {
+  padding-left: var(--space-2);
+  border-left: 3px solid var(--color-status-error-text);
+  font-weight: 500;
+}
+
+.reco-tolerance-note {
+  flex: 0 0 auto;
+  color: var(--color-text-tertiary);
+  text-align: right;
+}
+
+.reco-compare-related-row {
+  min-height: 3.5rem;
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-bg-subtle);
+}
+
+.reco-compare-links {
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.reco-compare-related-note {
+  flex: 0 0 auto;
+  margin: 0;
+  text-align: right;
+}
+
+.reco-compare-footer {
+  min-height: 3.5rem;
+  justify-content: space-between;
+  padding-block: var(--space-2);
+}
+
+.reco-compare-footer p {
+  margin: 0;
+}
+
 @media (max-width: 63.9375rem) {
   .reco-summary-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -189,9 +524,38 @@
   .reco-filter-actions {
     justify-content: flex-end;
   }
+
+  .reco-compare-modal {
+    width: min(65rem, calc(100vw - var(--layout-sidebar-current-width) - 3rem));
+  }
+
+  .reco-compare-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .reco-compare-diff-grid {
+    grid-template-columns: repeat(3, minmax(7rem, 1fr));
+  }
+
+  .reco-compare-result-badge {
+    align-self: end;
+  }
+
+  .reco-compare-related-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .reco-compare-related-note {
+    text-align: left;
+  }
 }
 
 @media (max-width: 47.9375rem) {
+  .reco-compare-backdrop > div {
+    width: 100%;
+  }
+
   .reco-summary-grid {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -222,5 +586,58 @@
 
   .reco-pagination {
     justify-content: center;
+  }
+
+  .reco-compare-modal-header {
+    align-items: flex-start;
+  }
+
+  .reco-compare-heading {
+    display: block;
+  }
+
+  .reco-compare-description {
+    margin-top: var(--space-1);
+    white-space: normal;
+  }
+
+  .reco-compare-summary {
+    min-width: 0;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .reco-compare-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .reco-compare-diff-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .reco-compare-formula-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .reco-tolerance-note {
+    text-align: left;
+  }
+
+  .reco-compare-links .button {
+    width: 100%;
+  }
+
+  .reco-compare-footer {
+    align-items: flex-end;
+    flex-direction: column;
+  }
+
+  .reco-compare-modal {
+    width: 100%;
+    transform: none;
+  }
+
+  .reco-compare-footer .button {
+    width: 100%;
   }
 }

--- a/src/main/resources/static/js/features/reco/reco.js
+++ b/src/main/resources/static/js/features/reco/reco.js
@@ -324,24 +324,68 @@
 
   // ---- RECO-W02 비교 상세 모달 — IF-API-41 ----
 
-  function matchExpectedRow(match) {
-    return "<tr>" +
-      "<td>" + escapeHtml(match.dueDate || "—") + "</td>" +
-      '<td class="fgc-th-num">' + won(match.basisAmount) + "</td>" +
-      '<td class="fgc-th-num">' + (match.ratePct == null ? "—" : match.ratePct + "%") + "</td>" +
-      '<td class="fgc-th-num">' + won(match.matchedAmount) + "</td>" +
-      "</tr>";
+  function paymentStageLabel(value) {
+    if (value === "INSURER_TO_GA") return "원수사→GA";
+    if (value === "GA_TO_FC") return "GA→설계사";
+    return value || "지급단계 미확인";
   }
 
-  function matchActualRow(match) {
-    return "<tr>" +
-      "<td>" + escapeHtml(match.attributionDate || "—") + "</td>" +
-      "<td>" + escapeHtml(match.settlementMonth || "—") + "</td>" +
-      '<td class="fgc-th-num">' + won(match.matchedAmount) + "</td>" +
-      "</tr>";
+  function settlementMonth(value) {
+    return value ? String(value).slice(0, 7) : "—";
+  }
+
+  function agentLabel(agent) {
+    if (!agent) return "없음";
+    var name = agent.agentName || "이름 미확인";
+    return agent.agentCode ? name + " · " + agent.agentCode : name;
+  }
+
+  function sourceRow(label, value, tone) {
+    var valueClass = "tabular-nums" + (tone ? " " + tone : "");
+    return "<div class=\"reco-compare-source-row\"><dt>" + escapeHtml(label) +
+      '</dt><dd class="' + valueClass + '">' + escapeHtml(value) + "</dd></div>";
+  }
+
+  function expectedSource(match, data, index) {
+    var sourceLabel = match.scheduleLineId == null ? "schedule_line —" : "schedule_line #" + match.scheduleLineId;
+    return '<section class="reco-compare-source-entry">' +
+      (index > 0 ? '<h4 class="reco-compare-source-entry-title">예상 원천 ' + (index + 1) + " · " + escapeHtml(sourceLabel) + "</h4>" : "") +
+      '<dl class="reco-compare-source-fields">' +
+      sourceRow("회차", match.installmentNo == null ? "—" : match.installmentNo + "회차") +
+      sourceRow("지급예정일", match.dueDate || "—") +
+      sourceRow("수령자", agentLabel(data.expectedAgent)) +
+      sourceRow("기준금액", won(match.basisAmount)) +
+      sourceRow("적용 요율", match.ratePct == null ? "—" : match.ratePct + "%") +
+      sourceRow("예상 금액", won(match.matchedAmount)) +
+      "</dl>" +
+      '<p class="reco-compare-source-note">' + escapeHtml(sourceLabel) + " · 저장된 대사 원천</p></section>";
+  }
+
+  function actualSource(match, data, index) {
+    var sourceLabel = match.commissionTransactionId == null
+      ? "commission_transaction —"
+      : "commission_transaction #" + match.commissionTransactionId;
+    var attributionLabel = match.transactionAttributionId == null
+      ? "—"
+      : "attribution #" + match.transactionAttributionId;
+    return '<section class="reco-compare-source-entry">' +
+      (index > 0 ? '<h4 class="reco-compare-source-entry-title">실제 원천 ' + (index + 1) + " · " + escapeHtml(sourceLabel) + "</h4>" : "") +
+      '<dl class="reco-compare-source-fields">' +
+      sourceRow("회차", match.installmentNo == null ? "—" : match.installmentNo + "회차") +
+      sourceRow("정산월", settlementMonth(match.settlementMonth)) +
+      sourceRow("수령자", agentLabel(data.actualAgent)) +
+      sourceRow("귀속 ID", attributionLabel) +
+      sourceRow("실제 금액", won(match.matchedAmount), Number(data.differenceAmount || 0) !== 0 ? "reco-amount-error" : "") +
+      sourceRow("지급일", match.referenceDate || match.attributionDate || "—") +
+      "</dl>" +
+      '<p class="reco-compare-source-note">' + escapeHtml(sourceLabel) + " · 저장된 대사 원천</p></section>";
   }
 
   function renderCompareModal(data) {
+    var snapshot = data.detailSnapshot || {};
+    var stage = paymentStageLabel(snapshot.paymentStage);
+    document.getElementById("h-eyebrow").textContent =
+      "대사 결과 #" + data.reconciliationResultId + " · " + stage;
     document.getElementById("h-contract").textContent = data.contractNo || "—";
     document.getElementById("h-item").textContent = data.commissionItemName || "—";
     document.getElementById("h-inst").textContent = data.installmentNo == null ? "—" : data.installmentNo;
@@ -350,42 +394,50 @@
     document.getElementById("h-key").textContent = data.matchGroupKey || "—";
     document.getElementById("h-reason").textContent = (data.primaryReason && data.primaryReason.label) || "—";
     document.getElementById("h-diff").textContent = won(data.differenceAmount);
+    document.getElementById("h-summary-diff").textContent = won(data.differenceAmount);
 
     var matches = data.matches || [];
     var expected = matches.filter(function (m) { return m.matchRole === "EXPECTED" || m.matchRole === "BOTH"; });
     var actual = matches.filter(function (m) { return m.matchRole === "ACTUAL" || m.matchRole === "BOTH"; });
+    document.getElementById("expected-source-id").textContent = expected.length === 1 && expected[0].scheduleLineId != null
+      ? "schedule_line #" + expected[0].scheduleLineId
+      : expected.length + "개 원천";
+    document.getElementById("actual-source-id").textContent = actual.length === 1 && actual[0].commissionTransactionId != null
+      ? "commission_transaction #" + actual[0].commissionTransactionId
+      : actual.length + "개 원천";
     document.getElementById("expected-body").innerHTML = expected.length
-      ? expected.map(matchExpectedRow).join("")
-      : '<tr><td colspan="4"><div class="fgc-empty">실제 없음</div></td></tr>';
+      ? expected.map(function (match, index) { return expectedSource(match, data, index); }).join("")
+      : '<div class="empty-state reco-compare-empty">예상 없음</div>';
     document.getElementById("actual-body").innerHTML = actual.length
-      ? actual.map(matchActualRow).join("")
-      : '<tr><td colspan="3"><div class="fgc-empty">실제 없음</div></td></tr>';
+      ? actual.map(function (match, index) { return actualSource(match, data, index); }).join("")
+      : '<div class="empty-state reco-compare-empty">실제 없음</div>';
 
-    document.getElementById("diff-body").innerHTML =
-      "<tr><th>예상 금액</th><td>" + won(data.expectedTotalAmount) + "</td></tr>" +
-      "<tr><th>실제 금액</th><td>" + won(data.actualTotalAmount) + "</td></tr>" +
-      "<tr><th>차액</th><td>" + won(data.differenceAmount) + "</td></tr>" +
-      "<tr><th>결과 유형</th><td>" + resultTypeBadge(data) + "</td></tr>";
-
-    document.getElementById("tolerance-note").textContent =
-      "1차 허용오차 0원 — 1원만 달라도 " + (data.resultTypeLabel || "불일치") + "로 판정됩니다.";
+    var secondaryReasons = (data.secondaryReasons || [])
+      .map(function (reason) { return reason.label; })
+      .join(", ") || "—";
+    document.getElementById("diff-expected").textContent = won(data.expectedTotalAmount);
+    document.getElementById("diff-actual").textContent = won(data.actualTotalAmount);
+    document.getElementById("diff-result-type").innerHTML = resultTypeBadge(data);
+    document.getElementById("diff-primary-reason").textContent =
+      (data.primaryReason && data.primaryReason.label) || "—";
+    document.getElementById("diff-secondary-reason").textContent = secondaryReasons;
+    document.getElementById("difference-formula").textContent =
+      "차액 = 실제 " + won(data.actualTotalAmount) + " − 예상 " + won(data.expectedTotalAmount) +
+      " = " + won(data.differenceAmount);
+    document.getElementById("tolerance-note").textContent = "허용오차 0원 · 시스템 계산 결과";
 
     var links = document.getElementById("links");
     links.innerHTML = "";
-    if (data.contractId) {
-      links.innerHTML += '<a class="fgc-btn fgc-btn--ghost" href="/contracts/' +
-        encodeURIComponent(data.contractId) + '">계약 상세</a>';
-    }
     var scheduleHeaderId = matches
       .map(function (m) { return m.scheduleHeaderId; })
       .filter(function (id) { return id != null; })[0];
     if (scheduleHeaderId != null) {
-      links.innerHTML += '<a class="fgc-btn fgc-btn--ghost" href="/schedules/' +
-        encodeURIComponent(scheduleHeaderId) + '">예상 스케줄 상세</a>';
+      links.innerHTML += '<a class="button button-secondary" href="/schedules/' +
+        encodeURIComponent(scheduleHeaderId) + '">스케줄 상세</a>';
     }
-    links.innerHTML += '<a class="fgc-btn fgc-btn--ghost" href="/transactions">지급 건 목록</a>';
-    links.innerHTML += '<a class="fgc-btn fgc-btn--ghost" href="/journals">관련 분개(검증원장)</a>';
-    links.innerHTML += '<a class="fgc-btn fgc-btn--ghost" href="/exceptions">예외함</a>';
+    links.innerHTML += '<a class="button button-secondary" href="/transactions">지급 건 목록</a>';
+    links.innerHTML += '<a class="button button-secondary" href="/journals">관련 분개</a>';
+    links.innerHTML += '<a class="button button-secondary" href="/exceptions">예외 건</a>';
   }
 
   function setCompareModalState(mode, message) {
@@ -396,7 +448,7 @@
       content.hidden = false;
       return;
     }
-    stateBox.className = "fgc-modal__body fgc-empty" + (mode === "error" ? " is-error" : "");
+    stateBox.className = "modal-body empty-state reco-compare-state" + (mode === "error" ? " is-error" : "");
     stateBox.textContent = message;
     stateBox.hidden = false;
     content.hidden = true;

--- a/src/main/resources/templates/reco/compare-modal.html
+++ b/src/main/resources/templates/reco/compare-modal.html
@@ -18,85 +18,116 @@
 -->
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
-<div th:fragment="modal" class="fgc-modal publishing-modal publishing-modal-reconciliation" style="max-width:860px">
+<section th:fragment="modal" class="modal modal-large publishing-modal reco-compare-modal"
+         role="dialog" aria-modal="true" aria-labelledby="reco-compare-title">
 
-  <div class="fgc-modal__head">
-    <span class="fgc-card__title">
-      대사 비교 상세 —
-      <span class="fgc-mono" id="h-contract">—</span> ·
-      <span id="h-item">—</span> · <span id="h-inst">—</span>회차
-    </span>
-    <span id="h-type"></span>
-    <button class="icon-button" type="button" data-modal-close aria-label="팝업 닫기" data-modal-initial-focus>
-      <span class="material-symbols-outlined" aria-hidden="true">close</span>
-    </button>
-  </div>
-
-  <div id="reco-compare-state" class="fgc-modal__body fgc-empty" hidden>불러오는 중입니다.</div>
-
-  <div id="reco-compare-content" class="fgc-modal__body">
-
-    <div class="fgc-banner fgc-banner--muted">
-      <span class="material-symbols-outlined" style="font-size:18px">visibility</span>
-      <span>보기 전용 화면입니다. 여기서 금액이나 결과 유형을 고칠 수 없습니다.
-        고쳐야 한다면 원천(지급 건 또는 스케줄)으로 가서 바로잡고 다시 대사합니다.</span>
+  <header class="modal-header reco-compare-modal-header">
+    <div class="reco-compare-heading">
+      <p class="reco-compare-eyebrow" id="h-eyebrow">대사 결과 —</p>
+      <h2 class="modal-title" id="reco-compare-title">대사 비교 상세</h2>
+      <p class="reco-compare-description">예상 스케줄과 실제 지급 건을 필드별로 비교합니다.</p>
     </div>
-
-    <!-- 결과 요약 -->
-    <div style="margin-top:16px;display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:16px">
-      <div><div class="fgc-label">결과 ID</div><div class="fgc-mono" id="h-id">—</div></div>
-      <div><div class="fgc-label">매칭키</div><div class="fgc-mono" id="h-key" style="font-size:11px">—</div></div>
-      <div><div class="fgc-label">주 원인</div><div class="fgc-mono" id="h-reason">—</div></div>
-      <div><div class="fgc-label">차액</div><div id="h-diff">—</div></div>
+    <div class="reco-compare-header-actions">
+      <span id="h-type"></span>
+      <button class="icon-button" type="button" data-modal-close aria-label="팝업 닫기" data-modal-initial-focus>
+        <span class="material-symbols-rounded" aria-hidden="true">close</span>
+      </button>
     </div>
+  </header>
+
+  <div id="reco-compare-state" class="modal-body empty-state reco-compare-state" hidden>불러오는 중입니다.</div>
+
+  <div id="reco-compare-content" class="modal-body reco-compare-content">
+    <dl class="reco-compare-summary" aria-label="대사 결과 요약">
+      <div class="reco-compare-summary-item reco-compare-context-item">
+        <dt>계약 · 항목 · 회차</dt>
+        <dd class="reco-compare-context-value">
+          <span class="reco-compare-context-segment">
+            <span class="tabular-nums" id="h-contract">—</span>
+          </span>
+          <span class="reco-compare-context-segment">
+            <span aria-hidden="true">·</span>
+            <span id="h-item">—</span>
+          </span>
+          <span class="reco-compare-context-segment">
+            <span aria-hidden="true">·</span>
+            <span><span class="tabular-nums" id="h-inst">—</span>회차</span>
+          </span>
+        </dd>
+      </div>
+      <div class="reco-compare-summary-item">
+        <dt>결과 ID</dt>
+        <dd class="tabular-nums" id="h-id">—</dd>
+      </div>
+      <div class="reco-compare-summary-item">
+        <dt>차액</dt>
+        <dd class="tabular-nums reco-compare-summary-amount" id="h-summary-diff">—</dd>
+      </div>
+      <div class="reco-compare-summary-item">
+        <dt>주 원인</dt>
+        <dd id="h-reason">—</dd>
+      </div>
+      <div class="reco-compare-summary-item">
+        <dt class="reco-compare-match-key">매칭키</dt>
+        <dd class="reco-compare-match-key" id="h-key">—</dd>
+      </div>
+    </dl>
 
     <!-- 좌우 대조 — 예상/실제 행은 결과 조회 API 연동 시 채운다.
-         한쪽이 없으면 빈칸("—")이 아니라 "실제 없음"으로 적는다 -->
-    <div class="fgc-compare" style="margin-top:16px">
-      <section class="fgc-compare__side fgc-compare__side--expected">
-        <div class="fgc-compare__head">예상 — 우리가 계산한 스케줄 (schedule_line)</div>
-        <table class="fgc-table">
-          <thead><tr><th>지급예정일</th><th class="fgc-th-num">기준금액</th><th class="fgc-th-num">요율</th><th class="fgc-th-num">금액</th></tr></thead>
-          <tbody id="expected-body">
-            <tr><td colspan="4"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
-          </tbody>
-        </table>
+         한쪽이 없으면 빈칸("—")이 아니라 어느 쪽이 없는지 명시한다. -->
+    <div class="reco-compare-grid">
+      <section class="surface reco-compare-side reco-compare-side-expected" aria-labelledby="reco-expected-title">
+        <header class="surface-header reco-compare-side-header">
+          <h3 class="surface-title" id="reco-expected-title">예상</h3>
+          <span class="reco-compare-source-id" id="expected-source-id">schedule_line —</span>
+        </header>
+        <div class="reco-compare-source-list" id="expected-body">
+          <div class="empty-state reco-compare-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div>
+        </div>
       </section>
-      <section class="fgc-compare__side fgc-compare__side--actual">
-        <div class="fgc-compare__head">실제 — 확정된 지급 건 (transaction_attribution)</div>
-        <table class="fgc-table">
-          <thead><tr><th>귀속일</th><th>정산월</th><th class="fgc-th-num">금액</th></tr></thead>
-          <tbody id="actual-body">
-            <tr><td colspan="3"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
-          </tbody>
-        </table>
+      <section class="surface reco-compare-side reco-compare-side-actual" aria-labelledby="reco-actual-title">
+        <header class="surface-header reco-compare-side-header">
+          <h3 class="surface-title" id="reco-actual-title">실제</h3>
+          <span class="reco-compare-source-id" id="actual-source-id">commission_transaction —</span>
+        </header>
+        <div class="reco-compare-source-list" id="actual-body">
+          <div class="empty-state reco-compare-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div>
+        </div>
       </section>
     </div>
 
-    <!-- 차액 · 판정 -->
-    <section class="fgc-card" style="margin-top:16px">
-      <div class="fgc-card__head"><span class="fgc-card__title">차액과 판정</span></div>
-      <div class="fgc-card__body">
-        <table class="fgc-table" style="font-size:13px">
-          <tbody id="diff-body">
-            <tr><td colspan="2"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
-          </tbody>
-        </table>
-        <div class="fgc-banner fgc-banner--warn" style="margin-top:12px">
-          <span class="material-symbols-outlined" style="font-size:18px">straighten</span>
-          <!-- 허용오차 안내 문구(FGC.NOTICE.TOLERANCE)와 건별 판정 설명은 서버 렌더링으로 채운다 -->
-          <span id="tolerance-note"></span>
+    <section class="surface reco-compare-panel" aria-labelledby="reco-diff-title">
+      <div class="surface-body reco-compare-diff-body" id="diff-body">
+        <h3 class="surface-title" id="reco-diff-title">차액과 판정</h3>
+        <dl class="reco-compare-diff-grid">
+          <div><dt>예상 금액</dt><dd class="tabular-nums" id="diff-expected">—</dd></div>
+          <div><dt>실제 금액</dt><dd class="tabular-nums" id="diff-actual">—</dd></div>
+          <div><dt>차액</dt><dd class="tabular-nums reco-amount-error" id="h-diff">—</dd></div>
+          <div class="reco-compare-result-badge"><dt class="visually-hidden">결과 유형</dt><dd id="diff-result-type"></dd></div>
+          <div><dt>주 원인</dt><dd class="reco-compare-reason" id="diff-primary-reason">—</dd></div>
+          <div><dt>보조 원인</dt><dd id="diff-secondary-reason">—</dd></div>
+        </dl>
+        <div class="reco-compare-formula-row">
+          <p class="reco-compare-formula" id="difference-formula">차액 계산 결과를 불러오는 중입니다.</p>
+          <p class="reco-tolerance-note" id="tolerance-note"></p>
         </div>
       </div>
     </section>
 
-    <!-- 관련 화면 바로가기 — 스케줄·지급 건·분개·예외함·계약 링크는 결과 데이터로 채운다 -->
-    <section class="fgc-card" style="margin-top:16px">
-      <div class="fgc-card__head"><span class="fgc-card__title">관련 화면 바로가기</span></div>
-      <div class="fgc-card__body" style="display:flex;gap:8px;flex-wrap:wrap" id="links"></div>
+    <!-- 관련 화면 바로가기 — 스케줄·지급 건·분개·예외함 링크는 결과 데이터로 채운다 -->
+    <section class="surface reco-compare-panel" aria-labelledby="reco-links-title">
+      <div class="surface-body reco-compare-related-row">
+        <h3 class="surface-title" id="reco-links-title">관련 화면</h3>
+        <nav class="reco-compare-links" id="links" aria-label="관련 업무 화면"></nav>
+        <p class="reco-compare-related-note">원천 수정 후 대사를 다시 실행합니다.</p>
+      </div>
     </section>
-
   </div>
-</div>
+
+  <footer class="modal-footer reco-compare-footer">
+    <p>이 화면에는 금액·원천·결과 유형을 변경하는 기능이 없습니다.</p>
+    <button class="button button-secondary button-medium" type="button" data-modal-close>닫기</button>
+  </footer>
+</section>
 </body>
 </html>

--- a/src/main/resources/templates/reco/list.html
+++ b/src/main/resources/templates/reco/list.html
@@ -237,7 +237,7 @@
 
   <!-- RECO-W02 비교 상세 팝업 — 페이지 로드 시 숨겨서 넣어두고 JS가 JSON으로 값만 채운다
        (cap-detail 모달과 같은 관례, contract/detail.html에서도 재사용) -->
-  <div class="modal-backdrop" data-modal="reco-compare" data-close-on-backdrop="true" hidden aria-hidden="true">
+  <div class="modal-backdrop reco-compare-backdrop" data-modal="reco-compare" data-close-on-backdrop="true" hidden aria-hidden="true">
     <div th:insert="~{reco/compare-modal :: modal}"></div>
   </div>
 

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -43,10 +43,37 @@ class PublishingTemplateStructureTest {
 
     @Test
     void reconciliationComparisonKeepsPopupPublishingScope() throws IOException {
+        assertThat(resource("templates/reco/list.html"))
+                .contains("class=\"modal-backdrop reco-compare-backdrop\"");
+
         assertThat(resource("templates/reco/compare-modal.html"))
                 .contains("th:fragment=\"modal\"")
-                .contains("publishing-modal")
+                .contains("class=\"modal modal-large publishing-modal reco-compare-modal\"")
+                .contains("role=\"dialog\" aria-modal=\"true\"")
+                .contains("class=\"reco-compare-grid\"")
+                .contains("class=\"reco-compare-source-list\" id=\"expected-body\"")
+                .contains("class=\"reco-compare-source-list\" id=\"actual-body\"")
+                .contains("class=\"reco-compare-diff-grid\"")
+                .contains("class=\"modal-footer reco-compare-footer\"")
+                .contains("class=\"surface reco-compare-panel\"")
+                .doesNotContain("class=\"fgc-modal")
+                .doesNotContain("class=\"fgc-card")
+                .doesNotContain("class=\"fgc-table")
+                .doesNotContain("class=\"fgc-banner")
+                .doesNotContain("class=\"guidance")
+                .doesNotContain("style=")
                 .doesNotContain("<main");
+
+        assertThat(resource("static/js/features/reco/reco.js"))
+                .contains("class=\"status-badge ")
+                .contains("empty-state reco-compare-empty\">예상 없음</div>")
+                .contains("empty-state reco-compare-empty\">실제 없음</div>")
+                .contains("sourceRow(\"적용 요율\"")
+                .contains("sourceRow(\"귀속 ID\"")
+                .contains("difference-formula")
+                .contains("class=\"button button-secondary\"")
+                .doesNotContain("class=\"fgc-btn fgc-btn--ghost\"")
+                .doesNotContain("class=\"fgc-th-num\"");
     }
 
     @Test


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- RECO-W02 대사 비교 상세 팝업을 최신 Figma와 공통 UI 컴포넌트 기준으로 재구성했습니다.
- 실제 대사 결과 상세 API 응답을 유지하면서 팝업 크기, 정보 구조, 반응형 레이아웃을 개선했습니다.

## 🔗 2. 관련 이슈

- Refs #138

## 🛠 3. 구현 내용

- 공통 `Modal`, `Surface`, `Status Badge`, `Button` 컴포넌트 기반으로 팝업 구조 전환
- Guidance 제거 및 대사 결과 요약, 예상·실제 원천, 차액 판정, 관련 화면 영역 재구성
- 계약·항목·회차 정보를 하나의 문맥으로 유지하면서 값 단위 자연스러운 줄바꿈 적용
- 예상 또는 실제 원천이 없는 경우를 명확한 빈 상태로 표시
- 여러 대사 원천이 반환되는 경우 모든 원천을 누락 없이 렌더링
- 실제 API가 제공하지 않는 상태 필드는 임의로 생성하지 않도록 처리
- 1040×860px 데스크톱 팝업과 좁은 화면의 Bottom Sheet 레이아웃 구현
- Esc 닫기 및 팝업 종료 후 실행 버튼 포커스 복귀 유지
- 퍼블리싱 구조 테스트 보강

## 🧪 4. 테스트 방법

1. `./gradlew bootRun --args='--server.port=8083'`으로 애플리케이션을 실행합니다.
2. `/reconciliations`에서 대사 실행 이력 행을 선택합니다.
3. 대사 결과의 `비교 상세` 버튼을 눌러 RECO-W02 팝업을 확인합니다.
4. 예상·실제 원천, 차액 판정, 관련 화면과 빈 원천 표시를 확인합니다.
5. 1440×1024, 900×900, 720×900에서 팝업 크기와 내부 스크롤을 확인합니다.
6. `X`, 하단 `닫기`, `Esc`로 팝업이 정상 종료되는지 확인합니다.
7. `./gradlew test` 전체 테스트를 실행합니다.

## 🗄️ 5. DB / Flyway 변경

- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

- 없음

## 📋 6. 리뷰 요구사항

- 실제 대사 상세 API 응답과 예상·실제 원천 매핑이 적절한지 확인 부탁드립니다.
- 900px 이하에서 팝업 내부 스크롤과 720px Bottom Sheet 전환이 자연스러운지 확인 부탁드립니다.
- API에 없는 상태값을 화면에서 임의로 생성하지 않는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

- [x] `develop` 최신 내용을 반영했습니다.
- [x] 로컬 빌드에 성공했습니다.
- [x] 애플리케이션 실행을 확인했습니다.
- [x] 관련 기능을 직접 테스트했습니다.
- [x] 테스트 코드가 필요한 경우 작성했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

- RECO-W02 팝업을 최신 Figma 정보 구조에 맞춰 재구성했습니다.
- 데스크톱 팝업 크기를 확대하고 900px 내부 스크롤과 720px Bottom Sheet 레이아웃을 적용했습니다.
- Guidance는 확정된 화면 정책에 따라 제거했습니다.

## 💬 9. 참고 사항

- Figma에 표현된 일부 원천 상태 정보는 현재 API 응답에 존재하지 않아 화면에서 임의로 표시하지 않았습니다.
- 백엔드 API, DB, Flyway 및 인터페이스 문서는 변경하지 않았습니다.