### PR TITLE
[Test] 핵심 E2E 3회 연속 성공 안정성 검증 체계

### DIFF
--- a/src/test/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/batch/MonthlyValidationJobIntegrationTest.java
@@ -291,4 +291,60 @@ class MonthlyValidationJobIntegrationTest {
                 runNo);
         assertThat(rows).isEmpty();
     }
+
+    /**
+     * TER-006 안정화 DoD — 핵심 배치 실행이 연속 3회 모두 성공해야 한다.
+     * 실제 계약이 걸린 월을 쓰면 클래스 Javadoc에 적힌 이유(스케줄 확정·대사 이력으로 잠겨
+     * 롤백 불가)로 안전하게 반복할 수 없어, 이 테스트는 completesAllStepsAgainstSeedData와
+     * 같은 대상 없음(TEST_MONTH) 시나리오로 "매번 새 JobInstance로 9개 Step이 전부 COMPLETED,
+     * 실행끼리 산출물이 섞이지 않음, 잔여 데이터 없음"을 3회 연속 재확인한다.
+     *
+     * @author hjKang
+     * @since 2026-08-20
+     */
+    @Test
+    void repeatsTheFullJobThreeTimesConsecutivelyWithIdenticalOutcomesAndNoCrossRunLeakage() throws Exception {
+        jobLauncherTestUtils.setJob(monthlyValidationJob);
+
+        List<Long> runIds = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            long runNo = ThreadLocalRandom.current().nextLong(1, Integer.MAX_VALUE);
+            JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters("req-repeat-" + i, runNo));
+
+            assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+            assertThat(jobExecution.getStepExecutions())
+                    .filteredOn(step -> step.getStatus() == BatchStatus.FAILED)
+                    .isEmpty();
+
+            Long validationRunId = ValidationRunBatchContext.getValidationRunId(jobExecution.getExecutionContext());
+            assertThat(validationRunId).isNotNull();
+            // 이전 회차와 같은 JobInstance로 잘못 이어붙지 않고 매번 새 실행이어야 한다.
+            assertThat(runIds).doesNotContain(validationRunId);
+            runIds.add(validationRunId);
+            createdValidationRunIds.add(validationRunId);
+
+            Set<String> completedStepNames = jobExecution.getStepExecutions().stream()
+                    .filter(se -> se.getStatus() == BatchStatus.COMPLETED)
+                    .map(StepExecution::getStepName)
+                    .collect(Collectors.toSet());
+            assertThat(completedStepNames).contains(
+                    "createRunStep", "selectTargetStep", "regenerateScheduleStep",
+                    "capCheckStep", "arbitrageCheckStep", "journalPostingStep",
+                    "imbalanceCheckStep", "reconciliationStep", "exceptionGenerationStep");
+
+            ValidationRunRow row = validationRunMapper.findById(validationRunId);
+            assertThat(row.getStatus()).isEqualTo("COMPLETED");
+            assertThat(row.getRunNo()).isEqualTo(Math.toIntExact(runNo));
+        }
+
+        assertThat(runIds).hasSize(3);
+        // 3회 각각 자신의 validation_run에만 결과가 귀속되고, 회차 간 산출물이 섞이거나
+        // 중복 행이 남지 않는다.
+        for (Long runId : runIds) {
+            long selectedTargets = jdbcTemplate.queryForObject(
+                    "SELECT COUNT(*) FROM fgc.validation_target WHERE validation_run_id = ?",
+                    Long.class, runId);
+            assertThat(selectedTargets).isZero();
+        }
+    }
 }


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* TC-SGY-024(핵심 E2E 3회 연속 성공, TER-006 안정화 DoD) QA 케이스 조사 중 발견된 자동화 테스트 갭을 메웠습니다.
* 핵심 배치(MonthlyValidationJob)가 연속 3회 실행돼도 매번 새 JobInstance로 정상 완료되고, 회차 간 산출물이 섞이거나 잔여 데이터가 남지 않는지 검증하는 테스트를 추가했습니다.

## 🔗 2. 관련 이슈

* Closes #299

## 🛠 3. 구현 내용

* `MonthlyValidationJobIntegrationTest`에 `repeatsTheFullJobThreeTimesConsecutivelyWithIdenticalOutcomesAndNoCrossRunLeakage` 테스트 추가
* 기존 `completesAllStepsAgainstSeedData`와 동일하게 안전한 대상-없음 검증월(TEST_MONTH)을 사용해 3회 루프를 돌며, 매 회차마다 (1) 새 runNo로 새 JobInstance가 생성되는지(이전 회차와 validationRunId 중복 없음), (2) 9개 Step이 전부 COMPLETED로 끝나는지, (3) validation_run 상태가 COMPLETED로 반영되는지 확인
* 3회 종료 후 각 회차의 validation_run_id별로 validation_target에 잔여/교차 오염이 없는지 최종 확인
* 실제 계약이 걸린 월을 쓰지 않은 이유: 클래스 Javadoc에 명시된 대로 스케줄이 확정/대사 이력으로 잠기면 `@AfterEach`에서 안전하게 되돌릴 수 없기 때문 — 기존 테스트 설계 제약을 그대로 따랐습니다.

## 🧪 4. 테스트 방법

1. `./gradlew test --tests "com.susukkang.fgc.validation.batch.MonthlyValidationJobIntegrationTest"` 실행 → 신규 테스트 포함 4개 전체 통과 확인
2. `./gradlew test --tests "com.susukkang.fgc.validation.*"` 실행 → 회귀 없음 확인

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* 이 테스트는 "대상 없음" 월로 배치 배선·반복 안정성만 증명합니다. TER-006 원문의 "로그인→계약→스케줄→지급→원장→대사→예외→월검증 확정" 전체 HTTP+배치 체인을 포함하는 진짜 E2E가 필요한지, 아니면 이 정도(배치 반복 안정성)로 DoD를 충족하는지 판단 부탁드립니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음

## 💬 9. 참고 사항
