### PR TITLE
[Refactor] CAP-W01·W02 공통 UI 및 계산근거 팝업 정리

### DIFF
--- a/src/main/resources/static/css/features/cap.css
+++ b/src/main/resources/static/css/features/cap.css
@@ -5,15 +5,7 @@
 }
 
 .cap-section-header {
-  align-items: flex-start;
-}
-
-.cap-section-description,
-.cap-modal-subtitle {
-  margin-top: var(--space-1);
-  color: var(--color-text-tertiary);
-  font-size: 0.75rem;
-  line-height: 1.125rem;
+  padding: var(--space-4) var(--space-6);
 }
 
 .cap-filter-panel,
@@ -29,6 +21,11 @@
   padding: var(--space-4) var(--space-6) var(--space-6);
 }
 
+.cap-filter-panel > .cap-section-header,
+.cap-stage-panel > .cap-section-header {
+  padding-bottom: 0;
+}
+
 .cap-filter-actions {
   display: flex;
   gap: var(--space-2);
@@ -41,10 +38,20 @@
   background: var(--color-bg-subtle);
 }
 
+.cap-filter-form .select-control {
+  min-width: 0;
+}
+
 .cap-kpi-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: var(--space-3);
+}
+
+.cap-kpi-grid.is-loading,
+.cap-stage-grid.is-loading {
+  opacity: 0.6;
+  cursor: progress;
 }
 
 .cap-kpi-card {
@@ -96,15 +103,12 @@
   font-size: 0.75rem;
 }
 
-.cap-stage-panel > .cap-section-header {
-  padding-bottom: 0;
-}
-
 .cap-stage-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--space-4);
   padding: var(--space-4) var(--space-6) var(--space-6);
+  transition: opacity var(--transition-fast);
 }
 
 .cap-stage-card {
@@ -227,33 +231,6 @@
   line-height: 1.125rem;
 }
 
-.cap-guidance {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: var(--space-3);
-  padding: var(--space-4) var(--space-6);
-  border: 1px solid var(--color-status-info-border);
-  border-radius: var(--radius-12);
-  color: var(--color-status-info-text);
-  background: var(--color-status-info-bg);
-}
-
-.cap-guidance h2 {
-  font-size: 0.8125rem;
-  line-height: 1.25rem;
-}
-
-.cap-guidance p {
-  margin-top: var(--space-1);
-  color: var(--color-text-secondary);
-  font-size: 0.75rem;
-  line-height: 1.25rem;
-}
-
-.cap-guidance code {
-  font-size: 0.6875rem;
-}
-
 .cap-table-panel {
   min-width: 0;
 }
@@ -316,6 +293,17 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.cap-contract-table td.cap-disclosure-cell,
+.cap-agent-table td.cap-disclosure-cell,
+.cap-detail-table td.cap-disclosure-cell {
+  overflow: visible;
+  white-space: normal;
+}
+
+.cap-disclosure-cell .table-cell-details {
+  white-space: normal;
 }
 
 .cap-contract-link,
@@ -412,15 +400,335 @@
 }
 
 .cap-detail-modal {
-  width: min(76rem, 100%);
+  width: min(67.5rem, 100%);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-16);
 }
 
 .cap-detail-modal .modal-body + .modal-body {
-  padding-top: 0;
+  padding-top: var(--space-3);
+}
+
+.cap-detail-modal-header {
+  min-height: 4.625rem;
+}
+
+.cap-detail-modal-heading {
+  min-width: 0;
+}
+
+.cap-detail-eyebrow {
+  color: var(--color-text-link);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.125rem;
+}
+
+.cap-detail-modal-heading .modal-title {
+  font-size: 1.375rem;
+  line-height: 1.75rem;
+}
+
+.cap-detail-footer-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: var(--space-2);
 }
 
 .cap-detail-state {
   min-height: 15rem;
+}
+
+.cap-detail {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-3);
+}
+
+.cap-detail-summary,
+.cap-detail-section {
+  min-width: 0;
+  overflow: hidden;
+  border-radius: var(--radius-12);
+}
+
+.cap-detail-summary-grid {
+  display: grid;
+  grid-template-columns: minmax(22rem, 1.9fr) repeat(3, minmax(0, 1fr));
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+}
+
+.cap-detail-summary-grid div {
+  min-width: 0;
+}
+
+.cap-detail-summary-grid dt,
+.cap-detail-count {
+  color: var(--color-text-tertiary);
+  font-size: 0.6875rem;
+  line-height: 1rem;
+}
+
+.cap-detail-summary-grid dd {
+  min-width: 0;
+  margin-top: var(--space-1);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1.25rem;
+}
+
+.cap-detail-summary-contract dd {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.cap-detail-contract-context {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  gap: var(--space-1);
+  align-items: center;
+}
+
+.cap-detail-contract-context #sum-contract {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cap-detail-contract-context #sum-stage,
+.cap-detail-contract-context > [aria-hidden="true"] {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.cap-detail-summary-contract #sum-badge {
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.cap-detail-layout {
+  display: grid;
+  grid-template-columns: 22rem minmax(0, 1fr);
+  gap: var(--space-4);
+  align-items: start;
+}
+
+.cap-detail-primary {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-4);
+}
+
+.cap-detail-section > .surface-header {
+  min-height: 2.625rem;
+  align-items: center;
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.cap-detail-step-header {
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+}
+
+.cap-detail-step-header .surface-title {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.cap-detail-count {
+  text-align: right;
+}
+
+.cap-detail-pair-table {
+  min-width: 0;
+}
+
+.cap-detail-pair-table th {
+  width: 58%;
+  padding: 0.1875rem var(--space-4);
+  border-bottom-color: var(--color-border-subtle);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-surface);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.125rem;
+}
+
+.cap-detail-pair-table td {
+  padding: 0.1875rem var(--space-4);
+  border-bottom-color: var(--color-border-subtle);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.125rem;
+  text-align: right;
+}
+
+.cap-detail-formula-body {
+  padding: var(--space-3) var(--space-4) var(--space-4);
+}
+
+.cap-detail-formula {
+  display: grid;
+  gap: var(--space-1);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-8);
+  color: var(--color-text-primary);
+  background: var(--color-bg-subtle);
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+  overflow-wrap: anywhere;
+}
+
+.cap-detail-formula strong {
+  font-size: 0.8125rem;
+}
+
+.cap-detail-formula span {
+  color: var(--color-text-secondary);
+}
+
+.cap-detail-formula em {
+  color: var(--color-status-success-text);
+  font-style: normal;
+  font-weight: 700;
+  text-align: right;
+}
+
+.cap-detail-result-gauge {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4) var(--space-4);
+}
+
+.cap-detail-gauge-heading,
+.cap-detail-final-status,
+.cap-detail-result-list div {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.cap-detail-gauge-heading {
+  color: var(--color-text-tertiary);
+  font-size: 0.6875rem;
+  line-height: 1rem;
+}
+
+.cap-detail-gauge-heading strong {
+  color: var(--color-status-success-text);
+  font-size: 0.75rem;
+}
+
+.cap-detail-gauge-track {
+  position: relative;
+  height: 0.625rem;
+  border-radius: var(--radius-full);
+  background: var(--color-bg-subtle);
+}
+
+.cap-detail-gauge-bar {
+  display: block;
+  width: 0;
+  height: 100%;
+  overflow: hidden;
+  border-radius: inherit;
+  background: var(--color-status-success-solid);
+  transition: width var(--transition-standard);
+}
+
+.cap-detail-gauge-bar.is-warning {
+  background: var(--color-status-warning-solid);
+}
+
+.cap-detail-gauge-bar.is-violation {
+  background: var(--color-status-error-solid);
+}
+
+.cap-detail-gauge-bar.is-review {
+  background: var(--color-status-review-solid);
+}
+
+.cap-detail-gauge-mark {
+  position: absolute;
+  top: -0.25rem;
+  width: 0.125rem;
+  height: 1.125rem;
+  background: var(--color-status-warning-solid);
+  transform: translateX(-50%);
+}
+
+.cap-detail-result-list {
+  display: grid;
+  gap: var(--space-1);
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+}
+
+.cap-detail-result-list dt {
+  color: var(--color-text-secondary);
+}
+
+.cap-detail-result-list dd {
+  font-weight: 600;
+}
+
+.cap-detail-final-status {
+  margin-top: var(--space-1);
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+}
+
+.cap-detail-table {
+  min-width: 39.5rem;
+}
+
+.cap-detail-lines > .data-table-viewport {
+  margin: 0 var(--space-4);
+}
+
+.cap-detail-col-seq { width: 2rem; }
+.cap-detail-col-item { width: 7rem; }
+.cap-detail-col-amount { width: 5.5rem; }
+.cap-detail-col-status { width: 5rem; }
+.cap-detail-col-reason { width: 12.5rem; }
+.cap-detail-col-evidence { width: 7.5rem; }
+
+.cap-detail-table tbody td:first-child {
+  text-align: right;
+}
+
+.cap-detail-table tfoot th,
+.cap-detail-table tfoot td {
+  min-height: 3rem;
+  padding: var(--space-3) var(--data-table-cell-padding-x);
+  border-bottom: 0;
+  background: var(--color-bg-subtle);
+  white-space: normal;
+}
+
+.cap-detail-table tfoot strong {
+  color: var(--color-action-primary);
+}
+
+@media (max-width: 63.9375rem) {
+  .cap-detail-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .cap-detail-primary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .cap-detail-primary > :last-child {
+    grid-column: 1 / -1;
+  }
 }
 
 @media (max-width: 79.9375rem) {
@@ -474,7 +782,8 @@
   }
 
   .cap-stage-grid,
-  .cap-filter-form {
+  .cap-filter-form,
+  .cap-section-header {
     padding-right: var(--space-4);
     padding-left: var(--space-4);
   }
@@ -483,11 +792,43 @@
     padding: var(--space-4);
   }
 
-  .cap-guidance {
-    padding: var(--space-4);
-  }
-
   .pagination {
     justify-content: center;
   }
+
+  .cap-detail-lines-header {
+    align-items: flex-start;
+    flex-direction: column;
+    padding-top: var(--space-3);
+    padding-bottom: var(--space-3);
+  }
+
+  .cap-detail-summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .cap-detail-summary-contract {
+    grid-column: 1 / -1;
+  }
+
+  .cap-detail-primary {
+    grid-template-columns: 1fr;
+  }
+
+  .cap-detail-primary > :last-child {
+    grid-column: auto;
+  }
+
+  .cap-detail-footer-actions,
+  .cap-detail-footer-actions .button {
+    width: 100%;
+  }
+
+}
+
+@media (max-width: 31.25rem) {
+  .cap-detail-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
 }

--- a/src/main/resources/static/js/features/cap/cap-list.js
+++ b/src/main/resources/static/js/features/cap/cap-list.js
@@ -73,10 +73,42 @@
     return value == null || value === "" ? "—" : String(value) + "%";
   }
 
+  function tableCellDisclosure(value, singleLine, previewHtml) {
+    var text = value == null || value === "" ? "—" : String(value);
+    var safeText = escapeHtml(text);
+    return '<div class="table-cell-disclosure">' +
+      '<span class="table-cell-preview' + (singleLine ? " is-single-line" : "") + '">' + (previewHtml || safeText) + '</span>' +
+      '<details class="table-cell-details" hidden><summary>' +
+      '<span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span>' +
+      '<span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span>' +
+      '</summary><p class="table-cell-full">' + safeText + '</p></details></div>';
+  }
+
+  function syncTableCellDisclosures(scope) {
+    (scope || document).querySelectorAll(".table-cell-disclosure").forEach(function (disclosure) {
+      var preview = disclosure.querySelector(".table-cell-preview");
+      var details = disclosure.querySelector(".table-cell-details");
+      if (!preview || !details || preview.clientWidth === 0) return;
+      var isTruncated = preview.scrollWidth > preview.clientWidth + 1 || preview.scrollHeight > preview.clientHeight + 1;
+      details.hidden = !isTruncated;
+      if (!isTruncated) details.open = false;
+    });
+  }
+
+  function scheduleDisclosureSync(scope) {
+    window.requestAnimationFrame(function () { syncTableCellDisclosures(scope); });
+  }
+
   function visualWidth(value) {
     var parsed = Number(value);
     if (!Number.isFinite(parsed) || parsed <= 0) return "0%";
     return Math.min(parsed, 100) + "%";
+  }
+
+  function accessibleProgress(value) {
+    var parsed = Number(value);
+    if (!Number.isFinite(parsed)) return 0;
+    return Math.max(0, Math.min(parsed, 100));
   }
 
   function queryFromLocation() {
@@ -179,8 +211,12 @@
   }
 
   function setLoading() {
-    document.getElementById("cap-kpi-grid").setAttribute("aria-busy", "true");
-    document.getElementById("cap-stage-grid").setAttribute("aria-busy", "true");
+    var kpiGrid = document.getElementById("cap-kpi-grid");
+    var stageGrid = document.getElementById("cap-stage-grid");
+    kpiGrid.setAttribute("aria-busy", "true");
+    stageGrid.setAttribute("aria-busy", "true");
+    kpiGrid.classList.add("is-loading");
+    stageGrid.classList.add("is-loading");
     document.getElementById("cap-agent-message").textContent = "설계사별 모니터링 지표를 불러오는 중입니다.";
     document.getElementById("cap-agent-message").hidden = false;
     document.getElementById("cap-agent-table-wrap").hidden = true;
@@ -203,7 +239,11 @@
       value.textContent = "—";
     });
     document.getElementById("cap-kpi-grid").setAttribute("aria-busy", "false");
-    document.getElementById("cap-stage-grid").setAttribute("aria-busy", "false");
+    var stageGrid = document.getElementById("cap-stage-grid");
+    stageGrid.setAttribute("aria-busy", "false");
+    document.getElementById("cap-kpi-grid").classList.remove("is-loading");
+    stageGrid.classList.remove("is-loading");
+    stageGrid.innerHTML = '<div class="cap-inline-message is-error">지급단계별 집계를 불러오지 못했습니다.</div>';
     document.getElementById("cap-agent-message").textContent = "설계사별 모니터링 지표를 불러오지 못했습니다.";
     document.getElementById("cap-agent-message").hidden = false;
     document.getElementById("cap-agent-table-wrap").hidden = true;
@@ -225,17 +265,20 @@
       button.setAttribute("aria-pressed", String(button.dataset.capStatus === controls.status.value));
     });
     document.getElementById("cap-kpi-grid").setAttribute("aria-busy", "false");
+    document.getElementById("cap-kpi-grid").classList.remove("is-loading");
   }
 
   function statusBadge(item) {
-    return '<span class="status-badge ' + (STATUS_CLASS[item.resultStatus] || "status-badge-neutral") + '">' + escapeHtml(item.resultStatusLabel) + '</span>';
+    return '<span class="status-badge ' + (STATUS_CLASS[item.resultStatus] || "status-badge-neutral") + '">' + escapeHtml(item.resultStatusLabel || item.resultStatus || "—") + '</span>';
   }
 
   function contractRow(item) {
     var isAgent = item.paymentStage === "GA_TO_FC";
     var deduction = isAgent ? '<span class="cap-not-applicable">적용하지 않음</span>' : won(item.complianceDeductionAmount);
+    var contractHref = "/contracts/" + encodeURIComponent(item.contractId) + "?tab=cap";
+    var contractLink = '<a class="cap-contract-link" href="' + contractHref + '">' + escapeHtml(item.contractNo) + '</a>';
     return "<tr>" +
-      '<td><a class="cap-contract-link" href="/contracts/' + encodeURIComponent(item.contractId) + '?tab=cap">' + escapeHtml(item.contractNo) + '</a></td>' +
+      '<td class="cap-disclosure-cell">' + tableCellDisclosure(item.contractNo, true, contractLink) + '</td>' +
       '<td><span class="cap-stage-label"><span class="cap-stage-dot' + (isAgent ? " is-agent" : "") + '"></span>' + escapeHtml(item.paymentStageLabel) + '</span></td>' +
       '<td class="tabular-nums">' + escapeHtml(item.asOfDate) + '</td>' +
       '<td class="text-right tabular-nums">' + won(item.basePremiumAmount) + '</td>' +
@@ -262,6 +305,7 @@
       document.getElementById("cap-contract-body").innerHTML = data.content.map(contractRow).join("");
       message.hidden = true;
       tableWrap.hidden = false;
+      scheduleDisclosureSync(tableWrap);
     }
     renderPagination(data.page, data.totalPages);
   }
@@ -291,6 +335,7 @@
   function renderStageSummary(rows) {
     var grid = document.getElementById("cap-stage-grid");
     grid.setAttribute("aria-busy", "false");
+    grid.classList.remove("is-loading");
     if (!rows || !rows.length) {
       grid.innerHTML = '<div class="cap-inline-message">조건에 맞는 지급단계별 집계가 없습니다.</div>';
       return;
@@ -301,9 +346,10 @@
   function agentRow(agent) {
     var organization = [agent.organizationCode, agent.organizationName].filter(Boolean).join(" · ") || "—";
     var status = stageStatus(agent);
+    var agentLabel = [agent.agentName || "—", agent.agentCode].filter(Boolean).join(" · ");
     return "<tr>" +
-      '<td><strong>' + escapeHtml(agent.agentName || "—") + '</strong><br><small>' + escapeHtml(agent.agentCode || "") + '</small></td>' +
-      '<td>' + escapeHtml(organization) + '</td>' +
+      '<td class="cap-disclosure-cell">' + tableCellDisclosure(agentLabel, false) + '</td>' +
+      '<td class="cap-disclosure-cell">' + tableCellDisclosure(organization, false) + '</td>' +
       '<td class="text-right tabular-nums">' + number(agent.contractCount) + '건</td>' +
       '<td class="text-right tabular-nums">' + won(agent.limitAmountTotal) + '</td>' +
       '<td class="text-right tabular-nums">' + won(agent.includedAmountTotal) + '</td>' +
@@ -323,6 +369,7 @@
     document.getElementById("cap-agent-body").innerHTML = rows.map(agentRow).join("");
     message.hidden = true;
     tableWrap.hidden = false;
+    scheduleDisclosureSync(tableWrap);
   }
 
   function pageButton(label, page, options) {
@@ -380,50 +427,63 @@
     return "<tr><th scope=\"row\">" + escapeHtml(label) + "</th><td class=\"text-right tabular-nums\">" + escapeHtml(value) + "</td></tr>";
   }
 
-  function detailPairHtml(label, valueHtml) {
-    return "<tr><th scope=\"row\">" + escapeHtml(label) + "</th><td class=\"text-right tabular-nums\">" + valueHtml + "</td></tr>";
-  }
-
   function renderDetail(data) {
     var item = data.capCheck;
     var snapshot = data.calculationSnapshot || {};
     document.getElementById("sum-contract").textContent = item.contractNo || "—";
     document.getElementById("sum-stage").textContent = item.paymentStageLabel || "—";
     document.getElementById("sum-asof").textContent = item.asOfDate || "—";
-    document.getElementById("sum-kind").textContent = item.checkKind || "저장 판정";
-    document.getElementById("sum-ruleset").textContent = "ID " + item.capRuleSetId;
-    document.getElementById("sum-id").textContent = item.capCheckId;
+    document.getElementById("sum-ruleset").textContent = item.capRuleSetId == null ? "—" : "룰셋 ID " + item.capRuleSetId;
+    document.getElementById("sum-id").textContent = item.capCheckId == null ? "—" : "cap_check #" + item.capCheckId;
     document.getElementById("sum-badge").innerHTML = statusBadge(item);
 
     var insurerStage = item.paymentStage === "INSURER_TO_GA";
+    var multiplier = snapshot.premiumMultiplier == null ? null : String(snapshot.premiumMultiplier);
+    var ruleSetLabel = item.capRuleSetId == null ? "—" : "룰셋 ID " + item.capRuleSetId;
     document.getElementById("input-body").innerHTML =
       detailPair("월납환산 초회보험료", won(item.basePremiumAmount)) +
-      detailPair("12차월 환급금 가산", refundAddition(item.refund12mAmount)) +
+      detailPair("한도 배수", multiplier == null ? "—" : multiplier + "배") +
+      detailPair("환급금 가산", won(item.refund12mAmount)) +
       detailPair("준법경영비 공제", insurerStage ? won(item.complianceDeductionAmount) : "적용하지 않음") +
-      detailPair("보험료 배수", snapshot.premiumMultiplier == null ? "—" : snapshot.premiumMultiplier);
+      detailPair("적용 룰셋", ruleSetLabel);
 
-    document.getElementById("formula").textContent = insurerStage
-      ? "기준 보험료 × 배수 + 환급금 가산 − 준법경영비 공제"
-      : "기준 보험료 × 배수 + 환급금 가산";
-    document.getElementById("formula-note").textContent = insurerStage
-      ? "원수사 → GA 단계의 저장된 공제 금액을 표시합니다."
-      : "GA → 설계사 단계에는 준법경영비 공제를 적용하지 않습니다.";
+    var limitParts = [number(item.basePremiumAmount), "×", multiplier == null ? "—" : multiplier];
+    if (Number(item.refund12mAmount) !== 0) limitParts.push("+", number(item.refund12mAmount));
+    if (insurerStage && Number(item.complianceDeductionAmount) !== 0) {
+      limitParts.push("−", number(item.complianceDeductionAmount));
+    }
+    document.getElementById("formula-limit").textContent =
+      "한도 = " + limitParts.join(" ") + " = " + won(item.limitAmount);
+    document.getElementById("formula-usage").textContent =
+      "사용률 = " + number(item.includedAmount) + " ÷ " + number(item.limitAmount) + " × 100";
+    document.getElementById("formula-result").textContent = "= " + percent(item.usagePct);
 
-    document.getElementById("final-bar").style.width = visualWidth(item.usagePct);
-    document.getElementById("final-limit-label").textContent = "한도 " + won(item.limitAmount);
+    var finalBar = document.getElementById("final-bar");
+    finalBar.className = "cap-detail-gauge-bar " + (STATUS_PROGRESS_CLASS[item.resultStatus] || "");
+    finalBar.style.width = visualWidth(item.usagePct);
+    finalBar.setAttribute("aria-valuenow", String(accessibleProgress(item.usagePct)));
+    finalBar.setAttribute("aria-valuetext", "사용률 " + percent(item.usagePct));
+    document.getElementById("final-usage").textContent = "사용률 " + percent(item.usagePct);
+    var warningMark = document.getElementById("final-warning-mark");
+    var warningUsagePct = Number(snapshot.warningUsagePct);
+    warningMark.hidden = !Number.isFinite(warningUsagePct);
+    if (!warningMark.hidden) warningMark.style.left = visualWidth(warningUsagePct);
     document.getElementById("final-body").innerHTML =
-      detailPair("한도", won(item.limitAmount)) + detailPair("산입금액", won(item.includedAmount)) +
-      detailPairHtml("잔여", remainingAmount(item.remainingAmount)) + detailPair("사용률", percent(item.usagePct)) +
-      detailPair("저장 판정", item.resultStatusLabel);
+      '<div><dt>산입 합계</dt><dd class="tabular-nums">' + won(item.includedAmount) + "</dd></div>" +
+      '<div><dt>한도</dt><dd class="tabular-nums">' + won(item.limitAmount) + "</dd></div>" +
+      '<div><dt>잔여</dt><dd class="tabular-nums">' + remainingAmount(item.remainingAmount) + "</dd></div>";
+    document.getElementById("final-status").innerHTML = statusBadge(item);
 
     var details = data.details || [];
+    document.getElementById("detail-count").textContent = number(details.length) + "개 항목";
     document.getElementById("detail-body").innerHTML = details.length ? details.map(function (detail) {
       var label = CLASSIFICATION_LABEL[detail.classificationSnapshot] || detail.classificationSnapshot;
       var badgeClass = detail.classificationSnapshot === "INCLUDED" ? "status-badge-info" : detail.classificationSnapshot === "REVIEW_REQUIRED" ? "status-badge-review" : "status-badge-neutral";
-      return "<tr><td>" + number(detail.detailSeq) + "</td><td>" + escapeHtml(detail.commissionItemName || "—") +
-        '</td><td class="text-right tabular-nums">' + won(detail.amount) + '</td><td><span class="status-badge ' + badgeClass + '">' + escapeHtml(label) +
-        "</span></td><td>" + escapeHtml(detail.decisionReason || "—") + "</td><td>" + escapeHtml(detail.evidenceRef || "증빙 미연결 / 후속 연결 대기") + "</td><td>저장 스냅샷</td></tr>";
-    }).join("") : '<tr><td colspan="7"><div class="cap-inline-message">저장된 항목별 산입 내역이 없습니다.</div></td></tr>';
+      return "<tr><td>" + number(detail.detailSeq) + '</td><td class="cap-disclosure-cell">' + tableCellDisclosure(detail.commissionItemName, false) +
+        '</td><td class="text-right tabular-nums">' + won(detail.amount) + '</td><td class="text-center"><span class="status-badge ' + badgeClass + '">' + escapeHtml(label) +
+        '</span></td><td class="cap-disclosure-cell">' + tableCellDisclosure(detail.decisionReason, false) +
+        '</td><td class="cap-disclosure-cell">' + tableCellDisclosure(detail.evidenceRef || "증빙 미연결 / 후속 연결 대기", false) + "</td></tr>";
+    }).join("") : '<tr><td colspan="6"><div class="cap-inline-message">저장된 항목별 산입 내역이 없습니다.</div></td></tr>';
     var includedDetailTotal = details.reduce(function (total, detail) {
       return detail.classificationSnapshot === "INCLUDED" ? total + Number(detail.amount || 0) : total;
     }, 0);
@@ -432,8 +492,9 @@
     var includedMatches = includedDetailTotal === Number(item.includedAmount);
     includedNote.classList.toggle("cap-detail-mismatch", !includedMatches);
     includedNote.textContent = includedMatches
-      ? "제외·검토필요 금액은 합계에 넣지 않습니다 · 저장 산입금액과 일치"
+      ? "제외 항목 미포함"
       : "저장 산입금액과 항목별 산입 합계가 일치하지 않습니다.";
+    scheduleDisclosureSync(document.getElementById("cap-detail-content"));
   }
 
   function openDetail(capCheckId) {
@@ -498,4 +559,8 @@
 
   queryFromLocation();
   loadReferenceData().then(load);
+  window.addEventListener("resize", function () { scheduleDisclosureSync(root); });
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(function () { scheduleDisclosureSync(root); });
+  }
 })();

--- a/src/main/resources/static/js/features/contract/contract-tabs.js
+++ b/src/main/resources/static/js/features/contract/contract-tabs.js
@@ -235,6 +235,7 @@
         renderCapDetail(data || {});
         state.hidden = true;
         content.hidden = false;
+        window.requestAnimationFrame(function () { syncCapDisclosures(content); });
       })
       .catch(function (error) {
         if (requestId !== capDetailRequestId || (error && error.name === "AbortError")) return;
@@ -249,9 +250,8 @@
     capText("sum-contract", item.contractNo);
     capText("sum-stage", item.paymentStageLabel || stageLabel(item.paymentStage));
     capText("sum-asof", item.asOfDate);
-    capText("sum-kind", item.checkKind || "저장 판정");
-    capText("sum-ruleset", item.capRuleSetId == null ? "—" : "ID " + item.capRuleSetId);
-    capText("sum-id", item.capCheckId);
+    capText("sum-ruleset", item.capRuleSetId == null ? "—" : "룰셋 ID " + item.capRuleSetId);
+    capText("sum-id", item.capCheckId == null ? "—" : "cap_check #" + item.capCheckId);
     var badge = document.getElementById("sum-badge");
     badge.replaceChildren();
     var badgeValue = document.createElement("span");
@@ -260,46 +260,76 @@
     badge.appendChild(badgeValue);
 
     var insurerStage = item.paymentStage === "INSURER_TO_GA";
+    var multiplier = snapshot.premiumMultiplier == null ? null : String(snapshot.premiumMultiplier);
+    var ruleSetLabel = item.capRuleSetId == null ? "—" : "룰셋 ID " + item.capRuleSetId;
     capTableRows("input-body", [
       ["월납환산 초회보험료", money(item.basePremiumAmount)],
-      ["12차월 환급금 가산", number(item.refund12mAmount) === 0 ? "해당없음" : money(item.refund12mAmount)],
+      ["한도 배수", multiplier == null ? "—" : multiplier + "배"],
+      ["환급금 가산", money(item.refund12mAmount)],
       ["준법경영비 공제", insurerStage ? money(item.complianceDeductionAmount) : "적용하지 않음"],
-      ["보험료 배수", snapshot.premiumMultiplier == null ? "—" : snapshot.premiumMultiplier]
+      ["적용 룰셋", ruleSetLabel]
     ]);
-    capText("formula", insurerStage
-      ? "기준 보험료 × 배수 + 환급금 가산 − 준법경영비 공제"
-      : "기준 보험료 × 배수 + 환급금 가산");
-    capText("formula-note", insurerStage
-      ? "원수사 → GA 단계의 저장된 공제 금액을 표시합니다."
-      : "GA → 설계사 단계에는 준법경영비 공제를 적용하지 않습니다.");
+    var limitParts = [number(item.basePremiumAmount).toLocaleString("ko-KR"), "×", multiplier == null ? "—" : multiplier];
+    if (number(item.refund12mAmount) !== 0) {
+      limitParts.push("+", number(item.refund12mAmount).toLocaleString("ko-KR"));
+    }
+    if (insurerStage && number(item.complianceDeductionAmount) !== 0) {
+      limitParts.push("−", number(item.complianceDeductionAmount).toLocaleString("ko-KR"));
+    }
+    capText("formula-limit", "한도 = " + limitParts.join(" ") + " = " + money(item.limitAmount));
+    capText("formula-usage", "사용률 = " + number(item.includedAmount).toLocaleString("ko-KR") + " ÷ "
+      + number(item.limitAmount).toLocaleString("ko-KR") + " × 100");
+    capText("formula-result", "= " + percent(item.usagePct));
     var finalBar = document.getElementById("final-bar");
+    finalBar.className = "cap-detail-gauge-bar " + capProgressClass(item.resultStatus);
     finalBar.style.width = capProgressWidth(item.usagePct);
-    capText("final-limit-label", "한도 " + money(item.limitAmount));
-    capTableRows("final-body", [
-      ["한도", money(item.limitAmount)], ["산입금액", money(item.includedAmount)],
-      ["잔여", money(item.remainingAmount)], ["사용률", percent(item.usagePct)],
-      ["저장 판정", value(item.resultStatusLabel || item.resultStatus)]
-    ]);
+    finalBar.setAttribute("aria-valuenow", String(Math.max(0, Math.min(100, number(item.usagePct)))));
+    finalBar.setAttribute("aria-valuetext", "사용률 " + percent(item.usagePct));
+    capText("final-usage", "사용률 " + percent(item.usagePct));
+    var warningMark = document.getElementById("final-warning-mark");
+    var warningUsagePct = Number(snapshot.warningUsagePct);
+    warningMark.hidden = !Number.isFinite(warningUsagePct);
+    if (!warningMark.hidden) warningMark.style.left = capProgressWidth(warningUsagePct);
+    var finalBody = document.getElementById("final-body");
+    finalBody.replaceChildren(
+      capResultRow("산입 합계", money(item.includedAmount)),
+      capResultRow("한도", money(item.limitAmount)),
+      capResultRow("잔여", money(item.remainingAmount))
+    );
+    var finalStatus = document.getElementById("final-status");
+    finalStatus.replaceChildren();
+    var finalBadge = document.createElement("span");
+    finalBadge.className = "status-badge " + capStatusClass(item.resultStatus);
+    finalBadge.textContent = value(item.resultStatusLabel || item.resultStatus);
+    finalStatus.appendChild(finalBadge);
 
     var details = Array.isArray(data.details) ? data.details : [];
+    capText("detail-count", details.length.toLocaleString("ko-KR") + "개 항목");
     var detailBody = document.getElementById("detail-body");
     detailBody.replaceChildren();
     if (!details.length) {
       var emptyRow = document.createElement("tr");
       var emptyCell = document.createElement("td");
-      emptyCell.colSpan = 7;
+      emptyCell.colSpan = 6;
       emptyCell.textContent = "저장된 항목별 산입 내역이 없습니다.";
       emptyRow.appendChild(emptyCell);
       detailBody.appendChild(emptyRow);
     } else {
       details.forEach(function (detail) {
         var row = document.createElement("tr");
-        [detail.detailSeq, detail.commissionItemName, money(detail.amount), capClassificationLabel(detail.classificationSnapshot),
-          detail.decisionReason, detail.evidenceRef, "저장 스냅샷"].forEach(function (entry) {
-          var cell = document.createElement("td");
-          cell.textContent = value(entry);
-          row.appendChild(cell);
-        });
+        var sequenceCell = document.createElement("td");
+        sequenceCell.textContent = value(detail.detailSeq);
+        var amountCell = document.createElement("td");
+        amountCell.className = "text-right tabular-nums";
+        amountCell.textContent = money(detail.amount);
+        var statusCell = document.createElement("td");
+        statusCell.className = "text-center";
+        var statusBadge = document.createElement("span");
+        statusBadge.className = "status-badge " + capClassificationClass(detail.classificationSnapshot);
+        statusBadge.textContent = capClassificationLabel(detail.classificationSnapshot);
+        statusCell.appendChild(statusBadge);
+        row.append(sequenceCell, capDisclosureCell(detail.commissionItemName, false), amountCell, statusCell,
+          capDisclosureCell(detail.decisionReason, false), capDisclosureCell(detail.evidenceRef || "증빙 미연결 / 후속 연결 대기", false));
         detailBody.appendChild(row);
       });
     }
@@ -307,9 +337,57 @@
       return detail.classificationSnapshot === "INCLUDED" ? total + number(detail.amount) : total;
     }, 0);
     capText("detail-included", includedTotal.toLocaleString("ko-KR"));
-    capText("detail-included-note", includedTotal === number(item.includedAmount)
-      ? "제외·검토필요 금액은 합계에 넣지 않습니다 · 저장 산입금액과 일치"
+    var includedMatches = includedTotal === number(item.includedAmount);
+    var includedNote = document.getElementById("detail-included-note");
+    includedNote.classList.toggle("cap-detail-mismatch", !includedMatches);
+    capText("detail-included-note", includedMatches
+      ? "제외 항목 미포함"
       : "저장 산입금액과 항목별 산입 합계가 일치하지 않습니다.");
+  }
+
+  function capResultRow(label, displayValue) {
+    var row = document.createElement("div");
+    var term = document.createElement("dt");
+    var description = document.createElement("dd");
+    description.className = "tabular-nums";
+    term.textContent = label;
+    description.textContent = displayValue;
+    row.append(term, description);
+    return row;
+  }
+
+  function capDisclosureCell(input, singleLine) {
+    var cell = document.createElement("td");
+    cell.className = "cap-disclosure-cell";
+    var disclosure = document.createElement("div");
+    disclosure.className = "table-cell-disclosure";
+    var preview = document.createElement("span");
+    preview.className = "table-cell-preview" + (singleLine ? " is-single-line" : "");
+    preview.textContent = value(input);
+    var details = document.createElement("details");
+    details.className = "table-cell-details";
+    details.hidden = true;
+    var summary = document.createElement("summary");
+    summary.innerHTML = '<span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span>' +
+      '<span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span>';
+    var full = document.createElement("p");
+    full.className = "table-cell-full";
+    full.textContent = value(input);
+    details.append(summary, full);
+    disclosure.append(preview, details);
+    cell.appendChild(disclosure);
+    return cell;
+  }
+
+  function syncCapDisclosures(scope) {
+    scope.querySelectorAll(".table-cell-disclosure").forEach(function (disclosure) {
+      var preview = disclosure.querySelector(".table-cell-preview");
+      var details = disclosure.querySelector(".table-cell-details");
+      if (!preview || !details || preview.clientWidth === 0) return;
+      var isTruncated = preview.scrollWidth > preview.clientWidth + 1 || preview.scrollHeight > preview.clientHeight + 1;
+      details.hidden = !isTruncated;
+      if (!isTruncated) details.open = false;
+    });
   }
 
   function capText(id, input) { document.getElementById(id).textContent = value(input); }
@@ -334,6 +412,12 @@
   }
   function capClassificationLabel(status) {
     return status === "INCLUDED" ? "산입" : status === "EXCLUDED" ? "제외" : status === "REVIEW_REQUIRED" ? "검토필요" : value(status);
+  }
+  function capClassificationClass(status) {
+    return status === "INCLUDED" ? "status-badge-info" : status === "REVIEW_REQUIRED" ? "status-badge-review" : "status-badge-neutral";
+  }
+  function capProgressClass(status) {
+    return status === "WARNING" ? "is-warning" : status === "VIOLATION" ? "is-violation" : status === "REVIEW_REQUIRED" ? "is-review" : "";
   }
   function capProgressWidth(input) { return Math.max(0, Math.min(100, number(input))) + "%"; }
   function usageGauge(input, status) {
@@ -364,6 +448,6 @@
   }
   function value(input) { return input === null || input === undefined || input === "" ? "—" : String(input); }
   function money(input) { var number = Number(input); return Number.isFinite(number) ? number.toLocaleString("ko-KR") + "원" : "—"; }
-  function percent(input) { var number = Number(input); return Number.isFinite(number) ? number.toLocaleString("ko-KR", { maximumFractionDigits: 6 }) + "%" : "—"; }
+  function percent(input) { return input === null || input === undefined || input === "" ? "—" : String(input) + "%"; }
   function stageLabel(stage) { return stage === "INSURER_TO_GA" ? "원수사→GA" : stage === "GA_TO_FC" ? "GA→설계사" : value(stage); }
 })();

--- a/src/main/resources/templates/cap/detail-modal.html
+++ b/src/main/resources/templates/cap/detail-modal.html
@@ -1,162 +1,109 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
   FGC-UI-CAP-W02 1,200% 계산근거 (팝업)
-  요구사항 FUN-035 / REG-06A · REG-11 · REG-20 · REG-21
-  데이터  읽기 cap_check, cap_check_detail, cap_check.calculation_snapshot(JSON)
-  API     GET /api/v1/cap-checks/{capCheckId}/details   (Ajax · 모달)
+  API: GET /api/v1/cap-checks/{capCheckId}/details
 
-  [★ 막을 것] 이 팝업에서 다시 계산하지 않습니다.
-    검증하던 그 순간에 저장해 둔 스냅샷을 그대로 펼쳐 보여줄 뿐입니다.
-    지금 다시 계산하면 "그때 왜 이 금액이었는지"를 설명할 수 없게 됩니다.
-
-  [화면 구성] 화면정의서 §4-6 공통 규칙: 입력값 → 계산식 → 항목별 → 합계 4단
-
-  [정적 부착 단계] 목업(30_산출물/화면_MVP/FGC-UI-CAP-W02)의 정적 골격만 옮겼다.
-  페이지가 아니라 프래그먼트(modal)다 — CAP-W01(cap/list.html)에서 IF-API-31(SIR-006)로
-  Ajax 로드해 모달에 끼운다. 셸 레이아웃(page)을 쓰지 않는다.
-  데이터 영역(요약·입력값·계산식·항목별·합계)은 IF-API-31 연동 시 채운다.
+  검증 당시 저장된 cap_check, cap_check_detail, calculationSnapshot만 표시한다.
+  이 프래그먼트에서는 판정이나 금액을 다시 계산하지 않는다.
 -->
-<html xmlns:th="http://www.thymeleaf.org">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <body>
-<div th:fragment="modal" class="fgc-cap-detail">
-
-  <div class="fgc-banner fgc-banner--muted">
-    <span class="material-symbols-outlined" style="font-size:18px">history_toggle_off</span>
-    <span>
-      이 화면은 <strong class="fgc-mono">cap_check.calculation_snapshot</strong>(검증 당시 저장한 계산 스냅샷)을
-      표로 펼친 것입니다. <strong>여기서 다시 계산하지 않습니다.</strong>
-    </span>
-  </div>
-
-  <!-- 요약 헤더 — IF-API-31 연동 시 채운다 -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__head">
-      <span class="fgc-card__title">
-        계약 <span class="fgc-mono" id="sum-contract">—</span> ·
-        <span id="sum-stage">—</span>
-      </span>
-      <span id="sum-badge"></span>
-    </div>
-    <div class="fgc-card__body" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:16px">
-      <div><div class="fgc-label">기준일</div><div class="fgc-mono" id="sum-asof">—</div></div>
-      <div><div class="fgc-label">검증 종류</div><div id="sum-kind">—</div></div>
-      <div><div class="fgc-label">적용 룰셋</div><div class="fgc-mono" id="sum-ruleset">—</div></div>
-      <div><div class="fgc-label">판정 ID</div><div class="fgc-mono" id="sum-id">—</div></div>
-    </div>
+<div th:fragment="modal" class="cap-detail">
+  <section class="surface cap-detail-summary" aria-labelledby="cap-detail-summary-title">
+    <dl class="surface-body cap-detail-summary-grid">
+      <div class="cap-detail-summary-contract">
+        <dt id="cap-detail-summary-title">계약 · 지급단계</dt>
+        <dd>
+          <span class="cap-detail-contract-context">
+            <span class="tabular-nums" id="sum-contract">—</span>
+            <span aria-hidden="true">·</span>
+            <span id="sum-stage">—</span>
+          </span>
+          <span id="sum-badge"></span>
+        </dd>
+      </div>
+      <div><dt>기준일</dt><dd class="tabular-nums" id="sum-asof">—</dd></div>
+      <div><dt>적용 룰셋</dt><dd class="tabular-nums" id="sum-ruleset">—</dd></div>
+      <div><dt>판정 ID</dt><dd class="tabular-nums" id="sum-id">—</dd></div>
+    </dl>
   </section>
 
-  <div style="margin-top:16px;display:grid;grid-template-columns:1fr 1.6fr;gap:16px" id="calc-grid">
+  <div class="cap-detail-layout">
+    <div class="cap-detail-primary">
+      <section class="surface cap-detail-section" aria-labelledby="cap-input-title">
+        <header class="surface-header cap-detail-step-header">
+          <h3 id="cap-input-title" class="surface-title">① 입력값</h3>
+        </header>
+        <div class="data-table-viewport">
+          <table class="data-table cap-detail-pair-table">
+            <caption class="visually-hidden">한도 계산 입력값</caption>
+            <tbody id="input-body"><tr><td colspan="2"><div class="empty-state" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr></tbody>
+          </table>
+        </div>
+      </section>
 
-    <div style="display:flex;flex-direction:column;gap:16px">
-
-      <!-- ① 입력값 — IF-API-31 연동 시 채운다 -->
-      <section class="fgc-card">
-        <div class="fgc-card__head"><span class="fgc-card__title">① 입력값</span></div>
-        <div class="fgc-card__body">
-          <div class="fgc-calc-step">
-            <span class="fgc-calc-step__no">STEP 1 · 무엇을 가지고 계산했나</span>
-            <table class="fgc-table" style="font-size:12px">
-              <tbody id="input-body">
-                <tr><td colspan="2"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
-              </tbody>
-            </table>
+      <section class="surface cap-detail-section" aria-labelledby="cap-formula-title">
+        <header class="surface-header cap-detail-step-header">
+          <h3 id="cap-formula-title" class="surface-title">② 계산식</h3>
+        </header>
+        <div class="surface-body cap-detail-formula-body">
+          <div class="cap-detail-formula">
+            <strong id="formula-limit">—</strong>
+            <span id="formula-usage">—</span>
+            <em id="formula-result">—</em>
           </div>
         </div>
       </section>
 
-      <!-- ② 계산식 — IF-API-31 연동 시 채운다 -->
-      <section class="fgc-card">
-        <div class="fgc-card__head"><span class="fgc-card__title">② 계산식</span></div>
-        <div class="fgc-card__body">
-          <div class="fgc-calc-step">
-            <span class="fgc-calc-step__no">STEP 2 · 어떻게 계산했나</span>
-            <div class="fgc-formula" id="formula">—</div>
-            <p class="fgc-help" style="margin-top:10px" id="formula-note"></p>
+      <section class="surface cap-detail-section" aria-labelledby="cap-total-title">
+        <header class="surface-header cap-detail-step-header">
+          <h3 id="cap-total-title" class="surface-title">④ 합계와 판정</h3>
+        </header>
+        <div class="surface-body cap-detail-result-gauge">
+          <div class="cap-detail-gauge-heading">
+            <strong id="final-usage">사용률 —</strong>
+            <span>한도 100%</span>
           </div>
-        </div>
-      </section>
-
-      <!-- ④ 합계와 판정 — IF-API-31 연동 시 채운다 -->
-      <section class="fgc-card">
-        <div class="fgc-card__head"><span class="fgc-card__title">④ 합계와 판정</span></div>
-        <div class="fgc-card__body">
-          <div class="fgc-calc-step">
-            <span class="fgc-calc-step__no">STEP 4 · 그래서 결론이 무엇인가</span>
-            <div class="fgc-gauge" style="margin-bottom:14px">
-              <div class="fgc-gauge__track" style="height:14px">
-                <div class="fgc-gauge__bar" id="final-bar" style="width:0%"></div>
-                <div class="fgc-gauge__mark fgc-gauge__mark--warn"></div>
-              </div>
-              <div class="fgc-gauge__legend">
-                <span>0</span><span id="final-limit-label">한도</span>
-              </div>
-            </div>
-            <table class="fgc-table" style="font-size:13px">
-              <tbody id="final-body">
-                <tr><td colspan="2"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
-              </tbody>
-            </table>
+          <div class="cap-detail-gauge-track">
+            <span class="cap-detail-gauge-bar" id="final-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-valuetext="사용률 0%"></span>
+            <span class="cap-detail-gauge-mark" id="final-warning-mark" aria-hidden="true"></span>
           </div>
+          <dl class="cap-detail-result-list" id="final-body">
+            <div><dt>산입 합계</dt><dd>—</dd></div>
+            <div><dt>한도</dt><dd>—</dd></div>
+            <div><dt>잔여</dt><dd>—</dd></div>
+          </dl>
+          <div class="cap-detail-final-status"><strong>저장된 최종 판정</strong><span id="final-status">—</span></div>
         </div>
       </section>
     </div>
 
-    <!-- ③ 항목별 산입 내역 — IF-API-31 연동 시 채운다 -->
-    <section class="fgc-card" style="align-self:start">
-      <div class="fgc-card__head">
-        <span class="fgc-card__title">③ 항목별 산입 내역</span>
-        <span class="fgc-muted" style="font-size:12px">cap_check_detail</span>
-      </div>
-      <div class="fgc-card__body" style="padding-bottom:0">
-        <div class="fgc-calc-step" style="margin-bottom:0">
-          <span class="fgc-calc-step__no">STEP 3 · 어떤 돈을 넣고 어떤 돈을 뺐나</span>
-        </div>
-      </div>
-      <div style="overflow-x:auto">
-        <table class="fgc-table">
-          <thead>
-            <tr>
-              <th style="width:34px">#</th>
-              <th>항목</th>
-              <th class="fgc-th-num" style="width:110px">금액</th>
-              <th style="width:88px">판정</th>
-              <th>판단 이유</th>
-              <th style="width:150px">근거</th>
-              <th style="width:110px">원천</th>
-            </tr>
-          </thead>
-          <tbody id="detail-body">
-            <tr><td colspan="7"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
-          </tbody>
-          <tfoot>
-            <tr>
-              <td colspan="2">산입 합계</td>
-              <td class="fgc-td-num"><span class="fgc-amount" id="detail-included">0</span></td>
-              <td colspan="4" class="fgc-muted" id="detail-included-note">제외·검토필요 금액은 합계에 넣지 않습니다</td>
-            </tr>
-          </tfoot>
+    <section class="surface cap-detail-section cap-detail-lines" aria-labelledby="cap-detail-lines-title">
+      <header class="surface-header cap-detail-step-header cap-detail-lines-header">
+        <h3 id="cap-detail-lines-title" class="surface-title">③ 항목별 산입 내역</h3>
+        <span class="cap-detail-count">cap_check_detail · <span id="detail-count">0개 항목</span></span>
+      </header>
+      <div class="data-table-viewport">
+        <table class="data-table cap-detail-table">
+          <caption class="visually-hidden">항목별 산입 판정과 근거</caption>
+          <colgroup>
+            <col class="cap-detail-col-seq"><col class="cap-detail-col-item"><col class="cap-detail-col-amount">
+            <col class="cap-detail-col-status"><col class="cap-detail-col-reason"><col class="cap-detail-col-evidence">
+          </colgroup>
+          <thead><tr>
+            <th scope="col" class="text-right">#</th><th scope="col">항목</th><th scope="col" class="text-right">금액</th>
+            <th scope="col" class="text-center">판정</th><th scope="col">판단 이유</th><th scope="col">근거</th>
+          </tr></thead>
+          <tbody id="detail-body"><tr><td colspan="6"><div class="empty-state" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr></tbody>
+          <tfoot><tr>
+            <th scope="row" colspan="2">산입 합계</th>
+            <td class="text-right tabular-nums"><strong id="detail-included">0</strong>원</td>
+            <td colspan="3" id="detail-included-note">제외 항목 미포함</td>
+          </tr></tfoot>
         </table>
-      </div>
-      <div class="fgc-card__body">
-        <div class="fgc-banner fgc-banner--warn">
-          <span class="material-symbols-outlined" style="font-size:18px">priority_high</span>
-          <span>
-            <strong>이름만 보고 제외하면 안 됩니다.</strong>
-            교육비·복리후생비·대여금이라는 이름이 붙어 있어도
-            실제로 모집이나 판매촉진의 대가라면 수수료등에 포함됩니다(REG-11 · REG-22).
-            판단 이유(<span class="fgc-mono">decision_reason</span>)는 저장이 필수입니다.
-          </span>
-        </div>
       </div>
     </section>
   </div>
-
-  <div style="margin-top:16px;display:flex;justify-content:flex-end;gap:8px">
-    <a class="fgc-btn fgc-btn--primary" id="go-exception" th:href="@{/exceptions}" style="text-decoration:none">
-      예외 목록 보기
-    </a>
-  </div>
-
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/cap/list.html
+++ b/src/main/resources/templates/cap/list.html
@@ -14,16 +14,12 @@
   <header class="page-header">
     <div class="page-header-copy">
       <h1 class="page-title">1,200% 한도 검증 현황</h1>
-      <p class="page-description">계약 단위 한도 판정과 지급단계별 사용 현황을 확인합니다.</p>
     </div>
   </header>
 
   <section class="surface cap-filter-panel" aria-labelledby="cap-filter-title">
     <header class="surface-header cap-section-header">
-      <div>
-        <h2 id="cap-filter-title" class="surface-title">검색 조건</h2>
-        <p class="cap-section-description">기준월과 계약 조건으로 저장된 판정 결과를 조회합니다.</p>
-      </div>
+      <h2 id="cap-filter-title" class="surface-title">검색 조건</h2>
     </header>
     <form id="cap-search-form" class="cap-filter-form">
       <div class="field cap-filter-month">
@@ -94,10 +90,7 @@
 
   <section class="surface cap-stage-panel" aria-labelledby="cap-stage-title">
     <header class="surface-header cap-section-header cap-stage-header">
-      <div>
-        <h2 id="cap-stage-title" class="surface-title">지급단계별 Stage Gauges</h2>
-        <p class="cap-section-description">서로 다른 규제이므로 두 단계를 합산하지 않습니다.</p>
-      </div>
+      <h2 id="cap-stage-title" class="surface-title">지급단계별 한도 게이지</h2>
       <span class="status-badge status-badge-neutral">전체 검색범위 집계</span>
     </header>
     <div id="cap-stage-grid" class="cap-stage-grid" aria-live="polite">
@@ -114,21 +107,9 @@
     </div>
   </section>
 
-  <section class="cap-guidance" aria-labelledby="cap-guidance-title">
-    <span class="material-symbols-outlined" aria-hidden="true">verified_user</span>
-    <div>
-      <h2 id="cap-guidance-title">계산 기준</h2>
-      <p><strong>한도 = 월납환산 초회보험료 × 12 + 12차월 예상 해약환급금 − 준법경영비 공제</strong></p>
-      <p>준법경영비 공제는 원수사 → GA에만 적용합니다. GA → 설계사에는 적용하지 않습니다. 판정 색상은 저장된 <code>resultStatus</code>를 사용합니다.</p>
-    </div>
-  </section>
-
   <section class="surface cap-table-panel" aria-labelledby="cap-contract-list-title">
     <header class="surface-header cap-section-header">
-      <div>
-        <h2 id="cap-contract-list-title" class="surface-title">계약별 판정 목록</h2>
-        <p class="cap-section-description">규제 판정 단위는 계약 1건입니다.</p>
-      </div>
+      <h2 id="cap-contract-list-title" class="surface-title">계약별 판정 목록</h2>
       <span class="cap-list-count"><strong id="cap-total-count">0</strong>건</span>
     </header>
     <div id="cap-list-message" class="cap-inline-message" role="status" aria-live="polite">판정 목록을 불러오는 중입니다.</div>
@@ -162,10 +143,7 @@
 
   <section class="surface cap-table-panel" aria-labelledby="cap-agent-title">
     <header class="surface-header cap-section-header cap-agent-header">
-      <div>
-        <h2 id="cap-agent-title" class="surface-title">설계사별 모니터링 지표</h2>
-        <p class="cap-section-description">GA → 설계사 지급단계만 집계합니다.</p>
-      </div>
+      <h2 id="cap-agent-title" class="surface-title">설계사별 합계</h2>
       <span class="status-badge status-badge-neutral">모니터링 지표 · 규제 판정 아님</span>
     </header>
     <div id="cap-agent-message" class="cap-inline-message">전체 검색범위 설계사 집계를 불러오는 중입니다.</div>
@@ -181,13 +159,21 @@
 
   <div class="modal-backdrop" data-modal="cap-detail" data-close-on-backdrop="true" hidden aria-hidden="true">
     <section class="modal modal-large cap-detail-modal" role="dialog" aria-modal="true" aria-labelledby="cap-detail-title">
-      <header class="modal-header">
-        <div><h2 id="cap-detail-title" class="modal-title">1,200% 계산근거</h2><p class="cap-modal-subtitle">검증 당시 저장된 스냅샷</p></div>
+      <header class="modal-header cap-detail-modal-header">
+        <div class="cap-detail-modal-heading">
+          <p class="cap-detail-eyebrow">1,200% 한도 · 계산 스냅샷</p>
+          <h2 id="cap-detail-title" class="modal-title">계산근거</h2>
+        </div>
         <button class="icon-button" type="button" data-modal-close aria-label="팝업 닫기" data-modal-initial-focus><span class="material-symbols-outlined" aria-hidden="true">close</span></button>
       </header>
       <div id="cap-detail-state" class="modal-body cap-detail-state">계산근거를 불러오는 중입니다.</div>
       <div id="cap-detail-content" class="modal-body" hidden th:insert="~{cap/detail-modal :: modal}"></div>
-      <footer class="modal-footer"><button class="button button-secondary" type="button" data-modal-close>닫기</button></footer>
+      <footer class="modal-footer cap-detail-modal-footer">
+        <div class="cap-detail-footer-actions">
+          <button class="button button-secondary" type="button" data-modal-close>닫기</button>
+          <a class="button button-primary" id="go-exception" th:href="@{/exceptions}">예외 목록 보기</a>
+        </div>
+      </footer>
     </section>
   </div>
 </main>

--- a/src/main/resources/templates/contract/detail.html
+++ b/src/main/resources/templates/contract/detail.html
@@ -15,7 +15,6 @@
   <header class="page-header contract-detail-page-header">
     <div class="page-header-copy">
       <h1 class="page-title">보험계약 상세</h1>
-      <p class="page-description">계약 기본정보와 검증·지급 이력을 한 화면에서 확인합니다.</p>
     </div>
   </header>
 
@@ -150,13 +149,21 @@
 
   <div class="modal-backdrop" data-modal="cap-detail" data-close-on-backdrop="true" hidden aria-hidden="true">
     <section class="modal modal-large cap-detail-modal" role="dialog" aria-modal="true" aria-labelledby="cap-detail-title">
-      <header class="modal-header">
-        <div><h2 id="cap-detail-title" class="modal-title">1,200% 계산근거</h2><p class="cap-modal-subtitle">검증 당시 저장된 스냅샷</p></div>
+      <header class="modal-header cap-detail-modal-header">
+        <div class="cap-detail-modal-heading">
+          <p class="cap-detail-eyebrow">1,200% 한도 · 계산 스냅샷</p>
+          <h2 id="cap-detail-title" class="modal-title">계산근거</h2>
+        </div>
         <button class="icon-button" type="button" data-modal-close aria-label="팝업 닫기" data-modal-initial-focus><span class="material-symbols-outlined" aria-hidden="true">close</span></button>
       </header>
       <div id="cap-detail-state" class="modal-body cap-detail-state">계산근거를 불러오는 중입니다.</div>
       <div id="cap-detail-content" class="modal-body" hidden th:insert="~{cap/detail-modal :: modal}"></div>
-      <footer class="modal-footer"><button class="button button-secondary" type="button" data-modal-close>닫기</button></footer>
+      <footer class="modal-footer cap-detail-modal-footer">
+        <div class="cap-detail-footer-actions">
+          <button class="button button-secondary" type="button" data-modal-close>닫기</button>
+          <a class="button button-primary" id="go-exception" th:href="@{/exceptions}">예외 목록 보기</a>
+        </div>
+      </footer>
     </section>
   </div>
 

--- a/src/test/java/com/susukkang/fgc/ui/CapPublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/CapPublishingTemplateStructureTest.java
@@ -1,0 +1,113 @@
+package com.susukkang.fgc.ui;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CapPublishingTemplateStructureTest {
+
+    @Test
+    void capListUsesCommonComponentsAndServerAggregates() throws IOException {
+        assertThat(resource("templates/cap/list.html"))
+                .contains("class=\"surface cap-filter-panel\"")
+                .contains("class=\"kpi-card cap-kpi-card")
+                .contains("class=\"data-table cap-contract-table\"")
+                .contains("class=\"data-table cap-agent-table\"")
+                .contains("지급단계별 한도 게이지")
+                .contains("모니터링 지표 · 규제 판정 아님")
+                .contains("data-modal=\"cap-detail\"")
+                .contains("class=\"modal-footer cap-detail-modal-footer\"")
+                .contains("class=\"button button-primary\"")
+                .doesNotContain("기준월과 계약 조건으로 저장된 판정 결과를 조회합니다.")
+                .doesNotContain("서로 다른 규제이므로 두 단계를 합산하지 않습니다.")
+                .doesNotContain("규제 판정 단위는 계약 1건입니다.")
+                .doesNotContain("GA → 설계사 지급단계만 집계합니다.")
+                .doesNotContain("검증 당시 저장된 값과 항목별 판단을 확인합니다.")
+                .doesNotContain("판정과 상세는 읽기 전용이며 이 팝업에서 수정할 수 없습니다.")
+                .doesNotContain("page-description")
+                .doesNotContain("cap-guidance")
+                .doesNotContain("fgc-banner")
+                .doesNotContain("style=");
+
+        assertThat(resource("static/js/features/cap/cap-list.js"))
+                .contains("/api/v1/cap-checks?")
+                .contains("renderStageSummary(data.stageSummary)")
+                .contains("renderAgentSummary(data.agentSummary)")
+                .contains("item.resultStatus")
+                .contains("function tableCellDisclosure(")
+                .contains("preview.scrollWidth > preview.clientWidth")
+                .contains("preview.scrollHeight > preview.clientHeight")
+                .contains("document.fonts.ready")
+                .doesNotContain("fetch(");
+    }
+
+    @Test
+    void capDetailRemainsACommonComponentModalWithoutGuidanceOrInlineStyles() throws IOException {
+        assertThat(resource("templates/cap/detail-modal.html"))
+                .contains("th:fragment=\"modal\"")
+                .contains("class=\"surface cap-detail-summary\"")
+                .contains("class=\"data-table cap-detail-table\"")
+                .contains("class=\"cap-detail-contract-context\"")
+                .contains("role=\"progressbar\"")
+                .contains("id=\"formula-limit\"")
+                .contains("id=\"final-warning-mark\"")
+                .contains("id=\"detail-count\"")
+                .contains("id=\"detail-included-note\"")
+                .contains("<th scope=\"col\">근거</th>")
+                .doesNotContain("id=\"sum-kind\"")
+                .doesNotContain("CAP-GA-FC-V1")
+                .doesNotContain("무엇으로 계산했나")
+                .doesNotContain("어떻게 계산했나")
+                .doesNotContain("결론은 무엇인가")
+                .doesNotContain("STEP 3 ·")
+                .doesNotContain("판단 이유는 검증 당시 저장된 필수 값이며")
+                .doesNotContain("<main")
+                .doesNotContain("page-description")
+                .doesNotContain("fgc-")
+                .doesNotContain("guidance")
+                .doesNotContain("style=");
+
+        assertThat(resource("static/css/features/cap.css"))
+                .contains(".cap-detail-layout")
+                .contains(".cap-detail-table")
+                .contains("@media (max-width: 63.9375rem)")
+                .contains("@media (max-width: 47.9375rem)")
+                .doesNotContain(".cap-guidance");
+
+        assertThat(resource("static/js/features/cap/cap-list.js"))
+                .contains("룰셋 ID ")
+                .contains("cap_check #")
+                .contains("snapshot.warningUsagePct")
+                .contains("item.resultStatus")
+                .contains("증빙 미연결 / 후속 연결 대기")
+                .doesNotContain("item.checkKind");
+
+        assertThat(resource("static/js/features/contract/contract-tabs.js"))
+                .contains("emptyCell.colSpan = 6")
+                .contains("capDisclosureCell(detail.decisionReason")
+                .contains("status-badge \" + capClassificationClass")
+                .contains("syncCapDisclosures(content)")
+                .contains("formula-limit")
+                .contains("snapshot.warningUsagePct")
+                .doesNotContain("item.checkKind");
+
+        assertThat(resource("templates/contract/detail.html"))
+                .contains("class=\"modal-header cap-detail-modal-header\"")
+                .contains("class=\"modal-footer cap-detail-modal-footer\"")
+                .doesNotContain("검증 당시 저장된 값과 항목별 판단을 확인합니다.")
+                .doesNotContain("판정과 상세는 읽기 전용이며 이 팝업에서 수정할 수 없습니다.")
+                .doesNotContain("page-description");
+    }
+
+    private String resource(String path) throws IOException {
+        try (var input = getClass().getClassLoader().getResourceAsStream(path)) {
+            if (input == null) {
+                throw new IOException("Resource not found: " + path);
+            }
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- CAP-W01 1,200% 한도 검증 현황 화면을 공통 UI 컴포넌트 기준으로 정리했습니다.
- CAP-W02 계산근거 팝업을 인터페이스 정의서와 현재 API 응답 구조에 맞게 개선했습니다.
- 화면 설명과 Guidance를 제거하고 반응형 여백, 긴 값 표시 및 접근성을 보완했습니다.

## 🔗 2. 관련 이슈

- Refs #138

## 🛠 3. 구현 내용

- CAP-W01 검색 조건, KPI, 지급단계별 한도 게이지, 계약별 판정 목록 및 설계사별 합계를 공통 Surface·Field·Table·Status Badge 구조로 정리
- 기존 `/api/v1/cap-checks` 응답의 `summary`, `stageSummary`, `agentSummary`, `content` 매핑 유지
- INSURER_TO_GA와 GA_TO_FC 지급단계를 별도 게이지로 표시하고 저장된 `resultStatus` 사용
- 긴 계약번호와 테이블 값을 안전하게 말줄임 처리하고 필요한 경우 `전체 보기` 제공
- CAP-W02를 기존 Modal 방식으로 유지하면서 입력값, 계산식, 항목별 산입·제외 및 최종 판정 구조 개선
- CAP-W02를 CAP 목록과 계약 상세 양쪽에서 동일한 구조로 실행하도록 정리
- Guidance, `page-description` 및 불필요한 보조 설명 문구 제거
- CAP 섹션의 데스크톱·모바일 padding과 검색 Grid 축소 동작 개선
- CAP 퍼블리싱 구조 회귀 테스트 추가

## 🧪 4. 테스트 방법

1. `./gradlew bootRun`으로 애플리케이션을 실행합니다.
2. `/cap-checks`에서 검색, 초기화, KPI 필터, 페이징 및 계약 상세 이동을 확인합니다.
3. 계약별 판정 목록에서 계산근거를 열어 CAP-W02 팝업의 요약, 계산식, 항목 목록 및 최종 판정을 확인합니다.
4. 보험계약 상세에서도 CAP-W02 팝업이 동일하게 열리는지 확인합니다.
5. 데스크톱 및 좁은 화면에서 검색 조건과 팝업 내용이 잘리거나 비정상적으로 넘치지 않는지 확인합니다.
6. `./gradlew test`를 실행합니다.

## 🗄️ 5. DB / Flyway 변경

- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

- 없음

## 📋 6. 리뷰 요구사항

- CAP-W01의 지급단계별 집계가 INSURER_TO_GA와 GA_TO_FC로 분리되어 표시되는지 확인 부탁드립니다.
- CAP-W02가 별도 Workspace Tab이 아닌 기존 Modal 방식으로 유지되는지 확인 부탁드립니다.
- 계산근거 화면이 현재 인터페이스 정의서와 API 응답 필드만 사용하는지 확인 부탁드립니다.
- CAP 목록과 계약 상세에서 동일한 팝업 구조와 동작이 유지되는지 확인 부탁드립니다.
- 1440px 및 좁은 화면에서 검색 조건과 팝업의 여백·줄바꿈을 확인 부탁드립니다.

## ✅ 7. 체크리스트

- [x] `develop` 최신 내용을 반영했습니다.
- [x] 로컬 빌드에 성공했습니다.
- [x] 애플리케이션 실행을 확인했습니다.
- [x] 관련 기능을 직접 테스트했습니다.
- [x] 테스트 코드가 필요한 경우 작성했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [x] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

- CAP-W01 검색 조건 및 섹션 여백 정리
- 지급단계별 한도 게이지와 계약·설계사 목록 공통 UI 적용
- CAP-W02 계산근거 Modal 레이아웃 및 반응형 구조 개선
- 불필요한 Guidance, 화면 설명 및 보조 문구 제거
- 긴 계약번호와 테이블 값 표시 UX 개선

## 💬 9. 참고 사항

- 백엔드 API, DB 및 Flyway 변경은 없습니다.
- 화면에서 판정 상태를 재계산하지 않고 기존 API의 저장된 `resultStatus`를 사용합니다.
- CAP-W02는 기존 정책에 따라 별도 페이지나 Workspace Tab이 아닌 Modal로 유지합니다.
- API에서 제공하지 않는 증빙 상세는 임의 데이터를 생성하지 않고 연동 대기 상태로 표시합니다.
- `./gradlew test` 전체 테스트가 통과했습니다.