### PR TITLE
[Fix] 계약 등록 및 수수료 지급 화면 편의성 개선

### DIFF
--- a/docs/05_인터페이스정의서_v2_0.md
+++ b/docs/05_인터페이스정의서_v2_0.md
@@ -320,6 +320,7 @@ DB가 던진 제약 이름(`uq_contract_no` 등)을 오류코드로 바꾸는 �
 | IF-API-28 | SCHE-W02 | `GET /api/v1/schedules/{id}` | — | 코드·`*Label`을 포함한 헤더 + 회차별 라인 + `ruleRef`(근거) | 전체 | **Ajax** | FUN-036·039 |
 | IF-API-28A | SCHE-W02 | `GET /api/v1/schedules/{id}/versions` | — | 같은 계약·지급단계의 코드·`*Label` 포함 스케줄 버전 목록(최신순) | 전체 | Ajax | FUN-039 |
 | IF-API-28B | SCHE-W02 | `GET /api/v1/schedules/{id}/export.csv` | — | UTF-8 BOM CSV. 해당 헤더의 회차 표 전체(줄번호·회차·계약차월·지급예정일·수수료 항목·수령자·기준·요율·예상금액·상태·규칙 ID) | 전체 | 다운로드 | FUN-036·039 |
+| IF-API-28C | SCHE-W02 | `GET /api/v1/schedules/{id}/active?paymentStage={paymentStage}` | `paymentStage`(`INSURER_TO_GA` 또는 `GA_TO_FC`) | 같은 계약·선택 지급단계에서 사용 중인 최신 운영 스케줄의 `scheduleHeaderId` | 전체 | Ajax | FUN-039 |
 | IF-API-29 | SCHE-W02 | `POST /api/v1/schedules/{id}/regenerate` | `reason`(필수) | 새 `scheduleHeaderId`, `versionNo` | SETTLEMENT | Ajax | FUN-039·040 |
 | IF-API-29A | SCHE-W02 | `POST /api/v1/schedules/{id}/confirm` | — | 확정된 헤더(`header.status:"CONFIRMED"`) + 회차별 라인(`lines[].lineStatus`는 실제 상태 유지) | SETTLEMENT | Ajax | FUN-039·040 |
 | IF-API-30 | CAP-W01 | `GET /api/v1/cap-checks?month=&stage=&status=&insurerId=&contractNo=&orgId=&page=1&size=20` | 검색조건 + `page`(1-base, 기본 1), `size`(기본 20·최대 100) | `summary{normal,warning,violation,reviewRequired}`(`stage` 적용·`status` 제외) + 전체 검색범위의 `stageSummary[2]`(`stage`·`status` 제외, `violationCount`, `warningCount`, `reviewRequiredCount`) + `agentSummary[]`(GA→설계사만, `stage`·`status` 제외, `violationCount`, `warningCount`, `reviewRequiredCount`, `worstContractNo`, `worstUsagePct`, 모니터링 전용) + 페이징 `content[]`, `page`, `size`, `totalElements`, `totalPages`, `sort` | 전체 | **Ajax** | FUN-030·032·034 |
@@ -393,7 +394,7 @@ DB가 던진 제약 이름(`uq_contract_no` 등)을 오류코드로 바꾸는 �
 | TRAN-W01 | `GET /transactions` | `transaction/list.html` | **IF-API-20** | 진입 + 필터·페이지 변경 | `/transactions` |
 | TRAN-W02 | `GET /transactions/new` | `transaction/form.html` | **IF-API-11·21·22·23·24·25** | 계약 검색 · 수정 진입 시 조회 · [저장]·[사전검증]·[확정] 버튼 | `/transactions/new` |
 | SCHE-W01 | `GET /schedules` | `schedule/list.html` | **IF-API-27** · IF-API-27A(CSV 다운로드) | 진입 + 필터 변경 · [CSV 내보내기] | `/schedules` |
-| SCHE-W02 | `GET /schedules/{id}` | `schedule/detail.html` | **IF-API-28·28A·29·29A** · IF-API-28B(CSV 다운로드) | 진입(본문·버전 목록) · [새 버전 만들기]·[확정] · [CSV 내보내기] | `/schedules/:id` |
+| SCHE-W02 | `GET /schedules/{id}` | `schedule/detail.html` | **IF-API-28·28A·28C·29·29A** · IF-API-28B(CSV 다운로드) | 진입(본문·버전 목록) · 지급단계 전환 · [새 버전 만들기]·[확정] · [CSV 내보내기] | `/schedules/:id` |
 | CAP-W01 | `GET /cap-checks` | `cap/list.html` | **IF-API-30·31** | 진입 + 필터 변경(목록 **전체**가 Ajax) · 금액 클릭(CAP-W02 모달) | `/cap-checks` |
 | CAP-W02 | (팝업, 라우트 없음) | `cap/detail-modal.html` fragment | **IF-API-31** | 금액 클릭 | 모달 컴포넌트 |
 | ARB-W01 | `GET /arbitrage-checks` | `arbitrage/list.html` | **IF-API-32·33** | 진입 + 필터 변경 · [이 계약만 다시 검증] | `/arbitrage-checks` |

--- a/docs/FGC_화면정의서_v2_0.md
+++ b/docs/FGC_화면정의서_v2_0.md
@@ -850,7 +850,7 @@ FGC — GA 수수료 정산·검증 플랫폼
 회차별로 언제 얼마를 주고받을 예정인지 한 줄씩 보여줍니다. **대사의 기준값이 여기서 나옵니다.**
 
 **화면 구성**
-① 헤더 정보 — 계약, 방향, 체계, 버전, 상태, 정책버전, 생성 사유·일시
+① 헤더 정보 — 계약, 방향, 체계, 버전, 상태, 정책버전, 생성 사유·일시. 지급단계를 선택하면 같은 계약·선택 단계의 사용 중인 최신 운영 스케줄로 이동
 ② 회차 표 (아래)
 ③ 합계 줄
 ④ 버전 비교 영역 — 이전 버전과 나란히
@@ -876,6 +876,7 @@ FGC — GA 수수료 정산·검증 플랫폼
 
 | 버튼 | 하는 일 |
 |---|---|
+| 지급단계 선택 | 같은 계약에서 선택한 지급단계의 사용 중인 최신 운영 스케줄 상세로 이동합니다 |
 | 재생성 | **새 버전**을 만듭니다. 기존 버전은 남습니다 |
 | 확정 | 헤더 상태를 확정으로 |
 | CSV 내보내기 | 회차 표 전체를 UTF-8 BOM CSV로 내려받기 |
@@ -892,7 +893,7 @@ FGC — GA 수수료 정산·검증 플랫폼
 
 **데이터**
 - 읽기: `schedule_header`, `schedule_line`, `commission_rule`
-- API: `GET /api/v1/schedules/{id}`, `GET /api/v1/schedules/{id}/export.csv`, `POST /api/v1/schedules/{id}/regenerate`, `POST /api/v1/schedules/{id}/confirm`
+- API: `GET /api/v1/schedules/{id}`, `GET /api/v1/schedules/{id}/active?paymentStage={paymentStage}`, `GET /api/v1/schedules/{id}/export.csv`, `POST /api/v1/schedules/{id}/regenerate`, `POST /api/v1/schedules/{id}/confirm`
 
 **관련 요구사항** FUN-036, FUN-039, FUN-040
 

--- a/src/main/java/com/susukkang/fgc/base/dto/ProductResponse.java
+++ b/src/main/java/com/susukkang/fgc/base/dto/ProductResponse.java
@@ -33,7 +33,9 @@ public record ProductResponse(
         @Schema(description = "수수료 체계 코드", example = "CURRENT")
         String feeRegimeCode,
         @Schema(description = "표준해약공제액 80% 이상 공제 상품 여부", example = "true")
-        boolean standardDeduction80Yn
+        boolean standardDeduction80Yn,
+        @Schema(description = "활성 해약환급률표의 납입기간(개월). 표가 없으면 null", example = "240", nullable = true)
+        Integer paymentTermMonths
 ) {
     public static ProductResponse from(ProductRow row) {
         return new ProductResponse(
@@ -50,7 +52,8 @@ public record ProductResponse(
                 row.channelCode(),
                 row.channelSpecialRuleYn(),
                 row.feeRegimeCode(),
-                row.standardDeduction80Yn()
+                row.standardDeduction80Yn(),
+                row.paymentTermMonths()
         );
     }
 }

--- a/src/main/java/com/susukkang/fgc/base/dto/ProductRow.java
+++ b/src/main/java/com/susukkang/fgc/base/dto/ProductRow.java
@@ -19,6 +19,7 @@ public record ProductRow(
         String channelCode,
         boolean channelSpecialRuleYn,
         String feeRegimeCode,
-        boolean standardDeduction80Yn
+        boolean standardDeduction80Yn,
+        Integer paymentTermMonths
 ) {
 }

--- a/src/main/java/com/susukkang/fgc/contract/service/ContractService.java
+++ b/src/main/java/com/susukkang/fgc/contract/service/ContractService.java
@@ -278,7 +278,7 @@ public class ContractService {
         )) {
             throw validationException(
                     "agentId",
-                    "존재하지 않는 설계사입니다."
+                    "계약일 기준 활동 중인 FC 직급의 모집설계사만 선택할 수 있습니다."
             );
         }
 

--- a/src/main/java/com/susukkang/fgc/exceptioncase/dto/ExceptionCaseResponseDTO.java
+++ b/src/main/java/com/susukkang/fgc/exceptioncase/dto/ExceptionCaseResponseDTO.java
@@ -90,6 +90,9 @@ public record ExceptionCaseResponseDTO(
             case "EXPECTED_MISSING" -> "예상 지급 없음";
             case "DUPLICATE" -> "대사 대상 중복";
             case "AMOUNT_DIFFERENCE" -> "금액 불일치";
+            case "ORGANIZATION_MISMATCH" -> "소속 조직 불일치";
+            case "INSTALLMENT_MISMATCH" -> "회차 불일치";
+            case "REVIEW_REQUIRED" -> "검토 필요";
             // PRE_CONFIRM 실시간 경로는 상위 유형명을 그대로 상세 원인으로 저장한다
             // (CommissionPaymentServiceImpl.exceptionReasonCode) — 유형 한글 라벨로 보여 준다.
             default -> {

--- a/src/main/java/com/susukkang/fgc/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/susukkang/fgc/schedule/controller/ScheduleController.java
@@ -1,6 +1,7 @@
 package com.susukkang.fgc.schedule.controller;
 
 import com.susukkang.fgc.common.security.Roles;
+import com.susukkang.fgc.common.code.PaymentStage;
 import com.susukkang.fgc.common.web.ApiResponse;
 import com.susukkang.fgc.common.web.CsvExportWriter;
 import com.susukkang.fgc.common.web.PageResponse;
@@ -99,6 +100,14 @@ public class ScheduleController {
     @GetMapping("/{scheduleHeaderId}")
     public ApiResponse<ScheduleDetailResponse> getScheduleLineById(@PathVariable Long scheduleHeaderId) {
         return ApiResponse.success(scheduleService.selectScheduleDetailById(scheduleHeaderId));
+    }
+
+    /** 같은 계약의 선택한 지급단계에서 사용 중인 운영 스케줄 헤더 ID를 반환한다. */
+    @GetMapping("/{scheduleHeaderId}/active")
+    public ApiResponse<Long> getActiveScheduleByPaymentStage(
+            @PathVariable Long scheduleHeaderId,
+            @RequestParam PaymentStage paymentStage) {
+        return ApiResponse.success(scheduleService.findActiveOperationalScheduleId(scheduleHeaderId, paymentStage));
     }
 
     @GetMapping("/{scheduleHeaderId}/versions")

--- a/src/main/java/com/susukkang/fgc/schedule/dto/ScheduleHeaderResponse.java
+++ b/src/main/java/com/susukkang/fgc/schedule/dto/ScheduleHeaderResponse.java
@@ -26,6 +26,8 @@ import java.time.OffsetDateTime;
 public class ScheduleHeaderResponse {
     private Long scheduleHeaderId; // 스케줄 헤더 ID
     private String contractNo; // 화면에 표시할 계약 번호
+    private String insurerName; // 보험회사명
+    private String productName; // 상품명
     private PaymentStage paymentStage; // 지급 단계
 
     public String getPaymentStageLabel() {

--- a/src/main/java/com/susukkang/fgc/schedule/service/ScheduleService.java
+++ b/src/main/java/com/susukkang/fgc/schedule/service/ScheduleService.java
@@ -151,6 +151,28 @@ public class ScheduleService {
         }
         return scheduleMapper.selectVersionsByScheduleHeaderId(scheduleHeaderId);
     }
+
+    /** 같은 계약에서 선택한 지급단계의 사용 중인 운영 스케줄 헤더를 찾는다. */
+    @Transactional(readOnly = true)
+    public Long findActiveOperationalScheduleId(Long scheduleHeaderId, PaymentStage paymentStage) {
+        if (scheduleHeaderId == null) {
+            throw validationException("scheduleHeaderId", "스케줄 헤더 ID는 필수입니다.");
+        }
+        if (paymentStage == null) {
+            throw validationException("paymentStage", "지급단계는 필수입니다.");
+        }
+
+        ScheduleHeaderInsertDTO current = scheduleMapper.selectScheduleHeaderById(scheduleHeaderId);
+        if (current == null) {
+            throw validationException("scheduleHeaderId", "존재하지 않는 스케줄입니다.");
+        }
+        ScheduleDetailResponse target = scheduleMapper.selectByContractIdAndPaymentStage(
+                current.getContractId(), paymentStage);
+        if (target == null || target.getScheduleHeaderId() == null) {
+            throw validationException("paymentStage", "선택한 지급단계의 사용 중인 운영 스케줄이 없습니다.");
+        }
+        return target.getScheduleHeaderId();
+    }
     /**
      * 설명 : 계약 ID에 따라 회차별 스케줄을 자동 생성한다
      * @param contract 계약 class

--- a/src/main/resources/mapper/base/ProductMapper.xml
+++ b/src/main/resources/mapper/base/ProductMapper.xml
@@ -26,7 +26,17 @@
                po.channel_code AS channelCode,
                po.channel_special_rule_yn AS channelSpecialRuleYn,
                po.fee_regime_code AS feeRegimeCode,
-               po.standard_deduction_80_yn AS standardDeduction80Yn
+               po.standard_deduction_80_yn AS standardDeduction80Yn,
+               (
+                   SELECT rrt.payment_term_months
+                     FROM fgc.refund_rate_table rrt
+                     JOIN fgc.policy_version pv ON pv.policy_version_id = rrt.policy_version_id
+                    WHERE rrt.product_offering_id = po.product_offering_id
+                      AND pv.status = 'ACTIVE'
+                      AND rrt.effective_from &lt;= #{criteria.asOf}
+                    ORDER BY rrt.effective_from DESC, rrt.refund_rate_table_id DESC
+                    LIMIT 1
+               ) AS paymentTermMonths
           FROM fgc.product p
           JOIN fgc.product_offering po
             ON po.product_id = p.product_id

--- a/src/main/resources/mapper/base/ProductMapper.xml
+++ b/src/main/resources/mapper/base/ProductMapper.xml
@@ -31,9 +31,12 @@
                    SELECT rrt.payment_term_months
                      FROM fgc.refund_rate_table rrt
                      JOIN fgc.policy_version pv ON pv.policy_version_id = rrt.policy_version_id
-                    WHERE rrt.product_offering_id = po.product_offering_id
+                    WHERE rrt.insurer_id = p.insurer_id
+                      AND rrt.product_id = p.product_id
+                      AND rrt.channel_code = po.channel_code
                       AND pv.status = 'ACTIVE'
                       AND rrt.effective_from &lt;= #{criteria.asOf}
+                      AND (rrt.effective_to IS NULL OR rrt.effective_to &gt;= #{criteria.asOf})
                     ORDER BY rrt.effective_from DESC, rrt.refund_rate_table_id DESC
                     LIMIT 1
                ) AS paymentTermMonths

--- a/src/main/resources/mapper/contract/ContractMapper.xml
+++ b/src/main/resources/mapper/contract/ContractMapper.xml
@@ -206,6 +206,7 @@
             SELECT 1
             FROM fgc.agent
             WHERE agent_id = #{agentId}
+              AND rank_code = 'FC'
               AND active_yn = TRUE
               AND agent_status = 'ACTIVE'
               AND appointment_date <![CDATA[ <= ]]> #{contractDate}

--- a/src/main/resources/mapper/schedule/ScheduleMapper.xml
+++ b/src/main/resources/mapper/schedule/ScheduleMapper.xml
@@ -176,6 +176,8 @@
                      javaType="com.susukkang.fgc.schedule.dto.ScheduleHeaderResponse">
             <id property="scheduleHeaderId" column="schedule_header_id"/>
             <result property="contractNo" column="contract_no"/>
+            <result property="insurerName" column="insurer_name"/>
+            <result property="productName" column="product_name"/>
             <result property="paymentStage" column="payment_stage"/>
             <result property="scheduleRegime" column="schedule_regime"/>
             <result property="schedulePurpose" column="schedule_purpose"/>
@@ -214,6 +216,8 @@
             -- 헤더 컬럼
             sh.schedule_header_id,
             c.contract_no,
+            i.insurer_name,
+            p.product_name,
             sh.payment_stage,
             sh.schedule_regime,
             sh.schedule_purpose,
@@ -243,6 +247,12 @@
         FROM schedule_header sh
              JOIN insurance_contract c
                   ON c.contract_id = sh.contract_id
+             JOIN insurer i
+                  ON i.insurer_id = c.insurer_id
+             JOIN product_offering po
+                  ON po.product_offering_id = c.product_offering_id
+             JOIN product p
+                  ON p.product_id = po.product_id
              JOIN policy_version pv
                   ON pv.policy_version_id = sh.policy_version_id
              LEFT JOIN schedule_line sl

--- a/src/main/resources/static/js/features/contract/contract-form.js
+++ b/src/main/resources/static/js/features/contract/contract-form.js
@@ -263,7 +263,11 @@
     updateSaveState();
     return contractApi.getAgents(contractDate).then(function (envelope) {
       if (requestSequence !== agentRequestSequence) return;
-      var agents = pageContent(envelope.data);
+      var agents = pageContent(envelope.data).filter(function (agent) {
+        return agent.rankCode === "FC"
+          && agent.agentStatus === "ACTIVE"
+          && agent.activeYn === true;
+      });
       replaceOptions(elements.agentId,
         agents.length ? "모집 설계사를 선택하세요" : "선택 가능한 설계사가 없습니다.",
         agents,
@@ -366,6 +370,7 @@
       loadAgents();
     }
     if (event.target === elements.agentId) setOrganizationFromAgent();
+    if (event.target === elements.productOfferingId) syncProductDependentFields();
     if (event.target === elements.paymentCycleCode) syncPremiumPerCycleAmount();
     updateSaveState();
   }
@@ -377,35 +382,34 @@
     });
   }
 
-  function warnIfRefundRateTableIsMissing(contractId) {
+  function syncProductDependentFields() {
     var product = selectedProductOffering();
-    if (!product || !product.standardDeduction80Yn) return Promise.resolve(false);
+    var standardDeductionAllowed = Boolean(product && product.standardDeduction80Yn);
+    elements.standardSurrenderDeductionAmount.disabled = !standardDeductionAllowed;
+    elements.standardSurrenderDeductionAmount.setAttribute("aria-disabled", String(!standardDeductionAllowed));
+    if (!standardDeductionAllowed) elements.standardSurrenderDeductionAmount.value = "";
 
-    return contractApi.getCapChecks(contractId).then(function (envelope) {
-      var checks = Array.isArray(envelope.data) ? envelope.data : [];
-      var missingRefundRateTable = checks.some(function (check) {
-        var result = check && check.result;
-        return result
-          && result.resultStatus === "REVIEW_REQUIRED"
-          && !result.refundRateTableId
-          && result.calculationSnapshot
-          && result.calculationSnapshot.refundAdditionCondition === "STANDARD_DEDUCTION_80";
-      });
-      if (!missingRefundRateTable) return false;
+    var paymentTermMonths = product && product.paymentTermMonths;
+    var hasRefundRateTable = Number.isInteger(Number(paymentTermMonths)) && Number(paymentTermMonths) > 0;
+    elements.paymentTermMonths.readOnly = hasRefundRateTable;
+    elements.paymentTermMonths.setAttribute("aria-readonly", String(hasRefundRateTable));
+    if (hasRefundRateTable) elements.paymentTermMonths.value = String(paymentTermMonths);
+  }
 
-      var term = elements.paymentTermMonths.value || "입력한";
-      if (window.FgcUi && typeof window.FgcUi.toast === "function") {
-        window.FgcUi.toast(
-          term + "개월 납입기간에 적용할 12차월 환급률표가 없어 1,200% 한도 판정이 검토필요입니다. 기준정보를 확인하세요.",
-          "warning",
-          6000
-        );
-      }
-      return true;
-    }).catch(function () {
-      // 계약 저장은 성공했으므로 안내 조회 실패가 상세 이동을 막으면 안 된다.
-      return false;
-    });
+  function warnIfRefundRateTableIsMissing() {
+    var product = selectedProductOffering();
+    if (!product || !product.standardDeduction80Yn || product.paymentTermMonths != null) {
+      return Promise.resolve(false);
+    }
+
+    if (window.FgcUi && typeof window.FgcUi.toast === "function") {
+      window.FgcUi.toast(
+        "선택한 상품버전에 적용할 해약환급률표가 없습니다. 계약은 저장되며, 월 통합검증에서 검토필요로 처리됩니다.",
+        "warning",
+        6000
+      );
+    }
+    return Promise.resolve(true);
   }
 
   function handleInput(event) {
@@ -436,11 +440,7 @@
       var redirect = function () {
         window.location.assign("/contracts/" + encodeURIComponent(savedContractId));
       };
-      if (isEditMode) {
-        redirect();
-        return;
-      }
-      warnIfRefundRateTableIsMissing(savedContractId).then(function (warned) {
+      warnIfRefundRateTableIsMissing().then(function (warned) {
         window.setTimeout(redirect, warned ? 1800 : 0);
       });
     }).catch(function (error) {
@@ -462,6 +462,7 @@
     showError(error, "계약 입력 화면을 준비하지 못했습니다.");
   }).finally(function () {
     isInitializing = false;
+    syncProductDependentFields();
     syncPremiumPerCycleAmount();
     updateSaveState();
   });

--- a/src/main/resources/static/js/features/contract/contract-form.js
+++ b/src/main/resources/static/js/features/contract/contract-form.js
@@ -370,7 +370,7 @@
       loadAgents();
     }
     if (event.target === elements.agentId) setOrganizationFromAgent();
-    if (event.target === elements.productOfferingId) syncProductDependentFields();
+    if (event.target === elements.productOfferingId) syncProductDependentFields(true);
     if (event.target === elements.paymentCycleCode) syncPremiumPerCycleAmount();
     updateSaveState();
   }
@@ -382,18 +382,22 @@
     });
   }
 
-  function syncProductDependentFields() {
+  function syncProductDependentFields(overwriteValues) {
     var product = selectedProductOffering();
     var standardDeductionAllowed = Boolean(product && product.standardDeduction80Yn);
     elements.standardSurrenderDeductionAmount.disabled = !standardDeductionAllowed;
     elements.standardSurrenderDeductionAmount.setAttribute("aria-disabled", String(!standardDeductionAllowed));
-    if (!standardDeductionAllowed) elements.standardSurrenderDeductionAmount.value = "";
+    if (overwriteValues && !standardDeductionAllowed) {
+      elements.standardSurrenderDeductionAmount.value = "";
+    }
 
     var paymentTermMonths = product && product.paymentTermMonths;
     var hasRefundRateTable = Number.isInteger(Number(paymentTermMonths)) && Number(paymentTermMonths) > 0;
     elements.paymentTermMonths.readOnly = hasRefundRateTable;
     elements.paymentTermMonths.setAttribute("aria-readonly", String(hasRefundRateTable));
-    if (hasRefundRateTable) elements.paymentTermMonths.value = String(paymentTermMonths);
+    if (overwriteValues && hasRefundRateTable) {
+      elements.paymentTermMonths.value = String(paymentTermMonths);
+    }
   }
 
   function warnIfRefundRateTableIsMissing() {
@@ -462,7 +466,9 @@
     showError(error, "계약 입력 화면을 준비하지 못했습니다.");
   }).finally(function () {
     isInitializing = false;
-    syncProductDependentFields();
+    // 수정 화면 최초 진입에서는 계약에 저장된 값을 보존하고 입력 가능 상태만 갱신한다.
+    // 상품버전을 사용자가 직접 변경했을 때만 새 상품 기준값으로 덮어쓴다.
+    syncProductDependentFields(!isEditMode);
     syncPremiumPerCycleAmount();
     updateSaveState();
   });

--- a/src/main/resources/static/js/features/schedule/schedule-detail.js
+++ b/src/main/resources/static/js/features/schedule/schedule-detail.js
@@ -10,6 +10,8 @@
   var regenerateReason = document.getElementById("regenerate-reason");
   var regenerateSubmit = document.getElementById("btn-regenerate-submit");
   var exportButton = document.getElementById("btn-export");
+  var stageSelect = document.getElementById("stage");
+  var currentPaymentStage = null;
   var PAYMENT_STAGE_LABELS = { INSURER_TO_GA: "원수사→GA", GA_TO_FC: "GA→설계사" };
   var SCHEDULE_REGIME_LABELS = {
     CURRENT: "현행",
@@ -46,6 +48,7 @@
   if (exportButton) exportButton.addEventListener("click", function () {
     window.location.assign("/api/v1/schedules/" + encodeURIComponent(scheduleHeaderId) + "/export.csv");
   });
+  if (stageSelect) stageSelect.addEventListener("change", moveToPaymentStage);
   if (regenerateButton) regenerateButton.addEventListener("click", regenerateSchedule);
   if (regenerateReason) regenerateReason.addEventListener("input", updateRegenerateSubmit);
   if (regenerateSubmit) regenerateSubmit.addEventListener("click", submitRegeneration);
@@ -78,7 +81,7 @@
   function renderHeader(header) {
     setText("hdr-id", "schedule_header #" + value(header.scheduleHeaderId));
     setText("hdr-contract", header.contractNo);
-    setText("hdr-product", "—");
+    setText("hdr-product", join(header.insurerName, header.productName));
     setText("hdr-stage", responseLabel(header.paymentStageLabel, PAYMENT_STAGE_LABELS, header.paymentStage));
     setText("hdr-regime", responseLabel(header.scheduleRegimeLabel, SCHEDULE_REGIME_LABELS, header.scheduleRegime));
     setText("hdr-purpose", responseLabel(header.schedulePurposeLabel, SCHEDULE_PURPOSE_LABELS, header.schedulePurpose));
@@ -88,10 +91,10 @@
     setText("hdr-policy", header.policyVersionLabel);
     setText("hdr-reason", join(header.generationReason, formatDateTime(header.generatedAt)));
 
-    var stage = document.getElementById("stage");
-    if (stage && header.paymentStage) {
-      stage.value = header.paymentStage;
-      stage.disabled = true;
+    if (stageSelect && header.paymentStage) {
+      currentPaymentStage = header.paymentStage;
+      stageSelect.value = header.paymentStage;
+      stageSelect.disabled = false;
     }
     if (confirmButton) {
       confirmButton.disabled = !canProcess || header.status !== "PLANNED" || header.activeYn !== true;
@@ -100,6 +103,25 @@
     if (regenerateButton) {
       regenerateButton.disabled = !canProcess || header.activeYn !== true || header.status === "CANCELLED";
     }
+  }
+
+  function moveToPaymentStage() {
+    var targetStage = stageSelect.value;
+    if (!targetStage || targetStage === currentPaymentStage) return;
+
+    stageSelect.disabled = true;
+    apiClient.request("/api/v1/schedules/" + encodeURIComponent(scheduleHeaderId)
+      + "/active?paymentStage=" + encodeURIComponent(targetStage))
+      .then(function (envelope) {
+        var targetScheduleHeaderId = envelope && envelope.data;
+        if (targetScheduleHeaderId == null) throw new Error("이동할 스케줄을 찾을 수 없습니다.");
+        window.location.assign("/schedules/" + encodeURIComponent(String(targetScheduleHeaderId)));
+      })
+      .catch(function (error) {
+        stageSelect.value = currentPaymentStage || "";
+        stageSelect.disabled = false;
+        toast(error && error.message ? error.message : "선택한 지급단계의 스케줄을 찾을 수 없습니다.", "warning", 4500);
+      });
   }
 
   function confirmSchedule() {

--- a/src/main/resources/static/js/features/transaction/transaction-form.js
+++ b/src/main/resources/static/js/features/transaction/transaction-form.js
@@ -6,7 +6,8 @@
   if (!apiClient || !main) return;
 
   var AGENTS = [];
-  var SOURCE_TYPES = [["GA_MANUAL_PAYMENT", "GA 수기지급"]];
+  var MANUAL_PAYMENT_SOURCE_TYPE = "GA_MANUAL_PAYMENT";
+  var SOURCE_TYPES = [[MANUAL_PAYMENT_SOURCE_TYPE, "GA 수기지급"]];
   var contracts = [];
   var attributionSequence = 0;
   var saving = false;
@@ -31,6 +32,7 @@
 
   initializeSettlementMonth();
   fillOptions(sourceType, SOURCE_TYPES, "원천유형을 선택하세요");
+  sourceType.value = MANUAL_PAYMENT_SOURCE_TYPE;
   fillOptions(recipient, [], "설계사를 불러오는 중입니다.");
   if (!paymentId && !bizKey.value) bizKey.value = generateBusinessKey();
 
@@ -124,7 +126,7 @@
         && (!isInsurerToGa() || entry.itemCode !== "NEWCOMER_SUPPORT");
     })
       .map(function (entry) {
-        return [String(entry.commissionItemId), entry.itemCode + " · " + entry.itemName];
+        return [String(entry.commissionItemId), entry.itemName];
       });
     fillOptions(item, options, "수수료 항목을 선택하세요");
     item.value = selected;
@@ -137,7 +139,7 @@
         var draft = envelope && envelope.data;
         if (!draft || draft.status !== "DRAFT") throw new Error("수정 가능한 지급 초안이 아닙니다.");
         stage.value = draft.paymentStage || "";
-        sourceType.value = draft.sourceType || "";
+        sourceType.value = MANUAL_PAYMENT_SOURCE_TYPE;
         bizKey.value = draft.sourceBusinessKey || "";
         settlementMonth.value = String(draft.settlementMonth || "").slice(0, 7);
         cashflow.value = draft.cashflowType || "PAYMENT";

--- a/src/main/resources/templates/transaction/form.html
+++ b/src/main/resources/templates/transaction/form.html
@@ -89,7 +89,6 @@
 
           <div class="fgc-field">
             <label class="fgc-label fgc-label--required" for="sourceType">원천유형</label>
-            <!-- 원천유형 선택지는 IF-API-22 연동 시 코드 테이블로 채운다 -->
             <select class="fgc-select" id="sourceType"></select>
           </div>
 
@@ -130,8 +129,8 @@
           <div class="fgc-field">
             <label class="fgc-label fgc-label--required" for="cashflow">흐름</label>
             <select class="fgc-select" id="cashflow">
-              <option value="PAYMENT">지급 (PAYMENT)</option>
-              <option value="DEDUCTION">차감 (DEDUCTION)</option>
+              <option value="PAYMENT">지급</option>
+              <option value="DEDUCTION">차감</option>
             </select>
           </div>
 

--- a/src/main/resources/templates/vrun/list.html
+++ b/src/main/resources/templates/vrun/list.html
@@ -113,9 +113,9 @@
                     th:classappend="${run.status().name() == 'FAILED'} ? 'fgc-badge--violation'
                                     : (${run.status().name() == 'FINALIZED'} ? 'fgc-badge--review'
                                     : (${run.status().name() == 'COMPLETED'} ? 'fgc-badge--normal' : 'fgc-badge--warning'))"
-                    th:text="${run.statusLabel()}">생성됨</span>
-              <span class="material-symbols-outlined" style="font-size:14px;vertical-align:middle"
-                    th:if="${run.status().name() == 'FINALIZED'}">lock</span>
+                    ><span th:text="${run.status().name() == 'FINALIZED' ? '확정' : run.statusLabel()}">생성됨</span><span class="material-symbols-outlined"
+                    style="font-size:14px;vertical-align:-2px;margin-left:2px"
+                    th:if="${run.status().name() == 'FINALIZED'}">lock</span></span>
             </td>
             <td class="fgc-mono"
                 th:text="|${run.currentStep()}/10 단계 (${run.currentStep() * 10}%)|">0/10 단계 (0%)</td>

--- a/src/test/java/com/susukkang/fgc/base/controller/ProductControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/base/controller/ProductControllerTest.java
@@ -69,7 +69,8 @@ class ProductControllerTest {
                 "FACE_TO_FACE",
                 false,
                 "CURRENT",
-                true
+                true,
+                240
         );
         given(productService.search(criteria, 1, 20)).willReturn(
                 PageResponse.of(List.of(product), 1, 20, 1, SORT)

--- a/src/test/java/com/susukkang/fgc/base/mapper/AgentMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/base/mapper/AgentMapperIntegrationTest.java
@@ -2,6 +2,7 @@ package com.susukkang.fgc.base.mapper;
 
 import com.susukkang.fgc.base.dto.AgentRow;
 import com.susukkang.fgc.base.dto.AgentSearchCriteria;
+import com.susukkang.fgc.common.code.AgentRankCode;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -108,6 +109,42 @@ class AgentMapperIntegrationTest {
         });
     }
 
+    @Test
+    void everyActiveSeedFcHasTeamBranchAndDivisionManagers() {
+        LocalDate asOf = LocalDate.of(2026, 8, 20);
+        List<SeedFc> activeFcs = jdbcTemplate.query("""
+                SELECT agent_code, organization_id
+                  FROM fgc.agent
+                 WHERE rank_code = 'FC'
+                   AND agent_status = 'ACTIVE'
+                   AND active_yn = TRUE
+                   AND appointment_date <= ?
+                   AND (termination_date IS NULL OR termination_date >= ?)
+                 ORDER BY agent_code
+                """, (rs, rowNum) -> new SeedFc(
+                        rs.getString("agent_code"),
+                        rs.getLong("organization_id")
+                ), asOf, asOf);
+
+        assertThat(activeFcs).extracting(SeedFc::agentCode)
+                .containsExactly("A-FC-001", "A-FC-002", "A-FC-003");
+
+        activeFcs.forEach(fc -> {
+            assertThat(agentMapper.findActiveAgentIdFromOrganizationHierarchy(
+                    fc.organizationId(), AgentRankCode.TEAM_LEADER, asOf))
+                    .as("%s의 팀장", fc.agentCode())
+                    .isNotNull();
+            assertThat(agentMapper.findActiveAgentIdFromOrganizationHierarchy(
+                    fc.organizationId(), AgentRankCode.BRANCH_MANAGER, asOf))
+                    .as("%s의 지사장", fc.agentCode())
+                    .isNotNull();
+            assertThat(agentMapper.findActiveAgentIdFromOrganizationHierarchy(
+                    fc.organizationId(), AgentRankCode.DIVISION_HEAD, asOf))
+                    .as("%s의 본부장", fc.agentCode())
+                    .isNotNull();
+        });
+    }
+
     private long insertOrganization(String code, String name) {
         return jdbcTemplate.queryForObject("""
                 INSERT INTO fgc.organization (
@@ -156,5 +193,8 @@ class AgentMapperIntegrationTest {
                 status,
                 activeYn
         );
+    }
+
+    private record SeedFc(String agentCode, long organizationId) {
     }
 }

--- a/src/test/java/com/susukkang/fgc/base/mapper/ProductMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/base/mapper/ProductMapperIntegrationTest.java
@@ -115,6 +115,29 @@ class ProductMapperIntegrationTest {
         assertThat(productMapper.countProducts(criteria)).isZero();
     }
 
+    @Test
+    void findsRefundRatePaymentTermByProductAndChannelAcrossOfferingVersions() {
+        Long insurerId = jdbcTemplate.queryForObject("""
+                SELECT insurer_id
+                  FROM fgc.insurer
+                 WHERE insurer_code = 'FGL02'
+                """, Long.class);
+
+        List<ProductRow> rows = productMapper.selectProducts(
+                new ProductSearchCriteria(insurerId, LocalDate.of(2026, 5, 10)),
+                0,
+                20
+        );
+
+        assertThat(rows)
+                .filteredOn(row -> "STD-LIFE-B".equals(row.standardProductCode()))
+                .singleElement()
+                .satisfies(row -> {
+                    assertThat(row.offeringVersion()).isEqualTo("2026-H1-B");
+                    assertThat(row.paymentTermMonths()).isEqualTo(240);
+                });
+    }
+
     private long insertInsurer(String code) {
         return jdbcTemplate.queryForObject("""
                 INSERT INTO fgc.insurer (insurer_code, insurer_name, insurer_type)

--- a/src/test/java/com/susukkang/fgc/base/service/ProductServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/base/service/ProductServiceImplTest.java
@@ -43,7 +43,7 @@ class ProductServiceImplTest {
                 21L, "P-B-001", "STD-LIFE-B", "가상 저해지 건강보험 B",
                 "HEALTH_PROTECTION", "2026-CURRENT-B",
                 LocalDate.of(2026, 7, 1), null, "BD-2026-07",
-                LocalDate.of(2026, 7, 1), "FACE_TO_FACE", false, "CURRENT", true
+                LocalDate.of(2026, 7, 1), "FACE_TO_FACE", false, "CURRENT", true, 240
         );
         when(productMapper.selectProducts(criteria, 20, 20)).thenReturn(List.of(row));
         when(productMapper.countProducts(criteria)).thenReturn(21L);
@@ -61,6 +61,7 @@ class ProductServiceImplTest {
             assertThat(response.productOfferingId()).isEqualTo(21L);
             assertThat(response.channelCode()).isEqualTo("FACE_TO_FACE");
             assertThat(response.standardDeduction80Yn()).isTrue();
+            assertThat(response.paymentTermMonths()).isEqualTo(240);
         });
     }
 

--- a/src/test/java/com/susukkang/fgc/contract/mapper/ContractMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/mapper/ContractMapperIntegrationTest.java
@@ -60,6 +60,17 @@ class ContractMapperIntegrationTest {
                 refs.insurerId(), refs.productOfferingId(), LocalDate.of(1900, 1, 1))).isFalse();
         assertThat(contractMapper.existsAgent(
                 refs.agentId(), LocalDate.of(1900, 1, 1))).isFalse();
+
+        Long managerId = jdbcTemplate.queryForObject("""
+                SELECT agent_id
+                  FROM fgc.agent
+                 WHERE rank_code <> 'FC'
+                   AND active_yn = TRUE
+                   AND agent_status = 'ACTIVE'
+                 ORDER BY agent_id
+                 LIMIT 1
+                """, Long.class);
+        assertThat(contractMapper.existsAgent(managerId, contractDate)).isFalse();
     }
 
     @Test
@@ -197,6 +208,9 @@ class ContractMapperIntegrationTest {
                 CROSS JOIN LATERAL (
                     SELECT agent_id, organization_id
                     FROM fgc.agent
+                    WHERE rank_code = 'FC'
+                      AND active_yn = TRUE
+                      AND agent_status = 'ACTIVE'
                     ORDER BY agent_id
                     LIMIT 1
                 ) a

--- a/src/test/java/com/susukkang/fgc/exceptioncase/controller/ExceptionCaseViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/exceptioncase/controller/ExceptionCaseViewControllerTest.java
@@ -29,6 +29,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -57,6 +58,16 @@ class ExceptionCaseViewControllerTest {
     private ExceptionCaseService service;
 
     private static final FgcUserDetails SETTLE = principal("settle01", "정산담당", "SETTLEMENT");
+
+    @Test
+    void mapsExceptionDetailReasonCodesToKoreanLabels() {
+        assertThat(ExceptionCaseResponseDTO.labelOf("ORGANIZATION_MISMATCH"))
+                .isEqualTo("소속 조직 불일치");
+        assertThat(ExceptionCaseResponseDTO.labelOf("INSTALLMENT_MISMATCH"))
+                .isEqualTo("회차 불일치");
+        assertThat(ExceptionCaseResponseDTO.labelOf("REVIEW_REQUIRED"))
+                .isEqualTo("검토 필요");
+    }
 
     @Test
     void defaultsToOpenAndRendersPagedRowsWithSelectableDetails() throws Exception {


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

<!-- 이 PR에서 무엇을 변경했는지 간단히 작성해주세요. -->

- 계약 등록 시 상품 및 설계사 조건에 따른 입력 제어를 추가했습니다.
- 수수료 지급, 스케줄 상세, 월 통합검증 및 예외함의 UI 표시를 개선했습니다.
- 활동 중인 FC의 상위 조직 수령자 시드 구성을 검증하는 테스트를 추가했습니다.

## 🔗 2. 관련 이슈

<!-- 병합 시 이슈를 자동 종료하려면 Closes 또는 Resolves를 사용해주세요. -->

* Closes #311

## 🛠 3. 구현 내용

<!-- 주요 구현 내용과 처리 방식을 작성해주세요. -->

- `standard_deduction_80_yn = true`인 상품만 표준해약공제액을 입력할 수 있도록 처리했습니다.
- 상품버전의 환급률표에 맞춰 납입기간을 자동으로 설정하고, 환급률표가 없으면 저장 후 경고 Toast를 표시하도록 했습니다.
- 계약의 모집설계사 선택 목록에는 활동 중인 FC만 표시하고, 서버에서도 FC 직급만 계약에 등록할 수 있도록 검증을 추가했습니다.
- 수수료 지급 생성의 수수료 항목과 흐름을 영문 코드 없이 한글 명칭으로 표시했습니다.
- 원천 유형은 `GA 수기지급`을 기본값으로 자동 선택하도록 변경했습니다.
- 스케줄 상세 헤더에 보험회사와 상품 정보를 표시했습니다.
- 스케줄 상세에서 지급단계를 변경하면 같은 계약의 해당 지급단계 최신 활성 스케줄로 이동하도록 변경했습니다.
- 월 통합검증 확정 상태의 자물쇠 아이콘을 상태 배지 내부로 이동했습니다.
- 예외함 상세 원인을 다음과 같이 한글로 표시하도록 추가했습니다.
  - `ORGANIZATION_MISMATCH` → `소속 조직 불일치`
  - `INSTALLMENT_MISMATCH` → `회차 불일치`
  - `REVIEW_REQUIRED` → `검토 필요`
- 최신 데모 시드 기준으로 활동 중인 모든 FC에게 팀장·지사장·본부장이 배정되어 있는지 검증하는 통합 테스트를 추가했습니다.

## 🧪 4. 테스트 방법

<!-- 리뷰어가 동일하게 확인할 수 있도록 테스트 절차를 작성해주세요. -->

1. 다음 테스트를 실행합니다.
   ```bash
   ./gradlew test \
     --tests "com.susukkang.fgc.contract.mapper.ContractMapperIntegrationTest" \
     --tests "com.susukkang.fgc.base.mapper.AgentMapperIntegrationTest" \
     --tests "com.susukkang.fgc.contract.service.ContractServiceTest" \
     --tests "com.susukkang.fgc.base.controller.ProductControllerTest" \
     --tests "com.susukkang.fgc.base.service.ProductServiceImplTest" \
     --tests "com.susukkang.fgc.exceptioncase.controller.ExceptionCaseViewControllerTest"
   ```
2. 계약 등록 화면에서 상품버전을 변경하여 표준해약공제액 활성화 여부, 납입기간 자동 설정 및 FC만 선택되는지 확인합니다.
3. 수수료 지급 생성, 스케줄 상세, 월 통합검증 실행목록 및 예외함에서 변경된 한글 명칭과 UI가 정상적으로 표시되는지 확인합니다.

## 🗄️ 5. DB / Flyway 변경

<!-- 해당 사항에 체크해주세요. -->

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

<!-- 예: V3__add_login_failure_count.sql -->

* 없음

## 📋 6. 리뷰 요구사항

<!-- 특별히 확인받고 싶은 로직이나 파일을 작성해주세요. -->

- 계약 등록 화면뿐 아니라 서버에서도 FC 직급을 검증하는 방식이 적절한지 확인 부탁드립니다.
- 환급률표가 없는 경우 계약 저장은 허용하고 경고만 표시하는 흐름을 확인 부탁드립니다.
- 지급단계 변경 시 같은 계약의 최신 활성 스케줄로 이동하는 기준을 확인 부탁드립니다.
- 예외함 상세 원인의 한글 명칭이 업무 용어와 일치하는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [ ] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [ ] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

<!-- 화면 변경이 없다면 '없음'으로 작성해주세요. -->

* 계약 등록
    - 표준해약공제액 입력 활성화 제어
    - 납입기간 자동 설정
    - 모집설계사 FC 제한
    - 환급률표 누락 경고 Toast
* 수수료 지급 생성
    - 수수료 항목 및 흐름 한글 표시
    - 원천 유형 기본값 설정
* 스케줄 상세
    - 보험회사·상품 정보 표시
    - 지급단계 변경 기능
* 월 통합검증
    - 확정 자물쇠 아이콘 위치 변경
* 예외함
    - 상세 원인 한글 표시

## 💬 9. 참고 사항

<!-- 리뷰어가 알아야 할 제약사항, 후속 작업, 보류 사항 등을 작성해주세요. -->

- 테스트 DB는 Testcontainers의 임시 PostgreSQL에 `db/migration`, `db/demo`를 처음부터 적용하여 검증했습니다.
- `V34__seed_team_leader_for_gangdong_second_team.sql`을 포함한 시드 기준으로 활동 중인 `A-FC-001`, `A-FC-002`, `A-FC-003`의 팀장·지사장·본부장 배정을 확인했습니다.
- `A-FC-004`는 해촉 시나리오용 데이터이므로 계약 등록 선택 대상에서 제외됩니다.
- 애플리케이션을 실행한 브라우저 수동 테스트는 별도로 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 상품 정보에 해약환급률표의 납입기간을 표시합니다.
  * 지급단계별 활성 스케줄을 조회하고 전환할 수 있습니다.
  * 스케줄 상세 화면에 보험사명과 상품명이 표시됩니다.
  * 계약 등록 시 활성 FC 설계사만 선택할 수 있습니다.

* **개선 사항**
  * 상품별 납입기간과 해약공제액 입력 상태가 자동으로 반영됩니다.
  * 예외 사유의 한글 라벨을 지원합니다.
  * 수기 지급의 원천 유형과 화면 표시 문구를 명확하게 정리했습니다.
  * 최종 실행 상태를 ‘확정’과 잠금 아이콘으로 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->