### PR TITLE
[Test] 규제·대사·차익거래 상태체계 분리 통합 테스트

### DIFF
--- a/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunDetailMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunDetailMapperIntegrationTest.java
@@ -146,6 +146,15 @@ class ValidationRunDetailMapperIntegrationTest {
                 """, reconRunId, matchGroupKey, resultType, differenceAmount);
     }
 
+    private void insertReconciliationResult(Long reconRunId, String matchGroupKey, String resultType,
+                                             Long contractId, BigDecimal differenceAmount) {
+        jdbcTemplate.update("""
+                INSERT INTO fgc.reconciliation_result
+                    (reconciliation_run_id, match_group_key, result_type, contract_id, difference_amount)
+                VALUES (?, ?, ?, ?, ?)
+                """, reconRunId, matchGroupKey, resultType, contractId, differenceAmount);
+    }
+
     private Long anyPolicyVersionId() {
         return jdbcTemplate.queryForObject(
                 "SELECT MIN(policy_version_id) FROM fgc.policy_version WHERE policy_type = 'CURRENT_COMMISSION'",
@@ -422,5 +431,43 @@ class ValidationRunDetailMapperIntegrationTest {
             assertThat(row.getViolationCount()).isEqualTo(1);
             assertThat(row.getWarningCount()).isZero();
         });
+    }
+
+    // ── FGC-FUN-043: 규제(한도)·차익거래·대사 판정은 계약 하나에 동시에 존재해도
+    //    서로 다른 테이블·컬럼에 남아 하나의 종합 상태로 합쳐지거나 덮어써지지 않는다 ──
+
+    @Test
+    void capArbitrageAndReconciliationStatusesForSameContractRemainIndependent() {
+        Long runId = insertValidationRun(LocalDate.of(2031, 12, 1), 1, "RUNNING");
+        Long c1 = contractId("FGC-FGL01-202607-0001");
+
+        insertCapCheck(runId, c1, "INSURER_TO_GA", "VIOLATION");
+        insertArbitrageCheck(runId, c1, "CANDIDATE");
+        Long reconRunId = insertReconciliationRun(runId);
+        insertReconciliationResult(reconRunId, "FUN043-TAX-1", "AMOUNT_DIFFERENCE", c1, new BigDecimal("1000"));
+
+        String capStatus = jdbcTemplate.queryForObject("""
+                SELECT result_status FROM fgc.cap_check
+                 WHERE validation_run_id = ? AND contract_id = ?
+                """, String.class, runId, c1);
+        String arbitrageStatus = jdbcTemplate.queryForObject("""
+                SELECT result_status FROM fgc.arbitrage_check
+                 WHERE validation_run_id = ? AND contract_id = ?
+                """, String.class, runId, c1);
+        String reconciliationType = jdbcTemplate.queryForObject("""
+                SELECT result_type FROM fgc.reconciliation_result
+                 WHERE reconciliation_run_id = ? AND contract_id = ?
+                """, String.class, reconRunId, c1);
+
+        // 세 판정이 서로 다른 테이블/컬럼에 각자의 값으로 남아 하나를 덮어쓰지 않는다.
+        assertThat(capStatus).isEqualTo("VIOLATION");
+        assertThat(arbitrageStatus).isEqualTo("CANDIDATE");
+        assertThat(reconciliationType).isEqualTo("AMOUNT_DIFFERENCE");
+
+        // 집계 레이어(요약)에서도 세 판정이 각자의 카운트로 분리 유지된다.
+        ValidationRunResultSummaryRow summary = mapper.summarize(runId);
+        assertThat(summary.getCapViolationCount()).isEqualTo(1);
+        assertThat(summary.getArbitrageCandidateCount()).isEqualTo(1);
+        assertThat(summary.getReconciliationMismatchCount()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* TC-SGY-012(규제·대사·차익거래 상태체계 분리) QA 케이스 조사 중 발견된 자동화 테스트 갭을 메웠습니다.
* 한도(cap)·차익거래(arbitrage)·대사(reconciliation) 판정이 같은 계약에 동시에 존재해도 서로 덮어쓰지 않고 독립적으로 유지되는지 검증하는 통합 테스트를 추가했습니다.

## 🔗 2. 관련 이슈

* Closes #298

## 🛠 3. 구현 내용

* `ValidationRunDetailMapperIntegrationTest`에 `capArbitrageAndReconciliationStatusesForSameContractRemainIndependent` 테스트 추가
* 한 계약(c1)에 cap_check(VIOLATION)·arbitrage_check(CANDIDATE)·reconciliation_result(AMOUNT_DIFFERENCE)를 동시에 삽입 후, 원본 테이블 3곳에서 각자의 값이 그대로 남아있는지 직접 SQL로 조회해 확인
* `mapper.summarize(runId)` 집계 레이어에서도 세 판정이 각자의 카운트(capViolationCount / arbitrageCandidateCount / reconciliationMismatchCount)로 분리 유지되는지 함께 검증
* 기존 `insertReconciliationResult` 헬퍼에 contract_id를 받는 오버로드를 추가(기존 호출부는 변경 없음)

## 🧪 4. 테스트 방법

1. `./gradlew test --tests "com.susukkang.fgc.validation.mapper.ValidationRunDetailMapperIntegrationTest"` 실행 → 신규 테스트 포함 전체 통과 확인
2. `./gradlew test --tests "com.susukkang.fgc.validation.*"` 실행 → 회귀 없음 확인

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* 신규 테스트가 실제로 검증하려는 불변조건(서로 다른 테이블·컬럼이라 구조적으로 덮어쓸 수 없음)이 QA 케이스 TC-SGY-012의 의도와 맞는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음

## 💬 9. 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 동일 계약의 cap, arbitrage, reconciliation 판정이 서로 덮어쓰지 않고 독립적으로 유지되는지 검증하는 테스트를 추가했습니다.
  * 각 판정이 집계 결과에서도 별도 카운트로 정확히 반영되는지 확인합니다.
  * 계약 ID를 포함한 reconciliation 결과 테스트 데이터 생성을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->