### PR TITLE
[Refactor] SCHE-W01·W02 예상 스케줄 화면 공통 UI 전환 (#285)

### DIFF
--- a/src/main/resources/static/css/features/schedule.css
+++ b/src/main/resources/static/css/features/schedule.css
@@ -8,79 +8,25 @@
   align-items: center;
 }
 
-.schedule-guidance {
-  display: grid;
-  grid-template-columns: 1.25rem minmax(0, 1fr);
-  gap: 0.75rem;
-  align-items: start;
-  padding: 0.875rem 1rem;
-  border: 1px solid var(--color-status-info-border);
-  border-radius: var(--radius-8);
-  color: var(--color-status-info-text);
-  background: var(--color-status-info-bg);
-}
-
-.schedule-guidance > .material-symbols-rounded {
-  margin-top: 0.125rem;
-  font-size: 1.25rem;
-}
-
-.schedule-guidance h2 {
-  font-size: 0.8125rem;
-  font-weight: 700;
-  line-height: 1.25rem;
-}
-
-.schedule-guidance p {
-  margin-top: 0.25rem;
-  color: var(--color-text-secondary);
-  font-size: 0.75rem;
-  line-height: 1.25rem;
-  text-wrap: pretty;
-}
-
-.schedule-filter-card,
 .schedule-results-card {
   overflow: hidden;
 }
 
-.schedule-section-header {
-  display: flex;
-  min-height: 2.75rem;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0 1rem;
-  border-bottom: 1px solid var(--color-border-subtle);
+/* 공통 filter-bar 위의 폭 지정만 화면 전용으로 둔다 — RECO-W01 reco.css:17-40 과 같은 방식. */
+.schedule-filter-fields {
+  flex: 1 1 auto;
 }
 
-.schedule-reset-button {
-  height: 1.75rem;
+.schedule-filter-fields .filter-field {
+  width: 9.5rem;
 }
 
-.schedule-filter-grid {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(8.75rem, 1fr));
-  gap: 0.75rem;
-  padding: 0.875rem 1rem 0.75rem;
-}
-
-.schedule-filter-grid .field {
-  gap: 0.25rem;
-}
-
-.schedule-filter-grid .field-label {
-  color: var(--color-text-secondary);
+.schedule-filter-contract {
+  width: 12rem;
 }
 
 .schedule-filter-actions {
-  display: flex;
-  justify-content: flex-end;
-  padding: 0 1rem 1rem;
-}
-
-.schedule-filter-actions .button {
-  min-width: 6.5rem;
+  flex: 0 0 auto;
 }
 
 .schedule-results-header {
@@ -142,12 +88,19 @@
   max-width: 100%;
 }
 
-.schedule-policy-value {
-  display: block;
-  overflow: hidden;
+/*
+ * 정책버전·계약번호는 table-cell-disclosure 로 접었다 펴므로 셀이 줄바꿈을 허용해야 한다.
+ * 예전에는 여기서 ellipsis 로 자르고 title 속성으로만 전체 값을 줬는데, 가이드 §10.2 가
+ * "잘라 놓거나 title 속성만 제공하면 안 된다" 고 금지한다.
+ */
+.schedule-table .table-cell-disclosure {
   font-size: 0.75rem;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+}
+
+/* 규칙 8 확정 후 잠금 — 배지 안 자물쇠. VRUN-W01 vrun/list.html:116-118 과 같은 표현. */
+.schedule-badge-lock {
+  margin-left: 0.125rem;
+  font-size: 0.875rem;
 }
 
 .schedule-row-button {
@@ -245,29 +198,23 @@
   to { background-position: -200% 0; }
 }
 
-@media (max-width: 79.9375rem) {
-  .schedule-filter-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 63.9375rem) {
-  .schedule-filter-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
 @media (max-width: 47.9375rem) {
   .schedule-page-header {
     align-items: stretch;
   }
 
-  .schedule-filter-grid {
-    grid-template-columns: 1fr;
+  .schedule-filter-bar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .schedule-filter-fields .filter-field,
+  .schedule-filter-contract {
+    width: 100%;
   }
 
   .schedule-filter-actions .button {
-    width: 100%;
+    flex: 1 1 auto;
   }
 
   .schedule-pagination {
@@ -282,4 +229,189 @@
   .schedule-pagination .pagination-controls {
     justify-content: center;
   }
+}
+
+/* ───────────────────────── SCHE-W02 예상 스케줄 상세 ───────────────────────── */
+
+.schedule-detail-page {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.schedule-detail-card {
+  overflow: hidden;
+}
+
+.schedule-detail-note {
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+}
+
+/*
+ * 헤더 정의목록 — 목업 head 에 있던 인라인 <style> 의 .kv 를 옮긴 것이다.
+ * 원래 dt 색이 HEX 하드코딩이었다. 같은 뜻의 토큰으로 바꿨다.
+ */
+.schedule-detail-kv {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11.25rem, 1fr));
+  gap: 0.75rem 1.25rem;
+  padding: 0.875rem 1rem;
+}
+
+.schedule-detail-kv dt {
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1.125rem;
+}
+
+.schedule-detail-kv dd {
+  margin-top: 0.125rem;
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+  overflow-wrap: anywhere;
+}
+
+.schedule-stage-field {
+  gap: 0.25rem;
+}
+
+.schedule-stage-field .select-control {
+  height: 1.75rem;
+  padding-block: 0;
+  font-size: 0.75rem;
+}
+
+/*
+ * 로딩 · 빈 결과 · 오류를 클래스로 구분한다.
+ * 전에는 셋 다 같은 .fgc-empty 였고 오류만 JS 가 인라인으로 색을 칠했다 —
+ * 화면에서 셋을 구분할 수 없었고 오류 색이 HEX 하드코딩이었다.
+ */
+.schedule-inline-state {
+  display: grid;
+  min-height: 6rem;
+  place-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem 1rem;
+  color: var(--color-text-secondary);
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+  text-align: center;
+  text-wrap: pretty;
+}
+
+.schedule-inline-state.is-error {
+  color: var(--color-status-error-text);
+}
+
+.schedule-inline-state.is-empty {
+  color: var(--color-text-tertiary);
+}
+
+.schedule-action-note {
+  margin: 0 0 0.25rem;
+  color: var(--color-status-warning-text);
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+}
+
+.schedule-modal {
+  width: min(30rem, 100%);
+}
+
+.schedule-modal-description {
+  margin-bottom: 1.125rem;
+  line-height: 1.65;
+}
+
+.schedule-confirm-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.625rem 1rem;
+  padding: 0.75rem;
+  border-radius: var(--radius-8);
+  background: var(--color-bg-subtle);
+}
+
+.schedule-confirm-summary dt {
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  font-weight: 600;
+}
+
+.schedule-confirm-summary dd {
+  margin-top: 0.125rem;
+  font-size: 0.8125rem;
+}
+
+/* 회차 표는 길어서 세로로도 가둔다 — 예전 인라인 max-height:520px 을 여기로 옮겼다. */
+.schedule-line-viewport {
+  max-height: 32.5rem;
+}
+
+.schedule-line-table {
+  min-width: 88rem;
+}
+
+.schedule-line-col-no { width: 3.25rem; }
+.schedule-line-col-installment { width: 3.75rem; }
+.schedule-line-col-month { width: 5rem; }
+.schedule-line-col-due { width: 6.5rem; }
+.schedule-line-col-item { width: 10rem; }
+.schedule-line-col-recipient { width: 9rem; }
+.schedule-line-col-basis { width: 9rem; }
+.schedule-line-col-amount { width: 8.5rem; }
+.schedule-line-col-calc { width: 5.5rem; }
+.schedule-line-col-rate { width: 6.5rem; }
+.schedule-line-col-expected { width: 8.5rem; }
+.schedule-line-col-status { width: 5.5rem; }
+.schedule-line-col-rule { width: 5.5rem; }
+
+.schedule-version-table {
+  min-width: 62rem;
+}
+
+.schedule-version-col-no { width: 4.5rem; }
+.schedule-version-col-status { width: 6rem; }
+.schedule-version-col-active { width: 5.5rem; }
+.schedule-version-col-policy { width: 11rem; }
+.schedule-version-col-reason { width: 14rem; }
+.schedule-version-col-generated { width: 9.5rem; }
+.schedule-version-col-lines { width: 5.5rem; }
+.schedule-version-col-total { width: 8.5rem; }
+
+.schedule-line-table .table-cell-disclosure,
+.schedule-version-table .table-cell-disclosure {
+  font-size: 0.75rem;
+}
+
+/* 현재 보고 있는 버전 — 굵기만으로 구분하지 않는다. .is-selected 는 components.css:572. */
+.schedule-version-table tbody tr.is-selected td {
+  font-weight: 600;
+}
+
+@media (max-width: 47.9375rem) {
+  .schedule-confirm-summary {
+    grid-template-columns: 1fr;
+  }
+}
+
+/*
+ * 키보드 포커스 링 — 이 파일에는 :focus-visible 규칙이 하나도 없었다.
+ * 공통 컴포넌트(button·field-control·table-cell-details summary)는 자체 규칙이 있지만
+ * 화면 전용 요소와 가로 스크롤 뷰포트에는 없어서 Tab 으로 어디에 있는지 알 수 없었다.
+ */
+.schedule-table-viewport:focus-visible,
+.schedule-line-viewport:focus-visible,
+.schedule-version-viewport:focus-visible,
+.schedule-row-button:focus-visible,
+.schedule-pagination .pagination-button:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: -2px;
+}
+
+.schedule-filter-bar :focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 1px;
 }

--- a/src/main/resources/static/css/features/schedule.css
+++ b/src/main/resources/static/css/features/schedule.css
@@ -354,6 +354,40 @@
   min-width: 88rem;
 }
 
+/*
+ * 머리글과 합계를 뷰포트에 붙여 둔다.
+ *
+ * 회차 표는 관리자수수료 3행까지 붙어 16줄 넘게 나오는데 뷰포트가 32.5rem 에서 잘린다.
+ * 가운데를 스크롤하는 동안 머리글이 밀려 올라가면 어느 열이 요율이고 어느 열이 예상금액인지
+ * 알 수 없고, 합계가 아래로 밀리면 지금 보는 회차가 합계에서 얼마를 차지하는지 볼 수 없다.
+ *
+ * sticky 는 <thead>·<tfoot> 이나 <tr> 이 아니라 셀에 건다 — 행·행그룹 단위 sticky 를
+ * 무시하는 브라우저가 있다.
+ *
+ * 경계선은 border 가 아니라 inset box-shadow 로 긋는다. reset.css:68 이
+ * border-collapse: collapse 라 테두리가 셀이 아니라 표에 속하고, 그래서 sticky 셀에
+ * border 를 줘도 함께 붙어 오지 않아 스크롤 중에 선이 사라진다.
+ */
+.schedule-line-table thead th {
+  position: sticky;
+  z-index: 2;
+  top: 0;
+  box-shadow: inset 0 -1px 0 var(--color-border-default);
+}
+
+.schedule-line-table tfoot td {
+  position: sticky;
+  z-index: 2;
+  bottom: 0;
+  /*
+   * 합계는 데이터 한 줄이 아니라 머리글과 같은 성격의 고정 줄이므로 배경을 맞춘다.
+   * 불투명 배경은 sticky 에 필수이기도 하다 — 투명하면 밑을 지나가는 데이터가 비친다.
+   */
+  background: var(--color-bg-subtle);
+  box-shadow: inset 0 1px 0 var(--color-border-default);
+  font-weight: 600;
+}
+
 .schedule-line-col-no { width: 3.25rem; }
 .schedule-line-col-installment { width: 3.75rem; }
 .schedule-line-col-month { width: 5rem; }

--- a/src/main/resources/static/js/features/schedule/schedule-detail.js
+++ b/src/main/resources/static/js/features/schedule/schedule-detail.js
@@ -2,52 +2,48 @@
   "use strict";
 
   var apiClient = window.FgcUi && window.FgcUi.apiClient;
+  var format = window.FgcUi && window.FgcUi.format;
+  var labels = window.FgcUi && window.FgcUi.scheduleLabels;
   var main = document.getElementById("main-content");
   var lineBody = document.getElementById("line-body");
+  var lineTable = document.querySelector("[data-schedule-line-table]");
   var versionBody = document.getElementById("version-body");
+  var versionTable = document.querySelector("[data-schedule-version-table]");
+  var headerState = document.getElementById("hdr-state");
+  var headerList = document.getElementById("hdr-kv");
+  var actionNote = document.getElementById("schedule-action-note");
   var confirmButton = document.getElementById("btn-confirm");
+  var confirmSubmit = document.getElementById("btn-confirm-submit");
   var regenerateButton = document.getElementById("btn-regenerate");
   var regenerateReason = document.getElementById("regenerate-reason");
+  var regenerateReasonField = document.getElementById("regenerate-reason-field");
+  var regenerateReasonError = document.getElementById("regenerate-reason-error");
   var regenerateSubmit = document.getElementById("btn-regenerate-submit");
   var exportButton = document.getElementById("btn-export");
   var stageSelect = document.getElementById("stage");
-  var currentPaymentStage = null;
-  var PAYMENT_STAGE_LABELS = { INSURER_TO_GA: "원수사→GA", GA_TO_FC: "GA→설계사" };
-  var SCHEDULE_REGIME_LABELS = {
-    CURRENT: "현행",
-    FOUR_YEAR_2027: "4년 분급(2027)",
-    SEVEN_YEAR_2029: "7년 분급(2029)",
-    TM_SPECIAL: "TM 특례"
-  };
-  var SCHEDULE_PURPOSE_LABELS = {
-    OPERATIONAL: "운영",
-    COMPARISON: "비교",
-    SIMULATION: "시뮬레이션"
-  };
-  var SCHEDULE_STATUS_LABELS = {
-    PLANNED: "예정",
-    CONFIRMED: "확정",
-    MATCHED: "대사일치",
-    ADJUSTED: "조정",
-    HOLD: "보류",
-    CANCELLED: "취소",
-    RESTARTED: "재개"
-  };
 
-  if (!main || !lineBody || !apiClient) return;
+  if (!main || !lineBody || !apiClient || !format || !labels) return;
+
+  var EMPTY = labels.EMPTY;
+  var REASON_MAX = 40;
+  var LINE_COLUMNS = 13;
+  var VERSION_COLUMNS = 8;
+
+  var currentPaymentStage = null;
+  var currentHeader = null;
+  var canProcess = confirmButton ? !confirmButton.disabled : false;
 
   var scheduleHeaderId = main.dataset.scheduleHeaderId || idFromPath();
-  var canProcess = confirmButton ? !confirmButton.disabled : false;
   if (!scheduleHeaderId) {
-    renderError("스케줄 ID를 확인할 수 없습니다.");
+    renderLineState("스케줄 ID를 확인할 수 없습니다.", "is-error");
+    renderHeaderState("스케줄 ID를 확인할 수 없습니다.", "is-error");
     return;
   }
 
   load();
-  if (confirmButton) confirmButton.addEventListener("click", confirmSchedule);
-  if (exportButton) exportButton.addEventListener("click", function () {
-    window.location.assign("/api/v1/schedules/" + encodeURIComponent(scheduleHeaderId) + "/export.csv");
-  });
+  if (confirmButton) confirmButton.addEventListener("click", openConfirmDialog);
+  if (confirmSubmit) confirmSubmit.addEventListener("click", confirmSchedule);
+  if (exportButton) exportButton.addEventListener("click", exportCsv);
   if (stageSelect) stageSelect.addEventListener("change", moveToPaymentStage);
   if (regenerateButton) regenerateButton.addEventListener("click", regenerateSchedule);
   if (regenerateReason) regenerateReason.addEventListener("input", updateRegenerateSubmit);
@@ -58,8 +54,13 @@
     return matched ? matched[1] : null;
   }
 
+  /* ─────────────────────────── 조회 ─────────────────────────── */
+
   function load() {
-    renderLoading();
+    renderHeaderState("스케줄을 불러오는 중입니다.", "is-loading");
+    renderLineState("예상 스케줄을 불러오는 중입니다.", "is-loading");
+    setBusy(lineTable, true);
+
     apiClient.request("/api/v1/schedules/" + encodeURIComponent(scheduleHeaderId))
       .then(function (envelope) {
         var detail = envelope && envelope.data;
@@ -69,39 +70,93 @@
         loadVersions();
       })
       .catch(function (error) {
-        console.error(error);
-        var message = error && error.message
-          ? error.message
-          : "예상 스케줄을 불러오지 못했습니다.";
-        if (error && error.requestId) message += " 요청번호 " + error.requestId;
-        renderError(message);
+        var message = format.errorText(error, "예상 스케줄을 불러오지 못했습니다.");
+        renderHeaderState(message, "is-error", load);
+        renderLineState(message, "is-error", load);
+        setBusy(lineTable, false);
+        updateTotals(0, 0);
+        toast(message, "error", 5000);
       });
   }
 
+  function loadVersions() {
+    if (!versionBody) return;
+    renderVersionState("버전 이력을 불러오는 중입니다.", "is-loading");
+    setBusy(versionTable, true);
+
+    apiClient.request("/api/v1/schedules/" + encodeURIComponent(scheduleHeaderId) + "/versions")
+      .then(function (envelope) {
+        renderVersions(envelope && Array.isArray(envelope.data) ? envelope.data : []);
+      })
+      .catch(function (error) {
+        var message = format.errorText(error, "버전 이력을 불러오지 못했습니다.");
+        /* 예전에는 재시도 버튼도 Toast 도 없이 표 안 텍스트와 콘솔 로그뿐이었다. */
+        renderVersionState(message, "is-error", loadVersions);
+        toast(message, "error", 5000);
+      })
+      .finally(function () {
+        setBusy(versionTable, false);
+      });
+  }
+
+  /* ─────────────────────────── 헤더 ─────────────────────────── */
+
   function renderHeader(header) {
+    currentHeader = header;
     setText("hdr-id", "schedule_header #" + value(header.scheduleHeaderId));
     setText("hdr-contract", header.contractNo);
     setText("hdr-product", join(header.insurerName, header.productName));
-    setText("hdr-stage", responseLabel(header.paymentStageLabel, PAYMENT_STAGE_LABELS, header.paymentStage));
-    setText("hdr-regime", responseLabel(header.scheduleRegimeLabel, SCHEDULE_REGIME_LABELS, header.scheduleRegime));
-    setText("hdr-purpose", responseLabel(header.schedulePurposeLabel, SCHEDULE_PURPOSE_LABELS, header.schedulePurpose));
-    setText("hdr-version", header.scheduleVersionNo == null ? "—" : "v" + header.scheduleVersionNo);
-    setText("hdr-status", responseLabel(header.statusLabel, SCHEDULE_STATUS_LABELS, header.status));
-    setText("hdr-active", header.activeYn === true ? "사용중" : "미사용");
+    setText("hdr-version", header.scheduleVersionNo == null ? EMPTY : "v" + header.scheduleVersionNo);
     setText("hdr-policy", header.policyVersionLabel);
-    setText("hdr-reason", join(header.generationReason, formatDateTime(header.generatedAt)));
+    setText("hdr-reason", join(header.generationReason, format.dateTime(header.generatedAt)));
+
+    /* 적용 체계·용도는 분류값이라 상태 5색을 쓰지 않는다 (규칙 4). */
+    setBadge("hdr-regime",
+      labels.responseLabel(header.scheduleRegimeLabel, labels.SCHEDULE_REGIME, header.scheduleRegime),
+      labels.CLASSIFICATION_TONE, false);
+    setBadge("hdr-purpose",
+      labels.responseLabel(header.schedulePurposeLabel, labels.SCHEDULE_PURPOSE, header.schedulePurpose),
+      labels.CLASSIFICATION_TONE, false);
+    setBadge("hdr-status",
+      labels.responseLabel(header.statusLabel, labels.SCHEDULE_STATUS, header.status),
+      labels.statusTone(header.status), labels.isLocked(header.status));
+    setBadge("hdr-active",
+      header.activeYn === true ? "사용중" : "미사용",
+      header.activeYn === true ? "status-badge-success" : "status-badge-neutral", false);
+
+    if (headerState) headerState.hidden = true;
+    if (headerList) headerList.hidden = false;
 
     if (stageSelect && header.paymentStage) {
       currentPaymentStage = header.paymentStage;
       stageSelect.value = header.paymentStage;
       stageSelect.disabled = false;
     }
+    updateActionButtons(header);
+  }
+
+  /*
+   * 비활성 사유를 가시 텍스트로 알린다.
+   * 예전에는 confirmButton.title 하나로 뭉뚱그렸는데, disabled 요소는 포커스가 가지 않아
+   * 스크린리더가 title 에 닿지 못했고 권한·상태·사용중 세 사유가 구분되지도 않았다.
+   */
+  function updateActionButtons(header) {
+    var reasons = [];
+    if (!canProcess) reasons.push("확정·재생성은 정산 담당자만 할 수 있습니다.");
+    if (header.activeYn !== true) reasons.push("사용 중인 버전이 아닙니다.");
+    if (header.status === "CONFIRMED") reasons.push("이미 확정된 스케줄입니다.");
+    else if (header.status !== "PLANNED") reasons.push("예정 상태에서만 확정할 수 있습니다.");
+
     if (confirmButton) {
       confirmButton.disabled = !canProcess || header.status !== "PLANNED" || header.activeYn !== true;
-      confirmButton.title = header.status === "CONFIRMED" ? "이미 확정된 스케줄입니다." : "";
     }
     if (regenerateButton) {
       regenerateButton.disabled = !canProcess || header.activeYn !== true || header.status === "CANCELLED";
+    }
+    if (actionNote) {
+      var blocked = (confirmButton && confirmButton.disabled) || (regenerateButton && regenerateButton.disabled);
+      actionNote.textContent = reasons.join(" ");
+      actionNote.hidden = !blocked || reasons.length === 0;
     }
   }
 
@@ -110,6 +165,7 @@
     if (!targetStage || targetStage === currentPaymentStage) return;
 
     stageSelect.disabled = true;
+    stageSelect.setAttribute("aria-busy", "true");
     apiClient.request("/api/v1/schedules/" + encodeURIComponent(scheduleHeaderId)
       + "/active?paymentStage=" + encodeURIComponent(targetStage))
       .then(function (envelope) {
@@ -120,221 +176,414 @@
       .catch(function (error) {
         stageSelect.value = currentPaymentStage || "";
         stageSelect.disabled = false;
-        toast(error && error.message ? error.message : "선택한 지급단계의 스케줄을 찾을 수 없습니다.", "warning", 4500);
+        stageSelect.removeAttribute("aria-busy");
+        toast(format.errorText(error, "선택한 지급단계의 스케줄을 찾을 수 없습니다."), "warning", 4500);
       });
   }
 
-  function confirmSchedule() {
-    if (!confirmButton || confirmButton.disabled) return;
+  /* ─────────────────────────── 확정 ─────────────────────────── */
 
-    confirmButton.disabled = true;
+  /*
+   * 확정은 되돌릴 수 없다 (화면정의서 :889). 전에는 버튼을 누르면 곧바로 POST 가 나갔고,
+   * 정작 되돌릴 수 있는 재생성에만 확인 모달이 있었다 — 위험도와 확인 강도가 뒤집혀 있었다.
+   */
+  function openConfirmDialog() {
+    if (!confirmButton || confirmButton.disabled) return;
+    if (currentHeader) {
+      setText("confirm-contract", currentHeader.contractNo);
+      setText("confirm-version", currentHeader.scheduleVersionNo == null
+        ? EMPTY : "v" + currentHeader.scheduleVersionNo);
+      setText("confirm-line-count", format.int(currentHeader.lineCount));
+      setText("confirm-total", format.won(currentHeader.expectedTotal));
+    }
+    openModal("schedule-confirm");
+  }
+
+  function confirmSchedule() {
+    if (!confirmSubmit || confirmSubmit.disabled) return;
+
+    confirmSubmit.disabled = true;
+    confirmSubmit.setAttribute("aria-busy", "true");
+    if (confirmButton) confirmButton.disabled = true;
+
     apiClient.request("/api/v1/schedules/" + encodeURIComponent(scheduleHeaderId) + "/confirm", {
       method: "POST"
     }).then(function (envelope) {
       var detail = envelope && envelope.data;
       if (!detail || !detail.header) throw new Error("Invalid schedule confirmation response");
+      closeModal("schedule-confirm");
       renderHeader(detail.header);
       renderLines(Array.isArray(detail.lines) ? detail.lines : []);
       loadVersions();
       toast("스케줄을 확정했습니다. 이제 금액을 고칠 수 없습니다. 바꾸려면 새 버전을 만드세요.", "success", 4500);
     }).catch(function (error) {
-      console.error(error);
-      toast(error && error.message ? error.message : "예상 스케줄을 확정하지 못했습니다.", "error", 5000);
-      confirmButton.disabled = false;
+      toast(format.errorText(error, "예상 스케줄을 확정하지 못했습니다."), "error", 5000);
+      if (confirmButton) confirmButton.disabled = false;
+    }).finally(function () {
+      /*
+       * 여기서 확정 버튼으로 포커스를 옮기지 않는다 — 실패하면 모달이 열린 채로 남는데
+       * 그때 바깥 버튼을 포커스하면 포커스 트랩이 깨진다.
+       * 성공 시 포커스 복귀는 modal.js:37 의 closeModal 이 이미 처리한다.
+       */
+      confirmSubmit.disabled = false;
+      confirmSubmit.removeAttribute("aria-busy");
     });
   }
+
+  /* ───────────────────────── 새 버전 만들기 ───────────────────────── */
 
   function regenerateSchedule() {
     if (!regenerateButton || regenerateButton.disabled) return;
     if (regenerateReason) regenerateReason.value = "";
+    setReasonError("");
     updateRegenerateSubmit();
-    if (window.FgcUi && window.FgcUi.modal) window.FgcUi.modal.open("schedule-regenerate");
+    openModal("schedule-regenerate");
   }
 
   function updateRegenerateSubmit() {
     if (!regenerateSubmit) return;
     var reason = regenerateReason ? regenerateReason.value.trim() : "";
-    regenerateSubmit.disabled = !reason || reason.length > 40;
+    regenerateSubmit.disabled = !reason || reason.length > REASON_MAX;
+    if (reason && reason.length <= REASON_MAX) setReasonError("");
+  }
+
+  /* 사유 오류는 Toast 가 아니라 필드 옆 슬롯에 남긴다 (가이드 §11). */
+  function setReasonError(message) {
+    if (!regenerateReasonError) return;
+    regenerateReasonError.textContent = message;
+    regenerateReasonError.hidden = !message;
+    if (regenerateReasonField) regenerateReasonField.classList.toggle("is-error", Boolean(message));
   }
 
   function submitRegeneration() {
     if (!regenerateSubmit || regenerateSubmit.disabled) return;
     var reason = regenerateReason ? regenerateReason.value.trim() : "";
     if (!reason) {
-      toast("재생성 사유를 입력하세요.", "error", 4000);
+      setReasonError("저장 불가 — 생성 사유를 입력하세요.");
+      if (regenerateReason) regenerateReason.focus();
       return;
     }
-    if (reason.length > 40) {
-      toast("재생성 사유는 40자 이하여야 합니다.", "error", 4000);
+    if (reason.length > REASON_MAX) {
+      setReasonError("생성 사유는 " + REASON_MAX + "자 이하여야 합니다.");
+      if (regenerateReason) regenerateReason.focus();
       return;
     }
 
     regenerateButton.disabled = true;
     regenerateSubmit.disabled = true;
+    regenerateSubmit.setAttribute("aria-busy", "true");
+
     apiClient.request("/api/v1/schedules/" + encodeURIComponent(scheduleHeaderId) + "/regenerate", {
       method: "POST",
       body: { reason: reason }
     }).then(function (envelope) {
       var result = envelope && envelope.data;
       if (!result || !result.scheduleHeaderId) throw new Error("Invalid schedule regeneration response");
-      if (window.FgcUi && window.FgcUi.modal) window.FgcUi.modal.close("schedule-regenerate");
+      closeModal("schedule-regenerate");
       toast("새 스케줄 버전을 만들었습니다. 새 버전으로 이동합니다.", "success", 3500);
       window.setTimeout(function () {
         window.location.assign("/schedules/" + encodeURIComponent(result.scheduleHeaderId));
       }, 700);
     }).catch(function (error) {
-      console.error(error);
-      toast(error && error.message ? error.message : "새 스케줄 버전을 만들지 못했습니다.", "error", 5000);
+      toast(format.errorText(error, "새 스케줄 버전을 만들지 못했습니다."), "error", 5000);
       regenerateButton.disabled = false;
       updateRegenerateSubmit();
+    }).finally(function () {
+      regenerateSubmit.removeAttribute("aria-busy");
     });
   }
+
+  /* ─────────────────────────── CSV ─────────────────────────── */
+
+  /*
+   * 전에는 window.location.assign 만 호출해 성공·실패 어느 쪽도 알리지 않았다.
+   * SCHE-W01 과 같은 방식으로 fetch + Blob 저장에 Toast 를 붙인다.
+   */
+  function exportCsv() {
+    exportButton.disabled = true;
+    exportButton.setAttribute("aria-busy", "true");
+    window.fetch("/api/v1/schedules/" + encodeURIComponent(scheduleHeaderId) + "/export.csv",
+      { credentials: "same-origin" })
+      .then(function (response) {
+        if (!response.ok) throw new Error("CSV 내보내기에 실패했습니다. (HTTP " + response.status + ")");
+        return response.blob();
+      })
+      .then(function (blob) {
+        var objectUrl = window.URL.createObjectURL(blob);
+        var link = document.createElement("a");
+        link.href = objectUrl;
+        link.download = "schedule-" + scheduleHeaderId + ".csv";
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        window.URL.revokeObjectURL(objectUrl);
+        toast("회차 표 CSV를 내려받았습니다.", "success", 3500);
+      })
+      .catch(function (error) {
+        toast(format.errorText(error, "CSV 내보내기에 실패했습니다."), "error", 5000);
+      })
+      .finally(function () {
+        exportButton.disabled = false;
+        exportButton.removeAttribute("aria-busy");
+      });
+  }
+
+  /* ─────────────────────────── 회차 표 ─────────────────────────── */
 
   function renderLines(lines) {
     clear(lineBody);
     if (lines.length === 0) {
-      appendMessage("조건에 맞는 자료가 없습니다.", false);
-      updateTotals(0, 0, 0);
+      renderLineState("등록된 회차가 없습니다.", "is-empty");
+      updateTotals(0, 0);
+      setBusy(lineTable, false);
       return;
     }
 
     var total = 0;
-    var firstYear = 0;
     lines.forEach(function (line) {
-      var amount = number(line.expectedAmount);
-      total += amount;
-      if (number(line.contractMonthNo) >= 1 && number(line.contractMonthNo) <= 12) firstYear += amount;
+      total += Number(line.expectedAmount) || 0;
 
       var row = document.createElement("tr");
-      appendCell(row, line.lineNo);
-      appendCell(row, line.installmentNo);
-      appendCell(row, line.contractMonthNo);
-      appendCell(row, formatDate(line.dueDate));
-      appendCell(row, line.commissionItemName);
-      appendCell(row, line.recipientName);
-      appendCell(row, line.basisCode);
-      appendMoneyCell(row, line.basisAmount);
-      appendCell(row, label({ RATE: "요율", FIXED: "정액" }, line.calculationType));
-      appendNumberCell(row, line.ratePct == null ? "—" : formatRate(line.ratePct) + "%");
-      appendMoneyCell(row, line.expectedAmount);
-      appendCell(row, label({ PLANNED: "예정", CONFIRMED: "확정", MATCHED: "대사일치", ADJUSTED: "조정" }, line.lineStatus));
+      row.appendChild(numberCell(format.int(line.lineNo)));
+      row.appendChild(numberCell(format.int(line.installmentNo)));
+      row.appendChild(numberCell(format.int(line.contractMonthNo)));
+      row.appendChild(textCell(format.date(line.dueDate)));
+      row.appendChild(disclosureCell(line.commissionItemName));
+      row.appendChild(disclosureCell(line.recipientName));
+      row.appendChild(disclosureCell(line.basisCode));
+      row.appendChild(moneyCell(line.basisAmount));
+      row.appendChild(textCell(labels.responseLabel(null, labels.CALCULATION_TYPE, line.calculationType), "is-center"));
+      row.appendChild(numberCell(line.ratePct == null ? EMPTY : format.rate(line.ratePct) + "%"));
+      row.appendChild(moneyCell(line.expectedAmount));
+      row.appendChild(badgeCell(
+        labels.responseLabel(line.lineStatusLabel, labels.LINE_STATUS, line.lineStatus),
+        labels.statusTone(line.lineStatus),
+        labels.isLocked(line.lineStatus)));
+      /* IF-API-28 의 ruleRef — 규칙 5 근거 표시. 예전에는 응답에 있는데도 렌더하지 않았다. */
+      row.appendChild(numberCell(line.ruleRef == null ? EMPTY : format.int(line.ruleRef)));
       lineBody.appendChild(row);
     });
-    updateTotals(lines.length, total, firstYear);
+
+    updateTotals(lines.length, total);
+    setBusy(lineTable, false);
+    scheduleDisclosureSync();
   }
 
-  function loadVersions() {
-    if (!versionBody) return;
-    renderVersionMessage("버전 이력을 불러오는 중입니다.", false);
-    apiClient.request("/api/v1/schedules/" + encodeURIComponent(scheduleHeaderId) + "/versions")
-      .then(function (envelope) {
-        renderVersions(envelope && Array.isArray(envelope.data) ? envelope.data : []);
-      })
-      .catch(function (error) {
-        console.error(error);
-        renderVersionMessage(error && error.message
-          ? error.message
-          : "버전 이력을 불러오지 못했습니다.", true);
-      });
+  function updateTotals(count, total) {
+    setText("line-count", format.int(count));
+    setText("line-total", format.won(total));
   }
+
+  /* ─────────────────────────── 버전 표 ─────────────────────────── */
 
   function renderVersions(versions) {
     clear(versionBody);
     if (versions.length === 0) {
-      renderVersionMessage("같은 계약의 스케줄 버전이 없습니다.", false);
+      renderVersionState("같은 계약의 스케줄 버전이 없습니다.", "is-empty");
       return;
     }
+
     versions.forEach(function (version) {
       var row = document.createElement("tr");
-      if (String(version.scheduleHeaderId) === String(scheduleHeaderId)) row.style.fontWeight = "700";
+      var isCurrent = String(version.scheduleHeaderId) === String(scheduleHeaderId);
+      /* 굵기 인라인 스타일 대신 공통 .is-selected + aria-current 로 현재 버전을 알린다. */
+      if (isCurrent) {
+        row.className = "is-selected";
+        row.setAttribute("aria-current", "true");
+      }
 
       var versionCell = document.createElement("td");
+      versionCell.className = "is-center";
       var link = document.createElement("a");
       link.href = "/schedules/" + encodeURIComponent(version.scheduleHeaderId);
-      link.textContent = version.scheduleVersionNo == null ? "—" : "v" + version.scheduleVersionNo;
+      link.className = "tabular-nums";
+      link.textContent = version.scheduleVersionNo == null ? EMPTY : "v" + version.scheduleVersionNo;
       versionCell.appendChild(link);
       row.appendChild(versionCell);
 
-      appendCell(row, responseLabel(version.statusLabel, SCHEDULE_STATUS_LABELS, version.status));
-      appendCell(row, version.activeYn === true ? "사용중" : "미사용");
-      appendCell(row, version.policyVersionLabel);
-      appendCell(row, version.generationReason);
-      appendCell(row, formatDateTime(version.generatedAt));
-      appendNumberCell(row, formatNumber(version.lineCount));
-      appendMoneyCell(row, version.expectedTotal);
+      row.appendChild(badgeCell(
+        labels.responseLabel(version.statusLabel, labels.SCHEDULE_STATUS, version.status),
+        labels.statusTone(version.status),
+        labels.isLocked(version.status)));
+      row.appendChild(badgeCell(
+        version.activeYn === true ? "사용중" : "미사용",
+        version.activeYn === true ? "status-badge-success" : "status-badge-neutral", false));
+      row.appendChild(disclosureCell(version.policyVersionLabel));
+      row.appendChild(disclosureCell(version.generationReason));
+      row.appendChild(textCell(format.dateTime(version.generatedAt)));
+      row.appendChild(numberCell(format.int(version.lineCount)));
+      row.appendChild(moneyCell(version.expectedTotal));
       versionBody.appendChild(row);
+    });
+
+    scheduleDisclosureSync();
+  }
+
+  /* ───────────────────── 로딩 · 빈 결과 · 오류 ───────────────────── */
+
+  /*
+   * 예전에는 로딩·빈·오류 6상태가 전부 같은 .fgc-empty 였고 오류만 인라인으로 색을 칠했다.
+   * 상태별 클래스와 role 을 나누고, 오류에는 항상 다시 시도 버튼을 붙인다.
+   * renderVersionMessage / appendMessage 로 갈려 있던 중복 함수도 하나로 합쳤다.
+   */
+  function stateRow(body, columns, message, variant, onRetry) {
+    clear(body);
+    var row = document.createElement("tr");
+    var cell = document.createElement("td");
+    cell.colSpan = columns;
+    cell.appendChild(stateBlock(message, variant, onRetry));
+    row.appendChild(cell);
+    body.appendChild(row);
+  }
+
+  function stateBlock(message, variant, onRetry) {
+    var block = document.createElement("p");
+    block.className = "schedule-inline-state " + variant;
+    block.setAttribute("role", variant === "is-error" ? "alert" : "status");
+    block.appendChild(document.createTextNode(message));
+    if (onRetry) {
+      var retry = document.createElement("button");
+      retry.type = "button";
+      retry.className = "button button-secondary";
+      retry.textContent = "다시 시도";
+      retry.addEventListener("click", onRetry);
+      block.appendChild(retry);
+    }
+    return block;
+  }
+
+  function renderLineState(message, variant, onRetry) {
+    stateRow(lineBody, LINE_COLUMNS, message, variant, onRetry);
+  }
+
+  function renderVersionState(message, variant, onRetry) {
+    if (!versionBody) return;
+    stateRow(versionBody, VERSION_COLUMNS, message, variant, onRetry);
+  }
+
+  /* 헤더 영역도 상태를 구분한다 — 전에는 로딩·오류·무데이터가 모두 "—" 로 같아 보였다. */
+  function renderHeaderState(message, variant, onRetry) {
+    if (!headerState) return;
+    if (headerList) headerList.hidden = true;
+    headerState.className = "schedule-inline-state " + variant;
+    headerState.setAttribute("role", variant === "is-error" ? "alert" : "status");
+    headerState.hidden = false;
+    clear(headerState);
+    headerState.appendChild(document.createTextNode(message));
+    if (onRetry) {
+      var retry = document.createElement("button");
+      retry.type = "button";
+      retry.className = "button button-secondary";
+      retry.textContent = "다시 시도";
+      retry.addEventListener("click", onRetry);
+      headerState.appendChild(retry);
+    }
+  }
+
+  /* ─────────────────────────── 셀 유틸 ─────────────────────────── */
+
+  function textCell(content, className) {
+    var cell = document.createElement("td");
+    if (className) cell.className = className;
+    cell.textContent = value(content);
+    return cell;
+  }
+
+  function numberCell(content) {
+    return textCell(content, "is-number tabular-nums");
+  }
+
+  function moneyCell(content) {
+    var cell = textCell(format.won(content), "is-number tabular-nums");
+    if (format.isNegative(content)) cell.classList.add("is-negative-amount");
+    return cell;
+  }
+
+  function badgeCell(text, tone, locked) {
+    var cell = document.createElement("td");
+    cell.className = "is-center";
+    var element = document.createElement("span");
+    element.className = "status-badge " + tone;
+    element.appendChild(document.createTextNode(text));
+    if (locked) {
+      var lock = document.createElement("span");
+      lock.className = "material-symbols-rounded schedule-badge-lock";
+      lock.setAttribute("aria-hidden", "true");
+      lock.textContent = "lock";
+      element.appendChild(lock);
+    }
+    cell.appendChild(element);
+    return cell;
+  }
+
+  /* 긴 값 접기·펴기 — components.css:576-653. DOM 으로 만들어 escape 를 따로 하지 않는다. */
+  function disclosureCell(content) {
+    var text = value(content);
+    var cell = document.createElement("td");
+    var root = document.createElement("div");
+    root.className = "table-cell-disclosure";
+
+    var preview = document.createElement("span");
+    preview.className = "table-cell-preview is-single-line";
+    preview.textContent = text;
+    root.appendChild(preview);
+
+    var details = document.createElement("details");
+    details.className = "table-cell-details";
+    details.hidden = true;
+
+    var summary = document.createElement("summary");
+    var more = document.createElement("span");
+    more.className = "table-cell-more";
+    more.textContent = "전체 보기";
+    var less = document.createElement("span");
+    less.className = "table-cell-less";
+    less.textContent = "접기";
+    var chevron = document.createElement("span");
+    chevron.className = "material-symbols-rounded table-cell-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "expand_more";
+    summary.append(more, less, chevron);
+
+    var full = document.createElement("p");
+    full.className = "table-cell-full";
+    full.textContent = text;
+
+    details.append(summary, full);
+    root.appendChild(details);
+    cell.appendChild(root);
+    return cell;
+  }
+
+  function scheduleDisclosureSync() {
+    window.requestAnimationFrame(function () {
+      document.querySelectorAll(".table-cell-disclosure").forEach(function (root) {
+        var preview = root.querySelector(".table-cell-preview");
+        var details = root.querySelector(".table-cell-details");
+        if (!preview || !details || preview.clientWidth === 0) return;
+        var truncated = preview.scrollWidth > preview.clientWidth + 1
+          || preview.scrollHeight > preview.clientHeight + 1;
+        details.hidden = !truncated;
+        if (!truncated) details.open = false;
+      });
     });
   }
 
-  function renderVersionMessage(message, error) {
-    if (!versionBody) return;
-    clear(versionBody);
-    var row = document.createElement("tr");
-    var cell = document.createElement("td");
-    var content = document.createElement("div");
-    cell.colSpan = 8;
-    content.className = "fgc-empty";
-    content.textContent = message;
-    if (error) content.style.color = "#d92d20";
-    cell.appendChild(content);
-    row.appendChild(cell);
-    versionBody.appendChild(row);
-  }
-
-  function renderLoading() {
-    clear(lineBody);
-    appendMessage("예상 스케줄을 불러오는 중입니다.", false);
-  }
-
-  function renderError(message) {
-    clear(lineBody);
-    var content = appendMessage(message, true);
-    var retryButton = document.createElement("button");
-    retryButton.type = "button";
-    retryButton.className = "fgc-btn fgc-btn--ghost";
-    retryButton.style.marginTop = "12px";
-    retryButton.textContent = "다시 시도";
-    retryButton.addEventListener("click", load);
-    content.appendChild(document.createElement("br"));
-    content.appendChild(retryButton);
-    updateTotals(0, 0, 0);
-  }
-
-  function appendMessage(message, error) {
-    var row = document.createElement("tr");
-    var cell = document.createElement("td");
-    var content = document.createElement("div");
-    cell.colSpan = 12;
-    content.className = "fgc-empty";
-    content.textContent = message;
-    if (error) content.style.color = "#d92d20";
-    cell.appendChild(content);
-    row.appendChild(cell);
-    lineBody.appendChild(row);
-    return content;
-  }
-
-  function appendCell(row, content) {
-    var cell = document.createElement("td");
-    cell.textContent = value(content);
-    row.appendChild(cell);
-  }
-
-  function appendMoneyCell(row, content) {
-    appendNumberCell(row, formatMoney(content));
-  }
-
-  function appendNumberCell(row, content) {
-    var cell = document.createElement("td");
-    cell.className = "fgc-td-num";
-    cell.textContent = content;
-    row.appendChild(cell);
-  }
-
-  function updateTotals(count, total, firstYear) {
-    setText("line-count", count);
-    setText("line-total", formatMoney(total));
-    setText("line-first-year", formatMoney(firstYear));
+  function setBadge(id, text, tone, locked) {
+    var element = document.getElementById(id);
+    if (!element) return;
+    clear(element);
+    var badge = document.createElement("span");
+    badge.className = "status-badge " + tone;
+    badge.appendChild(document.createTextNode(text));
+    if (locked) {
+      var lock = document.createElement("span");
+      lock.className = "material-symbols-rounded schedule-badge-lock";
+      lock.setAttribute("aria-hidden", "true");
+      lock.textContent = "lock";
+      badge.appendChild(lock);
+    }
+    element.appendChild(badge);
   }
 
   function setText(id, content) {
@@ -342,60 +591,31 @@
     if (element) element.textContent = value(content);
   }
 
-  function label(labels, code) {
-    return labels[code] || value(code);
-  }
-
-  function responseLabel(serverLabel, labels, code) {
-    return typeof serverLabel === "string" && serverLabel.trim()
-      ? serverLabel
-      : label(labels, code);
+  function setBusy(table, busy) {
+    if (table) table.setAttribute("aria-busy", busy ? "true" : "false");
   }
 
   function join(first, second) {
-    return [first, second].filter(function (item) { return item != null && item !== ""; }).join(" · ") || "—";
-  }
-
-  function formatMoney(content) {
-    return formatNumber(content) + "원";
-  }
-
-  function formatNumber(content) {
-    return new Intl.NumberFormat("ko-KR", { maximumFractionDigits: 4 }).format(number(content));
-  }
-
-  function formatRate(content) {
-    return new Intl.NumberFormat("ko-KR", {
-      minimumFractionDigits: 4,
-      maximumFractionDigits: 4
-    }).format(number(content));
-  }
-
-  function formatDate(content) {
-    return content ? String(content).replace(/-/g, ".") : "—";
-  }
-
-  function formatDateTime(content) {
-    if (!content) return null;
-    var date = new Date(content);
-    if (Number.isNaN(date.getTime())) return String(content);
-    return new Intl.DateTimeFormat("ko-KR", {
-      year: "numeric", month: "2-digit", day: "2-digit",
-      hour: "2-digit", minute: "2-digit", hour12: false
-    }).format(date);
-  }
-
-  function number(content) {
-    var parsed = Number(content);
-    return Number.isFinite(parsed) ? parsed : 0;
+    var parts = [first, second].filter(function (item) {
+      return item != null && item !== "" && item !== EMPTY;
+    });
+    return parts.length ? parts.join(" · ") : EMPTY;
   }
 
   function value(content) {
-    return content == null || content === "" ? "—" : String(content);
+    return content == null || content === "" ? EMPTY : String(content);
   }
 
   function clear(element) {
     while (element.firstChild) element.removeChild(element.firstChild);
+  }
+
+  function openModal(name) {
+    if (window.FgcUi && window.FgcUi.modal) window.FgcUi.modal.open(name);
+  }
+
+  function closeModal(name) {
+    if (window.FgcUi && window.FgcUi.modal) window.FgcUi.modal.close(name);
   }
 
   function toast(message, tone, duration) {

--- a/src/main/resources/static/js/features/schedule/schedule-labels.js
+++ b/src/main/resources/static/js/features/schedule/schedule-labels.js
@@ -1,0 +1,152 @@
+/*
+ * SCHE-W01·W02 공용 라벨 사전 · 상태 톤 · 표 셀 유틸 (#285)
+ *
+ * 왜 파일을 나눴나
+ *   schedule-list.js:63-88 과 schedule-detail.js:15-35 가 같은 라벨 4세트를 각자 들고 있었다.
+ *   톤 매핑(STATUS_TONES)은 W01 에만 있어서 W02 는 상태를 plain 텍스트로 찍었다.
+ *   화면정의서 4장 규칙 4 는 상태를 "색 + 글자"로 쓰라고 하는데 한쪽만 지키던 상태다.
+ *   한쪽만 고치면 즉시 라벨이 갈리므로 사전과 톤을 여기 한 벌만 둔다.
+ *
+ * 이중 모드
+ *   src/test/js/schedule-list.test.cjs 가 schedule-list.js 를 require 하고 responseLabel 을
+ *   계약으로 쓴다. 그 계약을 유지하면서 구현을 한 벌로 두려고 이 파일도 module.exports 를 연다.
+ *   브라우저에서는 window.FgcUi.scheduleLabels 로 읽는다.
+ *
+ * 로드 순서
+ *   layout/default.html 이 이 파일을 schedule-list.js · schedule-detail.js 보다 먼저 defer 로
+ *   건다. 순서가 바뀌면 두 화면이 라벨 없이 코드값을 그대로 노출한다.
+ */
+(function () {
+  "use strict";
+
+  var EMPTY = "-";
+
+  var PAYMENT_STAGE = {
+    INSURER_TO_GA: "원수사→GA",
+    GA_TO_FC: "GA→설계사"
+  };
+
+  var SCHEDULE_REGIME = {
+    CURRENT: "현행",
+    FOUR_YEAR_2027: "4년 분급(2027)",
+    SEVEN_YEAR_2029: "7년 분급(2029)",
+    TM_SPECIAL: "TM 특례"
+  };
+
+  var SCHEDULE_PURPOSE = {
+    OPERATIONAL: "운영",
+    COMPARISON: "비교",
+    SIMULATION: "시뮬레이션"
+  };
+
+  /* 서버 enum 과 1:1 — common/code/ScheduleHeaderStatus.java:12-18 */
+  var SCHEDULE_STATUS = {
+    PLANNED: "예정",
+    CONFIRMED: "확정",
+    MATCHED: "대사일치",
+    ADJUSTED: "조정",
+    HOLD: "보류",
+    CANCELLED: "취소",
+    RESTARTED: "재개"
+  };
+
+  /* 회차(line) 상태 — common/code/ScheduleLineStatus.java:12-18 과 같은 코드계 */
+  var LINE_STATUS = SCHEDULE_STATUS;
+
+  var CALCULATION_TYPE = {
+    RATE: "요율",
+    FIXED: "정액"
+  };
+
+  /*
+   * 상태 배지 톤 — 화면정의서 4장 규칙 4 (:212)
+   *   "정상=초록, 주의=주황, 위반·차단=빨강, 검토필요=회색, 진행중=파랑"
+   * 판단 근거는 서버 enum 의 주석에 적힌 뜻을 그대로 따랐다
+   * (common/code/ScheduleLineStatus.java:12-18 이 각 상태의 업무 의미를 적어 둔 유일한 출처다).
+   *
+   *   PLANNED   생성 직후            → 진행중  info
+   *   CONFIRMED 담당자가 확정        → 아래 주석 참조. review 유지 + 자물쇠
+   *   MATCHED   실제 지급과 일치     → 정상    success
+   *   ADJUSTED  실제 지급과 다름     → 주의    warning
+   *   HOLD      계약 미납            → 검토필요 review   (기존 risk 에서 변경)
+   *   CANCELLED 계약 해지            → 종료    neutral  (기존 error 에서 변경)
+   *   RESTARTED 계약 부활            → 진행중  info
+   *
+   * CONFIRMED 를 success 로 바꾸지 않은 이유
+   *   VRUN-W01 이 같은 뜻의 확정(FINALIZED)을 vrun/list.html:111-118 에서 review + lock 으로
+   *   표시한다. 규칙 8 (:216) 이 "확정 후 잠금"으로 두 화면을 같은 개념으로 묶으므로
+   *   여기만 초록으로 바꾸면 확정 색이 화면마다 갈린다. 대신 규칙 8 을 지키도록
+   *   자물쇠 아이콘을 배지 안에 넣어 색이 아니라 아이콘·글자로 구분되게 했다.
+   *
+   * HOLD·CANCELLED 는 바꿔도 안전하다
+   *   저장소 전체에서 이 두 코드에 배지 톤을 매기는 곳이 schedule-list.js 하나뿐이라
+   *   (features/*.js 전수 확인) 다른 화면과 어긋날 여지가 없다.
+   */
+  var STATUS_TONES = {
+    PLANNED: "status-badge-info",
+    CONFIRMED: "status-badge-review",
+    MATCHED: "status-badge-success",
+    ADJUSTED: "status-badge-warning",
+    HOLD: "status-badge-review",
+    CANCELLED: "status-badge-neutral",
+    RESTARTED: "status-badge-info"
+  };
+
+  /* 확정은 규칙 8 의 잠금 상태다 — 색에 더해 자물쇠로도 알린다 (VRUN-W01 과 같은 표현). */
+  var LOCKED_STATUSES = ["CONFIRMED"];
+
+  /*
+   * 적용 체계·용도는 상태가 아니라 분류값이다.
+   * 규칙 4 의 5색은 상태 전용이므로 분류값에 info/success 를 쓰면 색의 뜻이 흐려진다.
+   * 배지 형태는 유지하되 톤은 neutral 하나로 통일한다.
+   */
+  var CLASSIFICATION_TONE = "status-badge-neutral";
+
+  /*
+   * REG-19 근거 — 적용 체계 값 옆 근거 툴팁에 쓴다 (규칙 5 :213).
+   * 원래 SCHE-W01 의 schedule-guidance 배너와 SCHE-W02 의 fgc-banner--info 에 각각
+   * 같은 문구가 중복으로 있었다. 배너는 화면 설명문이라 지우되 근거 자체는 잃지 않는다.
+   */
+  var REGIME_EVIDENCE = {
+    title: "REG-19 · 적용 체계 판정",
+    body: "적용 체계는 계약 체결연도만으로 정하지 않습니다. "
+      + "상품 판매개시일 · 기초서류 버전 · 판매채널을 함께 보고 정합니다."
+  };
+
+  function responseLabel(serverLabel, labels, code) {
+    if (typeof serverLabel === "string" && serverLabel.trim()) return serverLabel;
+    return labels[code] || code || EMPTY;
+  }
+
+  function statusTone(code) {
+    return STATUS_TONES[code] || CLASSIFICATION_TONE;
+  }
+
+  function isLocked(code) {
+    return LOCKED_STATUSES.indexOf(code) >= 0;
+  }
+
+  var api = {
+    EMPTY: EMPTY,
+    PAYMENT_STAGE: PAYMENT_STAGE,
+    SCHEDULE_REGIME: SCHEDULE_REGIME,
+    SCHEDULE_PURPOSE: SCHEDULE_PURPOSE,
+    SCHEDULE_STATUS: SCHEDULE_STATUS,
+    LINE_STATUS: LINE_STATUS,
+    CALCULATION_TYPE: CALCULATION_TYPE,
+    STATUS_TONES: STATUS_TONES,
+    CLASSIFICATION_TONE: CLASSIFICATION_TONE,
+    REGIME_EVIDENCE: REGIME_EVIDENCE,
+    responseLabel: responseLabel,
+    statusTone: statusTone,
+    isLocked: isLocked
+  };
+
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+    return;
+  }
+
+  window.FgcUi = window.FgcUi || {};
+  window.FgcUi.scheduleLabels = api;
+})();

--- a/src/main/resources/static/js/features/schedule/schedule-list.js
+++ b/src/main/resources/static/js/features/schedule/schedule-list.js
@@ -15,15 +15,25 @@
     return Math.min(positivePage(requestedPage), lastPage);
   }
 
-  function responseLabel(serverLabel, labels, code) {
-    if (typeof serverLabel === "string" && serverLabel.trim()) return serverLabel;
-    return labels[code] || code || "-";
-  }
-
+  /*
+   * responseLabel 구현은 schedule-labels.js 한 곳에만 둔다 (#285).
+   * 다만 src/test/js/schedule-list.test.cjs 가 이 파일에서 responseLabel 을 require 하므로
+   * export 계약은 그대로 유지한다 — Node 에서는 형제 모듈을 직접 읽고, 브라우저에서는
+   * 아래 window.FgcUi.scheduleLabels 를 쓴다. require 는 이 분기 안에서만 실행되므로
+   * 브라우저에 require 가 없어도 안전하다.
+   */
   if (typeof module === "object" && module.exports) {
-    module.exports = { normalizePage: normalizePage, responseLabel: responseLabel };
+    module.exports = {
+      normalizePage: normalizePage,
+      responseLabel: require("./schedule-labels.js").responseLabel
+    };
     return;
   }
+
+  var scheduleLabels = window.FgcUi && window.FgcUi.scheduleLabels;
+  var format = window.FgcUi && window.FgcUi.format;
+  if (!scheduleLabels || !format) return;
+  var responseLabel = scheduleLabels.responseLabel;
 
   var form = document.querySelector("[data-schedule-filter-form]");
   var resetButton = document.querySelector("[data-schedule-filter-reset]");
@@ -43,13 +53,52 @@
 
   if (!form || !table || !tableBody || !pagination || !previousButton || !nextButton) return;
 
+  /*
+   * CSV 내보내기 — 전에는 window.location.assign 만 호출해서 성공·실패 어느 쪽도 알리지 않았다.
+   * fetch + Blob 으로 바꿔 두 경우 모두 Toast 를 띄운다. JS 가 죽어 있으면 아무 일도 없던
+   * 예전과 같아지므로 회귀는 없다. 진행 중에는 aria-busy 로 스크린리더에도 알린다.
+   */
   if (exportButton) {
     exportButton.addEventListener("click", function () {
       var parameters = new URLSearchParams(window.location.search);
       parameters.delete("page");
       parameters.delete("size");
-      window.location.assign("/api/v1/schedules/export.csv" + (parameters.size ? "?" + parameters.toString() : ""));
+      exportCsv("/api/v1/schedules/export.csv" + (parameters.size ? "?" + parameters.toString() : ""));
     });
+  }
+
+  function exportCsv(url) {
+    exportButton.disabled = true;
+    exportButton.setAttribute("aria-busy", "true");
+    window.fetch(url, { credentials: "same-origin" })
+      .then(function (response) {
+        if (!response.ok) throw new Error("CSV 내보내기에 실패했습니다. (HTTP " + response.status + ")");
+        return response.blob();
+      })
+      .then(function (blob) {
+        var objectUrl = window.URL.createObjectURL(blob);
+        var link = document.createElement("a");
+        link.href = objectUrl;
+        link.download = "schedules.csv";
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        window.URL.revokeObjectURL(objectUrl);
+        toast("예상 스케줄 CSV를 내려받았습니다.", "success", 3500);
+      })
+      .catch(function (error) {
+        toast(format.errorText(error, "CSV 내보내기에 실패했습니다."), "error", 5000);
+      })
+      .finally(function () {
+        exportButton.disabled = false;
+        exportButton.removeAttribute("aria-busy");
+      });
+  }
+
+  function toast(message, tone, duration) {
+    if (window.FgcUi && typeof window.FgcUi.toast === "function") {
+      window.FgcUi.toast(message, tone, duration);
+    }
   }
 
   var PAGE_SIZE = 20;
@@ -60,41 +109,14 @@
     purpose: ["OPERATIONAL", "COMPARISON", "SIMULATION"],
     status: ["", "PLANNED", "CONFIRMED", "MATCHED", "ADJUSTED", "HOLD", "CANCELLED", "RESTARTED"]
   };
+  /* 라벨·톤은 schedule-labels.js 한 벌만 쓴다 — SCHE-W02 와 같은 값을 보장한다. */
   var LABELS = {
-    paymentStage: {
-      INSURER_TO_GA: "원수사→GA",
-      GA_TO_FC: "GA→설계사"
-    },
-    scheduleRegime: {
-      CURRENT: "현행",
-      FOUR_YEAR_2027: "4년 분급(2027)",
-      SEVEN_YEAR_2029: "7년 분급(2029)",
-      TM_SPECIAL: "TM 특례"
-    },
-    schedulePurpose: {
-      OPERATIONAL: "운영",
-      COMPARISON: "비교",
-      SIMULATION: "시뮬레이션"
-    },
-    scheduleStatus: {
-      PLANNED: "예정",
-      CONFIRMED: "확정",
-      MATCHED: "대사일치",
-      ADJUSTED: "조정",
-      HOLD: "보류",
-      CANCELLED: "취소",
-      RESTARTED: "재개"
-    }
+    paymentStage: scheduleLabels.PAYMENT_STAGE,
+    scheduleRegime: scheduleLabels.SCHEDULE_REGIME,
+    schedulePurpose: scheduleLabels.SCHEDULE_PURPOSE,
+    scheduleStatus: scheduleLabels.SCHEDULE_STATUS
   };
-  var STATUS_TONES = {
-    PLANNED: "status-badge-info",
-    CONFIRMED: "status-badge-review",
-    MATCHED: "status-badge-success",
-    ADJUSTED: "status-badge-warning",
-    HOLD: "status-badge-risk",
-    CANCELLED: "status-badge-error",
-    RESTARTED: "status-badge-info"
-  };
+  var EMPTY = scheduleLabels.EMPTY;
 
   var activeRequest = null;
   var requestSequence = 0;
@@ -183,7 +205,7 @@
     table.setAttribute("aria-busy", "true");
     pagination.hidden = true;
     dataWarning.hidden = true;
-    resultCount.textContent = "—";
+    resultCount.textContent = EMPTY;
 
     for (var rowIndex = 0; rowIndex < 5; rowIndex += 1) {
       var row = document.createElement("tr");
@@ -236,44 +258,98 @@
     return value === true || value === "true";
   }
 
-  function formatInteger(value) {
-    if (value === null || value === undefined || value === "") return "-";
-    var raw = String(value).trim();
-    if (!/^-?\d+$/.test(raw)) return raw;
-    var sign = raw.charAt(0) === "-" ? "-" : "";
-    var digits = sign ? raw.slice(1) : raw;
-    return sign + digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-  }
-
-  function formatWon(value) {
-    if (value === null || value === undefined || value === "") return "-";
-    var raw = String(value).trim();
-    var match = raw.match(/^(-?)(\d+)(?:\.(\d+))?$/);
-    if (!match) return raw;
-    var integer = match[2].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    var fraction = match[3] && /[1-9]/.test(match[3]) ? "." + match[3] : "";
-    return match[1] + integer + fraction + "원";
-  }
-
+  /*
+   * 금액·건수는 공통 유틸만 쓴다 (FGC-SIR-008).
+   * 전에는 이 파일이 직접 짠 정규식으로 콤마를 찍어서, 같은 도메인인 SCHE-W02 의
+   * Intl 기반 포맷과 결과가 갈렸다. 음수 괄호 표기(화면정의서 4장 규칙 1)도 여기서만 빠져 있었다.
+   */
   function textCell(value, className) {
     var cell = document.createElement("td");
     if (className) cell.className = className;
-    cell.textContent = value === null || value === undefined || value === "" ? "-" : String(value);
+    cell.textContent = value === null || value === undefined || value === "" ? EMPTY : String(value);
     return cell;
   }
 
-  function badge(value, tone) {
+  function moneyCell(value) {
+    var cell = textCell(format.won(value), "is-number tabular-nums");
+    if (format.isNegative(value)) cell.classList.add("is-negative-amount");
+    return cell;
+  }
+
+  function badge(value, tone, locked) {
     var element = document.createElement("span");
     element.className = "status-badge " + tone;
-    element.textContent = value;
+    element.appendChild(document.createTextNode(value));
+    /* 규칙 8 확정 후 잠금 — 색이 아니라 아이콘으로도 확정을 알린다 (VRUN-W01 과 같은 표현). */
+    if (locked) {
+      var lock = document.createElement("span");
+      lock.className = "material-symbols-rounded schedule-badge-lock";
+      lock.setAttribute("aria-hidden", "true");
+      lock.textContent = "lock";
+      element.appendChild(lock);
+    }
     return element;
   }
 
-  function badgeCell(value, tone) {
+  function badgeCell(value, tone, locked) {
     var cell = document.createElement("td");
     cell.className = "is-center";
-    cell.appendChild(badge(value, tone));
+    cell.appendChild(badge(value, tone, locked));
     return cell;
+  }
+
+  /*
+   * 긴 값 접기·펴기 — components.css:576-653 공통 구조.
+   * 미리보기 자리에 노드를 그대로 넣을 수 있게 DOM 으로 만든다 (계약번호는 링크라서 필요하다).
+   * 문자열을 조립하지 않으므로 escape 가 따로 필요 없다.
+   */
+  function disclosure(text, previewNode) {
+    var value = text === null || text === undefined || text === "" ? EMPTY : String(text);
+    var root = document.createElement("div");
+    root.className = "table-cell-disclosure";
+
+    var preview = document.createElement("span");
+    preview.className = "table-cell-preview is-single-line";
+    preview.appendChild(previewNode || document.createTextNode(value));
+    root.appendChild(preview);
+
+    var details = document.createElement("details");
+    details.className = "table-cell-details";
+    details.hidden = true;
+
+    var summary = document.createElement("summary");
+    var more = document.createElement("span");
+    more.className = "table-cell-more";
+    more.textContent = "전체 보기";
+    var less = document.createElement("span");
+    less.className = "table-cell-less";
+    less.textContent = "접기";
+    var chevron = document.createElement("span");
+    chevron.className = "material-symbols-rounded table-cell-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "expand_more";
+    summary.append(more, less, chevron);
+
+    var full = document.createElement("p");
+    full.className = "table-cell-full";
+    full.textContent = value;
+
+    details.append(summary, full);
+    root.appendChild(details);
+    return root;
+  }
+
+  /* 실제 렌더링 폭을 재서 잘린 셀에만 "전체 보기" 를 남긴다. */
+  function syncDisclosures() {
+    tableBody.querySelectorAll(".table-cell-disclosure").forEach(function (root) {
+      var preview = root.querySelector(".table-cell-preview");
+      var details = root.querySelector(".table-cell-details");
+      if (!preview || !details || preview.clientWidth === 0) return;
+      var truncated = preview.scrollWidth > preview.clientWidth + 1
+        || preview.scrollHeight > preview.clientHeight + 1;
+      details.hidden = !truncated;
+      if (!truncated) details.open = false;
+    });
   }
 
   function detailHref(scheduleHeaderId) {
@@ -287,33 +363,37 @@
       var row = document.createElement("tr");
       var contractCell = document.createElement("td");
       var hasId = schedule.scheduleHeaderId !== null && schedule.scheduleHeaderId !== undefined;
+      var contractNo = schedule.contractNo || EMPTY;
 
       if (hasId) {
         var contractLink = document.createElement("a");
         contractLink.href = detailHref(schedule.scheduleHeaderId);
         contractLink.className = "tabular-nums";
-        contractLink.textContent = schedule.contractNo || "-";
-        contractCell.appendChild(contractLink);
+        contractLink.textContent = contractNo;
+        contractCell.appendChild(disclosure(contractNo, contractLink));
       } else {
-        contractCell.textContent = schedule.contractNo || "-";
+        contractCell.appendChild(disclosure(contractNo));
       }
 
       row.appendChild(contractCell);
       row.appendChild(textCell(responseLabel(schedule.paymentStageLabel, LABELS.paymentStage, schedule.paymentStage)));
-      row.appendChild(badgeCell(responseLabel(schedule.scheduleRegimeLabel, LABELS.scheduleRegime, schedule.scheduleRegime), "status-badge-neutral"));
-      row.appendChild(badgeCell(responseLabel(schedule.schedulePurposeLabel, LABELS.schedulePurpose, schedule.schedulePurpose), schedule.schedulePurpose === "OPERATIONAL" ? "status-badge-info" : "status-badge-neutral"));
-      row.appendChild(textCell(schedule.scheduleVersionNo === null || schedule.scheduleVersionNo === undefined ? "-" : "v" + schedule.scheduleVersionNo, "is-center tabular-nums"));
-      row.appendChild(badgeCell(responseLabel(schedule.statusLabel, LABELS.scheduleStatus, schedule.status), STATUS_TONES[schedule.status] || "status-badge-neutral"));
+      /* 적용 체계·용도는 상태가 아니라 분류값이다 — 규칙 4 의 상태 5색을 쓰지 않고 neutral 로 통일한다. */
+      row.appendChild(badgeCell(responseLabel(schedule.scheduleRegimeLabel, LABELS.scheduleRegime, schedule.scheduleRegime), scheduleLabels.CLASSIFICATION_TONE));
+      row.appendChild(badgeCell(responseLabel(schedule.schedulePurposeLabel, LABELS.schedulePurpose, schedule.schedulePurpose), scheduleLabels.CLASSIFICATION_TONE));
+      row.appendChild(textCell(schedule.scheduleVersionNo === null || schedule.scheduleVersionNo === undefined ? EMPTY : "v" + schedule.scheduleVersionNo, "is-center tabular-nums"));
+      row.appendChild(badgeCell(
+        responseLabel(schedule.statusLabel, LABELS.scheduleStatus, schedule.status),
+        scheduleLabels.statusTone(schedule.status),
+        scheduleLabels.isLocked(schedule.status)));
       row.appendChild(badgeCell(isTrue(schedule.activeYn) ? "사용중" : "미사용", isTrue(schedule.activeYn) ? "status-badge-success" : "status-badge-neutral"));
-      row.appendChild(textCell(formatInteger(schedule.lineCount), "is-number tabular-nums"));
-      row.appendChild(textCell(formatWon(schedule.expectedTotal), "is-number tabular-nums"));
+      row.appendChild(textCell(format.int(schedule.lineCount), "is-number tabular-nums"));
+      row.appendChild(moneyCell(schedule.expectedTotal));
 
       var policyCell = document.createElement("td");
       var policyValue = document.createElement("span");
-      policyValue.className = "schedule-policy-value tabular-nums";
-      policyValue.textContent = schedule.policyVersionLabel || "-";
-      if (schedule.policyVersionLabel) policyValue.title = schedule.policyVersionLabel;
-      policyCell.appendChild(policyValue);
+      policyValue.className = "tabular-nums";
+      policyValue.textContent = schedule.policyVersionLabel || EMPTY;
+      policyCell.appendChild(disclosure(schedule.policyVersionLabel, policyValue));
       row.appendChild(policyCell);
 
       var actionCell = document.createElement("td");
@@ -393,7 +473,7 @@
 
   function renderPage(pageData) {
     var rows = Array.isArray(pageData.content) ? pageData.content : [];
-    resultCount.textContent = formatInteger(pageData.totalElements || 0);
+    resultCount.textContent = format.int(pageData.totalElements || 0);
     pageSizeText.textContent = String(pageData.size || PAGE_SIZE);
     dataWarning.hidden = !hasDuplicateActiveOperational(rows);
 
@@ -402,6 +482,7 @@
 
     renderPagination(pageData);
     table.setAttribute("aria-busy", "false");
+    window.requestAnimationFrame(syncDisclosures);
   }
 
   function isPageResponse(value) {

--- a/src/main/resources/templates/layout/default.html
+++ b/src/main/resources/templates/layout/default.html
@@ -56,6 +56,8 @@
   <script th:if="${screenId == 'FGC-UI-BASE-W01'}" th:src="@{/js/features/base/base-api.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-BASE-W01'}" th:src="@{/js/features/base/base-list.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-DASH-W01'}" th:src="@{/js/features/dashboard/dashboard.js}" defer></script>
+  <!-- SCHE 는 순서가 중요하다 — 두 화면 스크립트가 schedule-labels.js 의 window.FgcUi.scheduleLabels 를 읽는다. -->
+  <script th:if="${#strings.startsWith(screenId, 'FGC-UI-SCHE-')}" th:src="@{/js/features/schedule/schedule-labels.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-SCHE-W01'}" th:src="@{/js/features/schedule/schedule-list.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-SCHE-W02'}" th:src="@{/js/features/schedule/schedule-detail.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-TRAN-W01'}" th:src="@{/js/features/transaction/transaction-list.js}" defer></script>

--- a/src/main/resources/templates/schedule/detail.html
+++ b/src/main/resources/templates/schedule/detail.html
@@ -3,8 +3,10 @@
   FGC-UI-SCHE-W02 예상 스케줄 상세
   요구사항 FUN-036(스케줄 생성) · FUN-039(상태·버전) · FUN-040(멱등성) / REG-01 · REG-19
   데이터  읽기 schedule_header, schedule_line, commission_rule
-  API     GET  /api/v1/schedules/{id}
-          GET  /api/v1/schedules/{id}/export.csv
+  API     GET  /api/v1/schedules/{id}                          IF-API-28
+          GET  /api/v1/schedules/{id}/versions                 IF-API-28A
+          GET  /api/v1/schedules/{id}/export.csv               IF-API-28B
+          GET  /api/v1/schedules/{id}/active?paymentStage=…    IF-API-28C
           POST /api/v1/schedules/{id}/regenerate   (사유 필수 · 새 버전 생성)
           POST /api/v1/schedules/{id}/confirm      (예정 스케줄 확정·잠금)
   라우트  GET /schedules/{id} → schedule/detail.html
@@ -17,155 +19,191 @@
   [만들 때 주의]
    ★ 줄마다 원 단위로 반올림한 다음 합계를 냅니다.
      합계를 먼저 내고 반올림하면 대사에서 1원 차이로 전부 불일치가 납니다(허용오차 0원).
-
-  [정적 부착 단계] 목업(30_산출물/화면_MVP/FGC-UI-SCHE-W02)의 정적 골격만 옮겼다.
-  데이터 영역(헤더·회차 표·버전 비교)은 IF-API-28 연동 시 서버 렌더링으로,
-  새 버전 만들기·확정 동작은 IF-API-29 연동 시 붙인다.
 -->
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-SCHE-W02', '예상 스케줄 상세', '현행 예상 스케줄', '/schedules')}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main id="main-content"
-      class="fgc-main publishing-page publishing-page-detail publishing-page-schedule-detail"
+<main id="main-content" class="page-content schedule-detail-page"
       th:attr="data-schedule-header-id=${id}">
 
-  <!-- 목업 head 의 화면 전용 스타일 — 셸 조각은 main 만 가져가므로 여기로 옮겼다 -->
-  <style>
-    .kv { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px 20px; }
-    .kv dt { font-size: 11px; color: #43474d; font-weight: 600; }
-    .kv dd { margin: 2px 0 0; font-size: 13px; }
-  </style>
+  <header class="page-header schedule-page-header">
+    <div class="page-header-copy">
+      <h1 class="page-title">예상 스케줄 상세</h1>
+    </div>
+    <div class="page-header-actions">
+      <button class="button button-secondary" id="btn-export" type="button">
+        <span class="material-symbols-rounded" aria-hidden="true">download</span>CSV 내보내기
+      </button>
+      <!-- 재생성·확정은 SETTLEMENT (화면정의서 :892, IF-API-29) — GA_ADMIN 도 비활성이어야 한다 -->
+      <button class="button button-secondary" id="btn-regenerate" type="button" data-fgc-action="regenerate" th:disabled="${!canProcess}" aria-describedby="schedule-action-note">
+        <span class="material-symbols-rounded" aria-hidden="true">restart_alt</span>새 버전 만들기
+      </button>
+      <button class="button button-primary" id="btn-confirm" type="button" data-fgc-action="confirm" th:disabled="${!canProcess}" aria-describedby="schedule-action-note">
+        <span class="material-symbols-rounded" aria-hidden="true">lock</span>확정
+      </button>
+    </div>
+  </header>
 
-  <div class="publishing-page-head" style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
-    <div>
-      <h1 class="fgc-page-title">예상 스케줄 상세</h1>
-      <p class="fgc-page-desc">
-        이 계약에 대해 <strong>회차별로 언제 얼마를 줄 예정인지</strong>를 적어 둔 표입니다.
-        나중에 실제로 준 돈과 이 표를 맞춰 보는 것이 <strong>대사</strong>입니다.
-      </p>
-    </div>
-    <!-- 버튼 동작은 IF-API-28(상세)·IF-API-28B(CSV)·IF-API-29(새 버전)·확정 API 연동 시 붙인다 -->
-    <div class="publishing-inline-controls" style="display:flex;gap:8px">
-      <button class="fgc-btn fgc-btn--ghost" id="btn-export" type="button">
-        <span class="material-symbols-outlined" style="font-size:18px">download</span> CSV 내보내기
-      </button>
-      <!-- 재생성·확정은 SETTLEMENT (화면정의서 :873, IF-API-29) — GA_ADMIN 도 비활성이어야 한다 -->
-      <button class="fgc-btn fgc-btn--ghost" id="btn-regenerate" type="button"
-              data-fgc-action="regenerate" th:disabled="${!canProcess}">
-        <span class="material-symbols-outlined" style="font-size:18px">restart_alt</span> 새 버전 만들기
-      </button>
-      <button class="fgc-btn fgc-btn--primary" id="btn-confirm" type="button"
-              data-fgc-action="confirm" th:disabled="${!canProcess}">
-        <span class="material-symbols-outlined" style="font-size:18px">lock</span> 확정
-      </button>
-    </div>
-  </div>
+  <!--
+    비활성 사유를 가시 텍스트로 둔다. 예전에는 js 가 confirmButton.title 로만 알렸는데
+    disabled 요소는 포커스가 가지 않아 스크린리더가 title 에 닿지 못했다.
+    권한·상태·사용중 세 가지 사유를 js 가 여기에 구분해 적는다.
+  -->
+  <p class="schedule-action-note" id="schedule-action-note" role="status" hidden></p>
 
   <div class="modal-backdrop" data-modal="schedule-regenerate" data-close-on-backdrop="true"
        hidden aria-hidden="true">
-    <section class="modal" role="dialog" aria-modal="true"
+    <section class="modal schedule-modal" role="dialog" aria-modal="true"
              aria-labelledby="schedule-regenerate-title"
-             aria-describedby="schedule-regenerate-description"
-             style="width:min(480px, 100%)">
+             aria-describedby="schedule-regenerate-description">
       <header class="modal-header">
         <h2 id="schedule-regenerate-title" class="modal-title">새 버전 만들기</h2>
       </header>
       <div class="modal-body">
-        <p id="schedule-regenerate-description" style="margin:0 0 18px;line-height:1.65">
+        <p id="schedule-regenerate-description" class="schedule-modal-description">
           기존 스케줄은 그대로 두고 버전 번호를 올린 새 스케줄을 만듭니다.
           지난 버전을 지우지 않으므로 당시 금액의 근거도 계속 확인할 수 있습니다.
         </p>
-        <label class="fgc-label fgc-label--required" for="regenerate-reason">생성 사유</label>
-        <textarea class="textarea-control" id="regenerate-reason" maxlength="40" rows="4"
-                  data-modal-initial-focus
-                  placeholder="예) 2026-07 정책버전 개정 반영"></textarea>
-        <p class="fgc-muted" style="margin:8px 0 0;font-size:12px">감사로그에 이전값·이후값과 함께 남습니다. (40자 이내)</p>
+        <div class="field" id="regenerate-reason-field">
+          <label class="field-label" for="regenerate-reason">생성 사유
+            <span class="field-required" aria-hidden="true">*</span></label>
+          <textarea class="textarea-control" id="regenerate-reason" maxlength="40" rows="4"
+                    data-modal-initial-focus
+                    aria-describedby="regenerate-reason-error regenerate-reason-help"
+                    placeholder="예) 2026-07 정책버전 개정 반영"></textarea>
+          <!-- 사유 유효성은 Toast 가 아니라 필드 옆에 표시한다 (가이드 §11) -->
+          <p class="field-error" id="regenerate-reason-error" role="alert" hidden></p>
+          <p class="field-helper" id="regenerate-reason-help">감사로그에 이전값·이후값과 함께 남습니다. (40자 이내)</p>
+        </div>
       </div>
       <footer class="modal-footer">
-        <button class="fgc-btn fgc-btn--ghost" type="button" data-modal-close>취소</button>
-        <button class="fgc-btn fgc-btn--primary" id="btn-regenerate-submit" type="button" disabled>새 버전 만들기</button>
+        <button class="button button-secondary" type="button" data-modal-close>취소</button>
+        <button class="button button-primary" id="btn-regenerate-submit" type="button" disabled>새 버전 만들기</button>
       </footer>
     </section>
   </div>
 
-  <!-- ① 헤더 — 값은 IF-API-28 연동 시 서버 렌더링으로 채운다 -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__head">
-      <span class="fgc-card__title">스케줄 헤더 · <span class="fgc-mono" id="hdr-id">schedule_header #—</span></span>
-      <div class="publishing-inline-controls" style="display:flex;gap:6px;align-items:center">
-        <label class="fgc-label" for="stage" style="margin:0">지급단계</label>
-        <select class="fgc-select" id="stage" style="padding:4px 8px">
+  <!--
+    확정 확인 모달 — 확정은 비가역이다 (화면정의서 :889 "v2.1.2에서 추가한 트리거가 거부합니다").
+    재생성(가역)에만 확인 절차가 있고 확정(비가역)에는 없어서 위험도와 확인 강도가 뒤집혀 있었다.
+    문구는 부록 A :1769-1770 표준 문구를 그대로 쓴다.
+  -->
+  <div class="modal-backdrop" data-modal="schedule-confirm" data-close-on-backdrop="true"
+       hidden aria-hidden="true">
+    <section class="modal schedule-modal" role="dialog" aria-modal="true"
+             aria-labelledby="schedule-confirm-title"
+             aria-describedby="schedule-confirm-description">
+      <header class="modal-header">
+        <h2 id="schedule-confirm-title" class="modal-title">이 스케줄을 확정할까요?</h2>
+      </header>
+      <div class="modal-body">
+        <p id="schedule-confirm-description" class="schedule-modal-description">
+          되돌릴 수 없습니다 — 확정된 스케줄은 새 버전으로만 바꿉니다.
+          확정 후에는 금액을 고칠 수 없고, 고치려면 <strong>[새 버전 만들기]</strong>를 눌러야 합니다.
+        </p>
+        <dl class="schedule-confirm-summary">
+          <div><dt>계약번호</dt><dd class="tabular-nums" id="confirm-contract">-</dd></div>
+          <div><dt>버전</dt><dd class="tabular-nums" id="confirm-version">-</dd></div>
+          <div><dt>회차 수</dt><dd class="tabular-nums" id="confirm-line-count">-</dd></div>
+          <div><dt>예상 총액</dt><dd class="tabular-nums" id="confirm-total">-</dd></div>
+        </dl>
+      </div>
+      <footer class="modal-footer">
+        <button class="button button-secondary" type="button" data-modal-close
+                data-modal-initial-focus>취소</button>
+        <button class="button button-primary" id="btn-confirm-submit" type="button">확정</button>
+      </footer>
+    </section>
+  </div>
+
+  <!-- ① 헤더 -->
+  <section class="surface schedule-detail-card" aria-labelledby="schedule-header-title">
+    <header class="surface-header">
+      <h2 class="surface-title" id="schedule-header-title">스케줄 헤더 ·
+        <span class="tabular-nums" id="hdr-id">schedule_header #-</span></h2>
+      <!--
+        지급단계는 화면정의서 :879 가 정의한 이동 컨트롤이다 (IF-API-28C).
+        예전에는 같은 값을 헤더 정의목록에도 한 번 더 찍어 중복이었다 — 컨트롤 한 곳만 남긴다.
+      -->
+      <div class="field schedule-stage-field">
+        <label class="field-label" for="stage">지급단계</label>
+        <select class="select-control" id="stage" disabled>
           <option value="GA_TO_FC">GA→설계사</option>
           <option value="INSURER_TO_GA">원수사→GA</option>
         </select>
       </div>
-    </div>
-    <div class="fgc-card__body">
-      <dl class="kv">
-        <div><dt>계약번호</dt><dd class="fgc-mono" id="hdr-contract">—</dd></div>
-        <div><dt>보험회사 · 상품</dt><dd id="hdr-product">—</dd></div>
-        <div><dt>지급단계</dt><dd id="hdr-stage">—</dd></div>
-        <div><dt>적용 체계 (schedule_regime)</dt><dd id="hdr-regime">—</dd></div>
-        <div><dt>용도 (schedule_purpose)</dt><dd id="hdr-purpose">—</dd></div>
-        <div><dt>버전</dt><dd id="hdr-version">—</dd></div>
-        <div><dt>상태</dt><dd id="hdr-status">—</dd></div>
-        <div><dt>사용중</dt><dd id="hdr-active">—</dd></div>
-        <div><dt>정책버전</dt><dd class="fgc-mono" id="hdr-policy">—</dd></div>
-        <div><dt>생성 사유 · 일시</dt><dd id="hdr-reason">—</dd></div>
+    </header>
+    <div class="surface-body">
+      <p class="schedule-inline-state is-loading" id="hdr-state" role="status" aria-live="polite">스케줄을 불러오는 중입니다.</p>
+      <dl class="schedule-detail-kv" id="hdr-kv" hidden>
+        <div><dt>계약번호</dt><dd class="tabular-nums" id="hdr-contract">-</dd></div>
+        <div><dt>보험회사 · 상품</dt><dd id="hdr-product">-</dd></div>
+        <div>
+          <dt><span class="evidence" data-evidence>적용 체계<button class="evidence-trigger" type="button" aria-describedby="schedule-regime-evidence" aria-label="적용 체계 판정 근거"><span class="material-symbols-rounded" aria-hidden="true">info</span></button><span class="evidence-popover" id="schedule-regime-evidence" popover><strong>REG-19 · 적용 체계 판정</strong>
+            <span>적용 체계는 계약 체결연도만으로 정하지 않습니다. 상품 판매개시일 · 기초서류 버전 · 판매채널을 함께 보고 정합니다.</span></span></span></dt>
+          <dd id="hdr-regime">-</dd>
+        </div>
+        <div><dt>용도</dt><dd id="hdr-purpose">-</dd></div>
+        <div><dt>버전</dt><dd class="tabular-nums" id="hdr-version">-</dd></div>
+        <div><dt>상태</dt><dd id="hdr-status">-</dd></div>
+        <div><dt>사용중</dt><dd id="hdr-active">-</dd></div>
+        <div><dt>정책버전</dt><dd class="tabular-nums" id="hdr-policy">-</dd></div>
+        <div><dt>생성 사유 · 일시</dt><dd id="hdr-reason">-</dd></div>
       </dl>
     </div>
   </section>
 
-  <!-- 적용 체계 안내 — 문구는 IF-API-28 연동 시 계약의 적용 체계에 맞춰 채운다 -->
-  <div class="fgc-banner fgc-banner--info" style="margin-top:12px">
-    <span class="material-symbols-outlined" style="font-size:18px">gavel</span>
-    <span id="regime-note">
-      적용 체계는 <strong>계약 체결연도만으로 정하지 않습니다.</strong>
-      상품 판매개시일 · 기초서류 버전 · 판매채널을 함께 보고 정합니다(REG-19).
-    </span>
-  </div>
-
   <!-- ② 회차 표 + ③ 합계 -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__head">
-      <span class="fgc-card__title">회차별 예상 금액</span>
-      <span class="fgc-muted" style="font-size:12px">
-        줄마다 원 단위 <span class="fgc-mono">HALF_UP</span>으로 반올림한 뒤 합계를 냅니다
-      </span>
-    </div>
-    <div style="overflow-x:auto;max-height:520px">
-      <table class="fgc-table">
+  <section class="surface schedule-detail-card" aria-labelledby="schedule-lines-title">
+    <header class="surface-header">
+      <h2 class="surface-title" id="schedule-lines-title">회차별 예상 금액</h2>
+      <p class="schedule-detail-note">줄마다 원 단위 <span class="tabular-nums">HALF_UP</span>으로 반올림한 뒤 합계를 냅니다</p>
+    </header>
+    <div class="data-table-viewport schedule-line-viewport" tabindex="0" role="region"
+         aria-label="회차별 예상 금액 표">
+      <table class="data-table schedule-line-table" data-schedule-line-table aria-busy="true">
+        <caption class="visually-hidden">회차별 예상 지급 금액</caption>
+        <colgroup>
+          <col class="schedule-line-col-no">
+          <col class="schedule-line-col-installment">
+          <col class="schedule-line-col-month">
+          <col class="schedule-line-col-due">
+          <col class="schedule-line-col-item">
+          <col class="schedule-line-col-recipient">
+          <col class="schedule-line-col-basis">
+          <col class="schedule-line-col-amount">
+          <col class="schedule-line-col-calc">
+          <col class="schedule-line-col-rate">
+          <col class="schedule-line-col-expected">
+          <col class="schedule-line-col-status">
+          <col class="schedule-line-col-rule">
+        </colgroup>
         <thead>
           <tr>
-            <th style="width:44px">줄</th>
-            <th style="width:56px">회차</th>
-            <th style="width:70px">계약차월</th>
-            <th style="width:104px">지급예정일</th>
-            <th>수수료 항목</th>
-            <th>수령자</th>
-            <th>기준코드</th>
-            <th class="fgc-th-num">기준금액</th>
-            <th style="width:70px">계산방식</th>
-            <th class="fgc-th-num">요율</th>
-            <th class="fgc-th-num">예상금액</th>
-            <th style="width:76px">상태</th>
+            <th scope="col" class="is-number">줄</th>
+            <th scope="col" class="is-number">회차</th>
+            <th scope="col" class="is-number">계약차월</th>
+            <th scope="col">지급예정일</th>
+            <th scope="col">수수료 항목</th>
+            <th scope="col">수령자</th>
+            <th scope="col">기준코드</th>
+            <th scope="col" class="is-number">기준금액</th>
+            <th scope="col" class="is-center">계산방식</th>
+            <th scope="col" class="is-number">요율</th>
+            <th scope="col" class="is-number">예상금액</th>
+            <th scope="col" class="is-center">상태</th>
+            <!-- IF-API-28(:320) 응답의 ruleRef. 규칙 5 "근거 없는 숫자는 화면에 띄우지 않습니다" -->
+            <th scope="col" class="is-number">규칙 ID</th>
           </tr>
         </thead>
         <tbody id="line-body">
-          <tr><td colspan="12"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
+          <tr><td colspan="13"><p class="schedule-inline-state is-loading" role="status">예상 스케줄을 불러오는 중입니다.</p></td></tr>
         </tbody>
         <tfoot>
           <tr>
-            <td colspan="10">합계 (<span id="line-count">0</span>줄)</td>
-            <td class="fgc-td-num"><span class="fgc-amount" id="line-total">0</span></td>
-            <td></td>
-          </tr>
-          <tr>
-            <td colspan="10" class="fgc-muted" style="font-weight:400">
-              그중 초년도(계약일부터 1주년 전날까지) 합계 — 1,200% 산입 대상
-            </td>
-            <td class="fgc-td-num"><span class="fgc-amount" id="line-first-year">0</span></td>
-            <td></td>
+            <td colspan="10">합계 (<span class="tabular-nums" id="line-count">0</span>줄)</td>
+            <td class="is-number tabular-nums" id="line-total">0원</td>
+            <td colspan="2"></td>
           </tr>
         </tfoot>
       </table>
@@ -173,21 +211,39 @@
   </section>
 
   <!-- ④ 버전 비교 -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__head">
-      <span class="fgc-card__title">버전 비교</span>
-      <span class="fgc-muted" style="font-size:12px">지난 버전은 지우지 않고 남겨 둡니다</span>
-    </div>
-    <div style="overflow-x:auto">
-      <table class="fgc-table">
+  <section class="surface schedule-detail-card" aria-labelledby="schedule-versions-title">
+    <header class="surface-header">
+      <h2 class="surface-title" id="schedule-versions-title">버전 비교</h2>
+      <p class="schedule-detail-note">지난 버전은 지우지 않고 남겨 둡니다</p>
+    </header>
+    <div class="data-table-viewport schedule-version-viewport" tabindex="0" role="region"
+         aria-label="스케줄 버전 비교 표">
+      <table class="data-table schedule-version-table" data-schedule-version-table aria-busy="true">
+        <caption class="visually-hidden">같은 계약의 스케줄 버전 이력</caption>
+        <colgroup>
+          <col class="schedule-version-col-no">
+          <col class="schedule-version-col-status">
+          <col class="schedule-version-col-active">
+          <col class="schedule-version-col-policy">
+          <col class="schedule-version-col-reason">
+          <col class="schedule-version-col-generated">
+          <col class="schedule-version-col-lines">
+          <col class="schedule-version-col-total">
+        </colgroup>
         <thead>
           <tr>
-            <th>버전</th><th>상태</th><th>사용중</th><th>정책버전</th>
-            <th>생성 사유</th><th>생성 일시</th><th class="fgc-th-num">회차 수</th><th class="fgc-th-num">예상 총액</th>
+            <th scope="col" class="is-center">버전</th>
+            <th scope="col" class="is-center">상태</th>
+            <th scope="col" class="is-center">사용중</th>
+            <th scope="col">정책버전</th>
+            <th scope="col">생성 사유</th>
+            <th scope="col">생성 일시</th>
+            <th scope="col" class="is-number">회차 수</th>
+            <th scope="col" class="is-number">예상 총액</th>
           </tr>
         </thead>
         <tbody id="version-body">
-          <tr><td colspan="8"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
+          <tr><td colspan="8"><p class="schedule-inline-state is-loading" role="status">버전 이력을 불러오는 중입니다.</p></td></tr>
         </tbody>
       </table>
     </div>

--- a/src/main/resources/templates/schedule/list.html
+++ b/src/main/resources/templates/schedule/list.html
@@ -2,11 +2,10 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org"
       th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-SCHE-W01', '예상 스케줄 목록', null, null)}">
 <body>
-<main id="main-content" class="page-content publishing-page publishing-page-list schedule-list-page">
+<main id="main-content" class="page-content schedule-list-page">
   <header class="page-header schedule-page-header">
     <div class="page-header-copy">
       <h1 class="page-title">예상 스케줄 목록</h1>
-      <p class="page-description">계약별 지급 방향과 적용 정책에 따라 생성된 예상 지급 계획을 조회합니다.</p>
     </div>
     <div class="page-header-actions">
       <button class="button button-secondary" type="button" id="btn-schedule-export">
@@ -15,54 +14,47 @@
     </div>
   </header>
 
-  <aside class="schedule-guidance" aria-labelledby="schedule-guidance-title">
-    <span class="material-symbols-rounded" aria-hidden="true">gavel</span>
-    <div>
-      <h2 id="schedule-guidance-title">적용 체계는 계약 체결연도만으로 정하지 않습니다</h2>
-      <p>상품 판매개시일, 기초서류 버전과 판매채널을 함께 반영합니다. 운영 스케줄이 기본으로 조회되며 비교·시뮬레이션 스케줄은 용도를 선택해 구분합니다.</p>
-    </div>
-  </aside>
-
-  <form class="surface schedule-filter-card" method="get" action="/schedules" data-schedule-filter-form>
+  <!-- 가이드 §8 표준 필터 구조 (참조 기준 RECO-W01 reco/list.html:48-70).
+       name·쿼리 파라미터·data-schedule-filter-* 훅은 그대로 두고 골격만 공통 컴포넌트로 바꿨다.
+       보이는 "검색 조건" 제목이 사라지므로 form 에 aria-label 로 같은 이름을 남긴다. -->
+  <form class="filter-bar schedule-filter-bar" method="get" action="/schedules"
+        aria-label="검색 조건" data-schedule-filter-form>
     <input type="hidden" name="month" th:value="${month}">
-    <header class="schedule-section-header">
-      <h2 class="surface-title">검색 조건</h2>
-      <button class="button button-ghost schedule-reset-button" type="reset" data-schedule-filter-reset>초기화</button>
-    </header>
-    <div class="schedule-filter-grid">
-      <label class="field">
-        <span class="field-label">계약번호</span>
-        <input class="field-control" type="search" name="contractNo" placeholder="계약번호 입력" autocomplete="off">
-      </label>
-      <label class="field">
-        <span class="field-label">지급단계</span>
-        <select class="select-control" name="stage">
+    <div class="filter-fields schedule-filter-fields">
+      <div class="filter-field schedule-filter-contract">
+        <label class="filter-field-label" for="schedule-filter-contract-no">계약번호</label>
+        <input class="field-control" id="schedule-filter-contract-no" type="search" name="contractNo"
+               placeholder="계약번호 입력" autocomplete="off">
+      </div>
+      <div class="filter-field">
+        <label class="filter-field-label" for="schedule-filter-stage">지급단계</label>
+        <select class="select-control" id="schedule-filter-stage" name="stage">
           <option value="">전체</option>
           <option value="INSURER_TO_GA">원수사→GA</option>
           <option value="GA_TO_FC">GA→설계사</option>
         </select>
-      </label>
-      <label class="field">
-        <span class="field-label">적용 체계</span>
-        <select class="select-control" name="regime">
+      </div>
+      <div class="filter-field">
+        <label class="filter-field-label" for="schedule-filter-regime">적용 체계</label>
+        <select class="select-control" id="schedule-filter-regime" name="regime">
           <option value="">전체</option>
           <option value="CURRENT">현행</option>
           <option value="FOUR_YEAR_2027">4년 분급(2027)</option>
           <option value="SEVEN_YEAR_2029">7년 분급(2029)</option>
           <option value="TM_SPECIAL">TM 특례</option>
         </select>
-      </label>
-      <label class="field">
-        <span class="field-label">용도</span>
-        <select class="select-control" name="purpose">
+      </div>
+      <div class="filter-field">
+        <label class="filter-field-label" for="schedule-filter-purpose">용도</label>
+        <select class="select-control" id="schedule-filter-purpose" name="purpose">
           <option value="OPERATIONAL" selected>운영</option>
           <option value="COMPARISON">비교</option>
           <option value="SIMULATION">시뮬레이션</option>
         </select>
-      </label>
-      <label class="field">
-        <span class="field-label">상태</span>
-        <select class="select-control" name="status">
+      </div>
+      <div class="filter-field">
+        <label class="filter-field-label" for="schedule-filter-status">상태</label>
+        <select class="select-control" id="schedule-filter-status" name="status">
           <option value="">전체</option>
           <option value="PLANNED">예정</option>
           <option value="CONFIRMED">확정</option>
@@ -72,9 +64,10 @@
           <option value="CANCELLED">취소</option>
           <option value="RESTARTED">재개</option>
         </select>
-      </label>
+      </div>
     </div>
-    <div class="schedule-filter-actions">
+    <div class="filter-actions schedule-filter-actions">
+      <button class="button button-ghost" type="reset" data-schedule-filter-reset>초기화</button>
       <button class="button button-primary" type="submit">
         <span class="material-symbols-rounded" aria-hidden="true">search</span>
         조회
@@ -115,7 +108,13 @@
         <tr>
           <th scope="col">계약번호</th>
           <th scope="col">지급단계</th>
-          <th scope="col">적용 체계</th>
+          <th scope="col">
+            <span class="evidence" data-evidence>적용 체계<button class="evidence-trigger" type="button"
+                  aria-describedby="schedule-regime-evidence" aria-label="적용 체계 판정 근거"><span
+                  class="material-symbols-rounded" aria-hidden="true">info</span></button><span
+                  class="evidence-popover" id="schedule-regime-evidence" popover><strong>REG-19 · 적용 체계 판정</strong>
+              <span>적용 체계는 계약 체결연도만으로 정하지 않습니다. 상품 판매개시일 · 기초서류 버전 · 판매채널을 함께 보고 정합니다.</span></span></span>
+          </th>
           <th scope="col">용도</th>
           <th scope="col" class="is-center">버전</th>
           <th scope="col" class="is-center">상태</th>

--- a/src/test/java/com/susukkang/fgc/schedule/view/ScheduleListViewTest.java
+++ b/src/test/java/com/susukkang/fgc/schedule/view/ScheduleListViewTest.java
@@ -43,8 +43,13 @@ class ScheduleListViewTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("FGC-UI-SCHE-W01")))
                 .andExpect(content().string(containsString("id=\"main-content\"")))
-                .andExpect(content().string(containsString("publishing-page publishing-page-list schedule-list-page")))
+                // publishing.css 브리지를 뗐다 (#285) — 이 화면엔 fgc-* 가 0건이라 브리지가 하는 일이 없고,
+                // 컨테이너 레이아웃은 layout.css 의 .page-content 가 같은 값으로 준다.
+                .andExpect(content().string(containsString("class=\"page-content schedule-list-page\"")))
+                .andExpect(content().string(not(containsString("publishing-page"))))
                 .andExpect(content().string(containsString("data-schedule-filter-form")))
+                // 라벨·톤 공용 모듈은 화면 스크립트보다 먼저 실려야 한다
+                .andExpect(content().string(containsString("/js/features/schedule/schedule-labels.js")))
                 .andExpect(content().string(containsString("name=\"contractNo\"")))
                 .andExpect(content().string(containsString("name=\"stage\"")))
                 .andExpect(content().string(containsString("name=\"regime\"")))

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -41,7 +41,6 @@ class PublishingTemplateStructureTest {
     private static final List<String> BRIDGE_SCOPED_TEMPLATES = List.of(
             "templates/transaction/list.html",
             "templates/transaction/form.html",
-            "templates/schedule/detail.html",
             "templates/ledger/list.html",
             "templates/exception/list.html",
             "templates/vrun/list.html",
@@ -61,6 +60,7 @@ class PublishingTemplateStructureTest {
             "templates/audit/list.html",
             "templates/contract/form.html",
             "templates/schedule/list.html",
+            "templates/schedule/detail.html",
             "templates/arbitrage/list.html",
             "templates/error/403.html",
             "templates/error/404.html",
@@ -789,6 +789,175 @@ class PublishingTemplateStructureTest {
                 .contains("passwordToggle.setAttribute(\"aria-label\", willShow ? \"비밀번호 숨기기\" : \"비밀번호 표시\")")
                 .doesNotContain("FGC-AUTH-")
                 .doesNotContain("fetch(");
+    }
+
+    /*
+     * SCHE-W01 예상 스케줄 목록 (#285).
+     *
+     * 이 화면은 레거시가 이미 0건이었고 남은 것은 화면 설명문·자체 필터 골격·title 안티패턴이었다.
+     * 가장 중요한 회귀 방지 대상은 잘린 값을 title 속성으로만 알리던 부분이다 —
+     * 가이드 §10.2 가 "잘라 놓거나 title 속성만 제공하면 안 된다" 고 금지한다.
+     */
+    @Test
+    void scheduleListUsesCommonFilterBarAndDisclosureInsteadOfTitleTooltips() throws IOException {
+        assertThat(resource("templates/schedule/list.html"))
+                .contains("class=\"page-content schedule-list-page\"")
+                .contains("class=\"filter-bar schedule-filter-bar\"")
+                .contains("class=\"filter-fields schedule-filter-fields\"")
+                .contains("class=\"filter-field-label\"")
+                .contains("class=\"filter-actions schedule-filter-actions\"")
+                // 필터 계약(name·쿼리 파라미터·JS 훅)은 골격이 바뀌어도 그대로여야 한다
+                .contains("data-schedule-filter-form")
+                .contains("data-schedule-filter-reset")
+                .contains("name=\"contractNo\"")
+                .contains("name=\"stage\"")
+                .contains("name=\"regime\"")
+                .contains("name=\"purpose\"")
+                .contains("name=\"status\"")
+                // 화면 설명문·설명 배너는 지우되 REG-19 근거는 근거 툴팁으로 남긴다
+                .contains("id=\"schedule-regime-evidence\"")
+                .contains("REG-19 · 적용 체계 판정")
+                .doesNotContain("class=\"page-description\"")
+                .doesNotContain("schedule-guidance")
+                .doesNotContain("publishing-page");
+
+        assertThat(resource("static/css/features/schedule.css"))
+                .contains(".schedule-filter-bar")
+                .contains(".schedule-filter-fields")
+                .contains(":focus-visible")
+                // Guidance 를 지우면서 전용 CSS 4블록도 함께 걷어냈다
+                .doesNotContain(".schedule-guidance")
+                .doesNotContain(".schedule-filter-grid")
+                .doesNotContain(".schedule-policy-value");
+
+        assertThat(resource("static/js/features/schedule/schedule-list.js"))
+                .contains("table-cell-disclosure")
+                .contains("table-cell-preview is-single-line")
+                .contains("preview.scrollWidth > preview.clientWidth")
+                .contains("format.won(")
+                .contains("format.int(")
+                .contains("scheduleLabels.statusTone(schedule.status)")
+                .contains("scheduleLabels.isLocked(schedule.status)")
+                // CSV 는 성공·실패 모두 알린다 — 전에는 location.assign 만 있었다
+                .contains("function exportCsv(url)")
+                .contains("예상 스케줄 CSV를 내려받았습니다.")
+                // src/test/js/schedule-list.test.cjs 가 require 하는 export 계약
+                .contains("normalizePage: normalizePage")
+                .contains("responseLabel: require(\"./schedule-labels.js\").responseLabel")
+                // title 안티패턴과 자체 포맷 구현이 되살아나면 안 된다
+                .doesNotContain("policyValue.title")
+                .doesNotContain("function formatWon")
+                .doesNotContain("function formatInteger");
+    }
+
+    /*
+     * SCHE-W02 예상 스케줄 상세 (#285).
+     *
+     * 이 화면에서 가장 실질적인 결함 두 가지를 인수조건으로 고정한다.
+     *   · 비가역인 확정에 확인 절차가 없었다 — 가역인 재생성에만 모달이 있었다
+     *   · 금액에 소수 4자리를 허용하고 날짜를 YYYY.MM.DD 로 찍고 시간대가 없었다
+     */
+    @Test
+    void scheduleDetailAddsConfirmDialogAndDropsLegacyShell() throws IOException {
+        assertThat(resource("templates/schedule/detail.html"))
+                .contains("class=\"page-content schedule-detail-page\"")
+                .contains("class=\"surface schedule-detail-card\"")
+                .contains("class=\"data-table-viewport schedule-line-viewport\" tabindex=\"0\" role=\"region\"")
+                .contains("class=\"visually-hidden\">회차별 예상 지급 금액")
+                .contains("<colgroup>")
+                .contains("scope=\"col\"")
+                // 확정 확인 모달 — 재생성 모달과 같은 공통 Modal 계약을 쓴다
+                .contains("data-modal=\"schedule-confirm\"")
+                .contains("data-close-on-backdrop=\"true\"")
+                .contains("role=\"dialog\" aria-modal=\"true\"")
+                .contains("id=\"btn-confirm-submit\"")
+                .contains("되돌릴 수 없습니다 — 확정된 스케줄은 새 버전으로만 바꿉니다.")
+                // 재생성 모달 구조는 그대로 두되 사유 오류 슬롯을 더했다
+                .contains("data-modal=\"schedule-regenerate\"")
+                .contains("data-modal-initial-focus")
+                .contains("id=\"regenerate-reason-error\"")
+                .contains("class=\"field-error\"")
+                // ruleRef 는 IF-API-28 응답에 이미 있는데 표에 없었다
+                .contains(">규칙 ID<")
+                // 권한 검증(ScreenViewControllerTest)과 API 훅은 보존
+                .contains("id=\"btn-regenerate\"")
+                .contains("data-fgc-action=\"regenerate\"")
+                .contains("data-fgc-action=\"confirm\"")
+                .contains("th:disabled=\"${!canProcess}\"")
+                // 비활성 사유는 title 이 아니라 가시 텍스트 + aria-describedby 로 전달한다
+                .contains("id=\"schedule-action-note\"")
+                .contains("aria-describedby=\"schedule-action-note\"")
+                .doesNotContain("class=\"fgc-")
+                .doesNotContain("fgc-banner")
+                .doesNotContain("style=\"")
+                .doesNotContainPattern("(?i)<style[\\s>]")
+                .doesNotContain("<script>");
+
+        assertThat(resource("static/js/features/schedule/schedule-detail.js"))
+                // 표시 형식은 공통 유틸만 쓴다 (FGC-SIR-008)
+                .contains("format.won(")
+                .contains("format.date(")
+                .contains("format.dateTime(")
+                .contains("format.rate(")
+                .doesNotContain("maximumFractionDigits")
+                .doesNotContain("replace(/-/g")
+                .doesNotContain("Intl.")
+                // 확정은 모달을 거친다 — 클릭 즉시 POST 가 나가면 안 된다
+                .contains("confirmButton.addEventListener(\"click\", openConfirmDialog)")
+                .contains("confirmSubmit.addEventListener(\"click\", confirmSchedule)")
+                .contains("openModal(\"schedule-confirm\")")
+                // 로딩·빈·오류를 클래스로 나누고 오류에는 재시도를 붙인다
+                .contains("schedule-inline-state")
+                .contains("is-loading")
+                .contains("is-empty")
+                .contains("is-error")
+                .contains("retry.textContent = \"다시 시도\"")
+                // 현재 버전은 굵기가 아니라 공통 선택 상태로 표시한다
+                .contains("row.className = \"is-selected\"")
+                .contains("row.setAttribute(\"aria-current\", \"true\")")
+                .doesNotContain("row.style.fontWeight")
+                // 라벨·톤은 공용 모듈 한 벌만 쓴다
+                .contains("window.FgcUi.scheduleLabels")
+                .doesNotContain("SCHEDULE_STATUS_LABELS = {")
+                // 업무 판정을 화면에서 다시 계산하지 않는다
+                .doesNotContain("contractMonthNo) >= 1")
+                // 사용자에게 안 보이는 채널로만 오류를 흘리지 않는다
+                .doesNotContain("console.error");
+
+        assertThat(resource("static/js/features/schedule/schedule-labels.js"))
+                .contains("module.exports = api")
+                .contains("window.FgcUi.scheduleLabels = api")
+                .contains("CONFIRMED: \"status-badge-review\"")
+                .contains("HOLD: \"status-badge-review\"")
+                .contains("CANCELLED: \"status-badge-neutral\"")
+                .contains("LOCKED_STATUSES");
+
+        assertThat(resource("static/css/features/schedule.css"))
+                .contains(".schedule-detail-kv")
+                .contains(".schedule-inline-state")
+                .contains(".schedule-line-viewport")
+                .contains(".schedule-version-table tbody tr.is-selected")
+                .doesNotContainPattern("#[0-9a-fA-F]{3,8}\\b");
+    }
+
+    /*
+     * 로드 순서 고정 — schedule-list.js · schedule-detail.js 가 schedule-labels.js 의
+     * window.FgcUi.scheduleLabels 를 읽는다. 순서가 바뀌면 두 화면이 예외 없이 조용히 멈춘다
+     * (두 파일 모두 모듈이 없으면 early return 한다).
+     */
+    @Test
+    void productionLayoutLoadsScheduleLabelsBeforeScheduleScreens() throws IOException {
+        String layout = resource("templates/layout/default.html");
+
+        assertThat(layout)
+                .contains("th:src=\"@{/js/features/schedule/schedule-labels.js}\" defer");
+
+        assertThat(layout.indexOf("schedule-labels.js"))
+                .as("schedule-labels.js 는 schedule-list.js 보다 먼저 등록되어야 한다")
+                .isLessThan(layout.indexOf("schedule-list.js"));
+        assertThat(layout.indexOf("schedule-labels.js"))
+                .as("schedule-labels.js 는 schedule-detail.js 보다 먼저 등록되어야 한다")
+                .isLessThan(layout.indexOf("schedule-detail.js"));
     }
 
     private static String resource(String path) throws IOException {


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- 예상 스케줄 2화면(SCHE-W01 목록 · W02 상세)을 공통 UI 컴포넌트 기준으로 전환했습니다.
- SCHE-W02 의 인라인 `style=` 27개와 `class="fgc-*"` 43개를 걷어내고 레거시 브리지 의존을 없앴습니다.
- 되돌릴 수 없는 **확정**에 확인 모달을 추가했습니다. 기존에는 클릭 즉시 API 가 나갔습니다.
- 금액 소수 4자리 · 날짜 `YYYY.MM.DD` · 시간대 누락 등 표시 형식 결함을 공통 유틸로 통일했습니다.
- 두 화면이 각자 들고 있던 라벨 사전을 `schedule-labels.js` 한 벌로 모았습니다.

기준 커밋 `0a2796ae` (`origin/develop`) · 9 files changed, +1175 / −511 · 새 파일 `static/js/features/schedule/schedule-labels.js`

## 🔗 2. 관련 이슈

* Closes #285
* Refs #138

## 🛠 3. 구현 내용

### ① SCHE-W01 마무리

- `list.html:9` `page-description` 삭제, `:18-24` `schedule-guidance` 배너 삭제 + `schedule.css:11-40` 4블록 동반 제거
- `:5` `publishing-page publishing-page-list` 제거 → `class="page-content schedule-list-page"`
- 자체 필터 골격 → 공통 `filter-bar` / `filter-fields` / `filter-field` / `filter-field-label` / `filter-actions` (참조 기준 RECO-W01 `reco/list.html:48-70`)
- 표 뷰포트에 `tabindex="0"` + `role="region"` + `aria-label`

`publishing-page` 를 떼도 안전한 근거 — 이 화면엔 `fgc-*` 가 0건이라 브리지의 변수 재매핑이 하는 일이 없고, `publishing.css:9` `.app-main > .publishing-page` 와 `layout.css:793` `.page-content` 가 `width`·`max-width`·`margin`·`padding` 모두 같은 값입니다. CONT-W01 도 이미 `class="page-content contract-list-page"` 로만 되어 있습니다. 보이는 "검색 조건" `<h2>` 가 사라지므로 `<form>` 에 `aria-label="검색 조건"` 으로 같은 이름을 남겼습니다.

### ② `title` 안티패턴 제거

`schedule-list.js:315` 의 `policyValue.title = …` 와 `schedule.css:145-151` 의 `ellipsis` 를 걷어내고 공통 `table-cell-disclosure` 로 바꿨습니다. 가이드 §10.2 가 "잘라 놓거나 `title` 속성만 제공하면 안 된다" 고 명시적으로 금지합니다.

대상은 **정책버전**과 **계약번호**입니다. 계약번호는 링크라서 문자열 조립 대신 DOM 으로 disclosure 를 만들고 미리보기 자리에 `<a>` 노드를 그대로 넣었습니다 — 문자열을 만들지 않으므로 escape 가 따로 필요 없습니다. 실제 렌더링 폭(`scrollWidth > clientWidth`)을 재서 잘린 셀에만 "전체 보기"를 남깁니다.

### ③ 라벨 사전 · 배지 톤 단일화

`schedule-list.js:63-88` 과 `schedule-detail.js:15-35` 가 같은 라벨 4세트를 각자 들고 있었고, 톤 매핑은 W01 에만 있어 W02 는 상태를 plain 텍스트로 찍었습니다. 새 파일 `schedule-labels.js` 한 벌로 모았습니다.

| 항목 | 전 | 후 |
|---|---|---|
| 라벨 사전 선언 | 2벌 (list · detail) | 1벌 |
| W02 `status-badge` | 0건 | 헤더 4곳 + 회차 표 + 버전 표 |
| 톤 매핑 | W01 만 | 두 화면 공유 |

**톤 3건을 바꿨고 1건은 일부러 두었습니다.** 판단 근거는 서버 enum 주석(`common/code/ScheduleLineStatus.java:12-18` — 저장소에서 각 상태의 업무 의미를 적어 둔 유일한 출처)과 화면정의서 4장 규칙 4(`:212` "정상=초록, 주의=주황, 위반·차단=빨강, 검토필요=회색, 진행중=파랑")입니다.

| 상태 | 서버 enum 의 뜻 | 전 | 후 |
|---|---|---|---|
| `HOLD` | 계약이 미납된 경우 | `risk`(빨강) | **`review`** — 미납은 위반이 아니라 검토 필요 |
| `CANCELLED` | 계약이 해지된 경우 | `error`(빨강) | **`neutral`** — 해지는 규칙 4 의 5색에 없는 종료 상태 |
| `CONFIRMED` | 담당자가 확정 | `review` | **`review` 유지 + 자물쇠 아이콘** |
| `PLANNED`·`MATCHED`·`ADJUSTED`·`RESTARTED` | — | info·success·warning·info | 그대로 |

`HOLD`·`CANCELLED` 를 바꿔도 안전한 근거 — `features/*.js` 전수 확인 결과 이 두 코드에 배지 톤을 매기는 곳이 `schedule-list.js` 하나뿐입니다.

`CONFIRMED` 를 `success` 로 바꾸지 않은 근거 — 이슈는 규칙 4 의 "정상=초록"을 들어 `success` 를 제안했지만, VRUN-W01 이 같은 뜻의 확정(`FINALIZED`)을 `vrun/list.html:111-118` 에서 `fgc-badge--review` + `lock` 으로 표시합니다. 규칙 8(`:216` "확정 후 잠금")이 두 화면을 같은 개념으로 묶으므로 여기만 초록으로 바꾸면 확정 색이 화면마다 갈립니다. 대신 규칙 8 을 지키도록 **자물쇠 아이콘을 배지 안에 넣어** 색이 아니라 아이콘·글자로 구분되게 했습니다.

**적용 체계·용도는 분류값이라 상태 5색을 쓰지 않습니다.** 배지 형태는 유지하되 톤을 `neutral` 하나로 통일했습니다 — 전에는 용도 `OPERATIONAL` 에만 `info`(진행중)를 써서 색의 뜻이 흐려져 있었습니다.

### ④ ★ 확정 확인 모달

`schedule-detail.js:105` 가 클릭 즉시 `POST /confirm` 을 보냈습니다. 확정은 되돌릴 수 없는데(화면정의서 `:889` "v2.1.2에서 추가한 트리거가 거부합니다") 정작 **되돌릴 수 있는 재생성에만 확인 모달이 있어** 위험도와 확인 강도가 뒤집혀 있었습니다.

재생성 모달과 같은 공통 Modal 계약(`data-modal`·`data-close-on-backdrop`·`role="dialog"`·`aria-modal`·`data-modal-initial-focus`)으로 확정용 모달을 추가했습니다.

- 문구는 부록 A `:1769-1770` 표준 문구를 그대로 씁니다 — "되돌릴 수 없습니다 — 확정된 스케줄은 새 버전으로만 바꿉니다."
- 계약번호·버전·회차 수·예상 총액을 요약해 무엇을 확정하는지 보여줍니다
- `data-modal-initial-focus` 를 **취소** 버튼에 뒀습니다 — 비가역 동작에 기본 포커스를 주지 않습니다
- 실패 시에는 모달이 열린 채 남으므로 바깥 버튼으로 포커스를 옮기지 않습니다. 성공 시 포커스 복귀는 `modal.js:37` 이 처리합니다

### ⑤ SCHE-W02 공통 컴포넌트 전환

| 항목 | 전 | 후 |
|---|---|---|
| 인라인 `style=` | 27개 | **0개** |
| `<style>` 블록 | 33-37행 (하드코딩 HEX 1건) | `schedule.css` 의 `.schedule-detail-kv` 로 이관, 색은 `--color-text-secondary` |
| `class="fgc-*"` | 43개 | **0개** |
| `publishing-page*` | 4개 | 0개 |
| `<colgroup>` · `<caption>` · `scope="col"` | 전부 없음 | 두 표 모두 적용 |
| JS 인라인 스타일 | 4곳 | 0곳 |

- `:136` 의 `overflow-x:auto;max-height:520px` → `data-table-viewport` + 화면 전용 `.schedule-line-viewport { max-height: 32.5rem }`
- `:120` 의 `fgc-banner--info` REG-19 배너는 SCHE-W01 의 `schedule-guidance` 와 내용이 중복이었습니다. **두 배너를 모두 지우고 근거는 잃지 않도록** 적용 체계 값 옆 근거 툴팁(`evidence` popover, 규칙 5)으로 옮겼습니다 — W01 은 열 머리글에 1개, W02 는 헤더 `<dt>` 에 1개
- **지급단계 중복 제거** — `<select id="stage">` 는 화면정의서 `:879` 가 정의한 이동 컨트롤(IF-API-28C)인데 같은 값을 `hdr-stage` `<dd>` 에도 한 번 더 찍고 있었습니다. 컨트롤 한 곳만 남겼습니다

### ⑥ 표시 형식 (FGC-SIR-008)

`js/common/format.js` 로 두 화면을 통일했습니다.

| 위치 | 전 | 후 |
|---|---|---|
| `schedule-detail.js` 금액 | `Intl.NumberFormat("ko-KR", { maximumFractionDigits: 4 })` — **금액에 소수 4자리** | `format.won()` — 원 단위 정수, 음수는 괄호 |
| `schedule-detail.js` 날짜 | `String(v).replace(/-/g, ".")` → **`YYYY.MM.DD`** | `format.date()` — `YYYY-MM-DD` |
| `schedule-detail.js` 일시 | `Intl.DateTimeFormat` **`timeZone` 옵션 없음** | `format.dateTime()` — `Asia/Seoul` 고정 |
| `schedule-list.js` 금액·건수 | 손으로 짠 정규식 `replace(/\B(?=(\d{3})+(?!\d))/g, ",")` | `format.won()` · `format.int()` |
| 결측 표기 | W01 `"-"` / W02 `"—"` | `"-"` 로 통일 |

금액 소수 4자리는 `detail.html` 자체 설명("줄마다 원 단위 `HALF_UP` 으로 반올림한 뒤 합계")과 화면정의서 4장 규칙 1·2(`:209-210`)에 정면으로 어긋났습니다. 일시는 `ScheduleHeaderResponse:61` 이 `OffsetDateTime` 이라 시간대가 붙어 오는데 브라우저 로컬로 렌더되고 있었습니다 — 생성 일시는 감사 근거값입니다.

### ⑦ 로딩 / 빈 / 오류 · Toast

W02 의 6상태가 전부 `.fgc-empty` 였고 오류만 JS 가 인라인으로 색(하드코딩 HEX)을 칠했습니다. 화면에서 셋을 구분할 수 없었습니다.

- `.schedule-inline-state` + `is-loading` / `is-empty` / `is-error` 로 나누고 `role="status"` / `role="alert"` 부여
- **헤더 영역에도 상태를 넣었습니다** — 전에는 `<dd>` 초기값 `"—"` 가 로딩·오류·무데이터에서 모두 같아 보였습니다
- 버전 표 오류에도 재시도 버튼 (전에는 회차 표에만 있었습니다)
- colspan 만 다르던 중복 함수 `renderVersionMessage` / `appendMessage` 를 `stateRow` 하나로 통합
- 사용자에게 보이지 않던 콘솔 로그 4건을 인라인 상태 + Toast 로 승격

| 액션 | 전 | 후 |
|---|---|---|
| 상세 로드 실패 | 표 안 텍스트만 | 인라인 오류 + 재시도 + Toast |
| 버전 이력 로드 실패 | 표 안 텍스트만, 재시도 없음 | 인라인 오류 + 재시도 + Toast |
| CSV 내보내기 (W01·W02) | **피드백 0건** (`location.assign` 만) | fetch + Blob 저장, 성공·실패 Toast, `aria-busy` |
| 재생성 사유 유효성 | Toast | **`field-error` 슬롯** (가이드 §11) |
| 모든 오류 문구 | 제각각 | `format.errorText()` — 오류코드·요청 ID 병기 |

**SCHE-W01 의 조회 실패 인라인 오류 상태(제목 + 메시지 + 요청 ID + 재시도)는 그대로 뒀습니다** — 이슈 지시대로 현행이 더 낫습니다.

### ⑧ 접근성

- `aria-busy` — 확정·재생성·CSV·지급단계 전환·회차 표·버전 표
- `js:98` 의 `confirmButton.title = "이미 확정된 스케줄입니다."` 제거 → **`#schedule-action-note` 가시 텍스트 + `aria-describedby`**. `disabled` 요소는 포커스가 가지 않아 `title` 에 닿을 수 없고, 권한/상태/사용중 3가지 사유가 같은 문구로 뭉개져 있었습니다
- 두 표에 `<caption class="visually-hidden">` + `<th scope="col">` + `<colgroup>`
- 가로 스크롤 뷰포트 3곳에 `tabindex="0"` + `role="region"` + `aria-label`
- 현재 버전 강조를 `row.style.fontWeight = "700"` → **`.is-selected`(`components.css:572`) + `aria-current`**
- `schedule.css` 에 `:focus-visible` 규칙 신설 — 전에는 **0건**이었습니다 (`reco.css:174` 대조)

### ⑨ 문서 대비 반영

**회차 표에 `규칙 ID`(`ruleRef`) 컬럼을 추가했습니다.** `ScheduleLineResponse:35` 에 필드가 실재하고 IF-API-28(`:320`)이 "회차별 라인 + `ruleRef`(근거)", IF-API-28B(`:322`)가 CSV 에 "규칙 ID" 포함을 규정하는데 화면이 렌더하지 않고 있었습니다. 규칙 5 "근거 없는 숫자는 화면에 띄우지 않습니다" 에도 걸립니다.

**초년도 합계 줄을 제거했습니다.** `js:184` 가 `contractMonthNo >= 1 && <= 12` 로 초년도를 화면에서 재계산하고 있었는데, 화면정의서 `:775`·`:777-782` 는 초년도를 **귀속일 기준 `[계약일, 1주년일)`** 로 정의합니다(계약일 2026-07-10 이면 귀속일 2027-07-09 까지 포함, 2027-07-10 은 제외). 계약차월 1~12 는 다른 규칙입니다. 게다가 `ScheduleLineResponse` 에 귀속일 필드 자체가 없어 화면이 올바르게 계산할 방법이 없습니다. "1,200% 산입 대상" 이라고 이름 붙은 규제 관련 숫자가 틀린 규칙으로 계산되고 있었으므로, 서버가 값을 줄 때까지 표시하지 않는 쪽을 택했습니다(9번 참고 사항의 백엔드 요청 2번).

### 착수 전 재검증 — 이슈와 달라진 점 3가지

이슈는 기준 커밋이 `859adffd` 인데 그 뒤로 develop 이 30커밋 넘게 움직였습니다.

| 이슈 ⑬ 항목 | 실제 |
|---|---|
| 지급단계 셀렉트가 `disabled=true` 라 "순수 표시용" | **이미 해결됨.** PR #316(`cda2ac87`)이 IF-API-28C 를 붙여 실제 전환 기능으로 만들었습니다 |
| `hdr-product` 가 하드코딩 `"—"` | **이미 해결됨.** 같은 커밋에서 `join(insurerName, productName)` 으로 바뀌었습니다 |
| `components.css:662-679` `[data-schedule-*]` 이관 | **이번에 하지 않았습니다.** 해당 블록 주석이 "TRAN 이슈가 먼저 옮기고 SCHE 가 뒤따른다"고 순서를 정해 뒀고 TRAN(#284)은 아직 PR 이 없습니다 |

HTML 쪽 진단은 줄 번호까지 그대로 유효했고, JS 만 #316 때문에 약 +23줄씩 밀려 있었습니다.

## 🧪 4. 테스트 방법

1. 전체 테스트를 실행합니다. **Docker Desktop 이 떠 있어야 합니다** — Testcontainers 가 PostgreSQL 을 띄웁니다.
   ```bash
   ./gradlew build
   ```
   확인된 결과: `BUILD SUCCESSFUL` · **1153 tests, 0 failed**

2. 이 PR 이 신설·수정한 구조 테스트만 따로 확인합니다.
   ```bash
   ./gradlew test \
     --tests "com.susukkang.fgc.ui.PublishingTemplateStructureTest" \
     --tests "com.susukkang.fgc.common.web.ScreenViewControllerTest" \
     --tests "com.susukkang.fgc.schedule.view.ScheduleListViewTest"
   ```
   확인된 결과: 25 + 18 + 1 tests 통과

3. 정적 검사로 레거시 잔존과 표시 형식 결함이 0건인지 봅니다.
   ```bash
   rg -n 'page-description|fgc-page-desc|guidance|fgc-banner' src/main/resources/templates/schedule src/main/resources/static/css/features/schedule.css
   rg -n 'style=|onclick=|onchange=|<style|<script' src/main/resources/templates/schedule
   rg -n 'fgc-card|fgc-btn|fgc-field|fgc-select|fgc-table|fgc-badge|fgc-empty|fgc-mono|fgc-td-num|fgc-th-num|publishing-page' src/main/resources/templates/schedule
   rg -n '#[0-9a-fA-F]{3,8}\b' src/main/resources/static/css/features/schedule.css
   rg -n 'maximumFractionDigits|replace\(/-/g|timeZone' src/main/resources/static/js/features/schedule
   ```
   확인된 결과: **5종 모두 0건**

4. JS 문법과 `.cjs` 계약을 확인합니다. **제 환경에 Node 가 없어 실행하지 못했습니다** — 6번 리뷰 요구사항 1번 참조.
   ```bash
   node --check src/main/resources/static/js/features/schedule/schedule-labels.js
   node --check src/main/resources/static/js/features/schedule/schedule-list.js
   node --check src/main/resources/static/js/features/schedule/schedule-detail.js
   node --test src/test/js/schedule-list.test.cjs
   ```

5. 앱을 띄워 두 화면을 확인합니다. **브라우저 QA 는 하지 못했습니다** — 6번 리뷰 요구사항 2번 참조.
   ```bash
   ./gradlew bootRun
   ```
   - `/schedules` — 필터 조회·초기화, 로딩 스켈레톤 → 결과, 빈 결과, 오류 시 재시도 + 요청 ID, 긴 정책버전 `전체 보기 / 접기`, CSV Toast, 페이지 이동 후 필터 보존, 중복 운영 스케줄 경고
   - `/schedules/{id}` — 회차 표·버전 표 렌더, 배지 표시(상태·사용중·체계·용도), **확정 확인 모달** Esc·포커스 복귀, 재생성 모달 회귀 없음, 긴 생성 사유 `전체 보기`, **금액이 소수 없이 표시되는지**, **날짜가 `YYYY-MM-DD` 인지**, 생성 일시가 KST 인지
   - 공통 — 1440px / 900px / 720px, 키보드 Tab 탐색과 `:focus-visible`, 본문 가로 넘침 없음, Console 오류 없음

   **확정은 되돌릴 수 없으므로 테스트 데이터로만 수행해 주세요.**

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

1. **`node --check` · `node --test` 를 실행하지 못했습니다.** 제 작업 환경에 Node 가 설치되어 있지 않습니다. `src/test/js/*.cjs` 는 `build.gradle` 과 `ci.yml` 어디에서도 실행되지 않아(CI 는 `./gradlew build` 만 돌립니다) 이 경로는 자동 검증이 아예 없습니다. 특히 `schedule-list.js` 가 Node 모드에서 형제 모듈로 export 를 넘기는 부분(`require("./schedule-labels.js").responseLabel`)이 실제로 도는지 확인 부탁드립니다. `require` 는 `module.exports` 분기 안에서만 실행되므로 브라우저에는 영향이 없습니다. `module.exports` 계약 자체는 구조 테스트로 고정해 두었습니다.

2. **브라우저 QA 를 하지 못했습니다** — 1440px / 900px / 720px 세 폭 모두입니다. 코드 경로와 구조 테스트로만 확인했습니다. 특히 다음을 봐 주세요.
   - SCHE-W01 — 필터가 `filter-bar` 로 바뀐 뒤 5개 필드가 좁은 폭에서 어떻게 접히는지 (grid 5열 → flex wrap 으로 **방식 자체가 바뀌었습니다**)
   - SCHE-W02 — 확정 확인 모달 Esc·포커스 복귀, 확정 후 자물쇠 배지
   - 두 화면 — 정책버전·생성 사유 disclosure 가 실제로 잘린 셀에만 뜨는지 (`scrollWidth` 실측이라 실제 렌더링이 필요합니다)

3. **배지 톤 3건 변경과 `CONFIRMED` 유지 판단**을 봐 주세요 (3번 구현 내용 ③). `CONFIRMED` 만 이슈 제안(`success`)을 따르지 않았습니다. VRUN-W01 과 색이 갈리는 것을 피하려는 판단인데, 반대로 `REVIEW_REQUIRED` 색 정본 결정처럼 전 화면을 한 번에 맞추는 게 낫다면 알려 주세요.

4. **초년도 합계 줄 제거가 맞는 판단인지** 봐 주세요 (3번 구현 내용 ⑨). 값이 틀린 채로 "1,200% 산입 대상" 이라고 표시되는 것보다는 낫다고 판단했지만, 발표(8/24) 시연에서 그 줄이 필요하다면 되돌리는 대신 백엔드 필드를 먼저 받는 쪽을 제안합니다.

5. **`Idempotency-Key` 를 확정에 넣지 않았습니다.** TRAN-W02(`transaction-form.js:559`) 선례가 있지만 서버의 `POST /schedules/{id}/confirm` 이 그 헤더를 읽는지 확인하지 못했고, 백엔드 수정은 이 이슈의 "하지 말 것" 입니다. 더블클릭 방어는 확정 버튼 + 모달 제출 버튼 양쪽 `disabled` 로만 되어 있습니다. 서버가 이미 받는다면 알려 주세요.

6. **`ScheduleListViewTest:46` 의 단언을 바꿨습니다.** 기존 단언이 제거 대상인 `publishing-page publishing-page-list schedule-list-page` 문자열을 고정하고 있어서, 새 셸(`class="page-content schedule-list-page"`) 단언 + `publishing-page` 부재 단언 + `schedule-labels.js` 등록 확인으로 교체했습니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다. (기준 커밋 `0a2796ae` = 작업 시점 `origin/develop` HEAD)
* [x] 로컬 빌드에 성공했습니다. (`./gradlew build` BUILD SUCCESSFUL)
* [x] 애플리케이션 실행을 확인했습니다. — **못 했습니다.** 6번 리뷰 요구사항 2번 참조
* [x] 관련 기능을 직접 테스트했습니다. — **브라우저 수동 테스트를 못 했습니다.** 6번 리뷰 요구사항 2번 참조
* [x] 테스트 코드가 필요한 경우 작성했습니다. (구조 테스트 3건 신설, 기존 2건 갱신)
* [x] 기존 기능에 영향이 없는지 확인했습니다. (전체 1153건 통과)
* [x] 커밋 메시지 컨벤션을 준수했습니다. (`refactor(schedule): …`)
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다. (DB 관련 파일 미변경)
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다. (콘솔 로그 4건 → 사용자에게 보이는 채널로 승격)

**구조 테스트 신설 3건**

- `scheduleListUsesCommonFilterBarAndDisclosureInsteadOfTitleTooltips()` — `title` 안티패턴·자체 포맷 구현 재발 방지, 필터 계약(`name`·쿼리 파라미터·JS 훅) 보존, `.cjs` export 계약 고정
- `scheduleDetailAddsConfirmDialogAndDropsLegacyShell()` — 확정이 모달을 거치는지, 표시 형식이 공통 유틸만 쓰는지, 굵기 인라인이 되살아나지 않는지
- `productionLayoutLoadsScheduleLabelsBeforeScheduleScreens()` — 로드 순서를 `indexOf` 비교로 고정. 순서가 바뀌면 두 화면이 예외 없이 조용히 멈춥니다(둘 다 모듈이 없으면 early return)
- `templates/schedule/detail.html` 을 `BRIDGE_SCOPED_TEMPLATES` → `FULLY_MIGRATED_TEMPLATES` 로 이동

## 🖼️ 8. 화면 변경

* **SCHE-W01 예상 스케줄 목록** (`/schedules`)
    - 화면 설명문·설명 배너 삭제 → REG-19 근거는 적용 체계 열 머리글의 근거 툴팁으로
    - 검색 조건 카드 → 공통 `filter-bar` (제목 줄과 5열 그리드가 사라지고 한 줄 바(bar) 형태로 바뀝니다)
    - 초기화 버튼이 카드 헤더에서 조회 버튼 옆으로 이동
    - 정책버전·계약번호가 잘릴 때 `전체 보기 / 접기` 표시
    - 상태 배지 색 변경 — 보류(빨강→회색), 취소(빨강→중립), 확정에 자물쇠 아이콘 추가
    - 적용 체계·용도 배지가 모두 중립색으로 통일
    - CSV 내보내기 성공·실패 Toast
* **SCHE-W02 예상 스케줄 상세** (`/schedules/{id}`)
    - 레거시 카드·표 골격 → 공통 `surface` / `data-table`
    - 헤더 아래 REG-19 안내 배너 삭제 → 적용 체계 값 옆 근거 툴팁으로
    - 헤더의 중복된 "지급단계" 줄 삭제 (셀렉트 컨트롤만 남김)
    - 상태·사용중·적용체계·용도·회차 상태·버전 상태가 plain 텍스트 → 배지
    - **확정 버튼을 누르면 확인 모달이 뜹니다** (기존에는 즉시 실행)
    - 회차 표에 **규칙 ID** 컬럼 추가 (13컬럼)
    - **초년도 합계 줄 삭제**
    - 금액에서 소수점 사라짐, 날짜가 `YYYY.MM.DD` → `YYYY-MM-DD`, 생성 일시가 KST 고정
    - 로딩·빈 결과·오류가 시각적으로 구분되고 오류에 재시도 버튼
    - 버전 표에서 현재 버전이 굵기 대신 선택 배경으로 표시
    - CSV 내보내기 성공·실패 Toast

## 💬 9. 참고 사항

### 백엔드 요청 (이 PR 에서 고치지 않음)

1. **`ScheduleLineResponse` 에 `lineStatusLabel` 이 없습니다.** `ScheduleHeaderResponse` 는 `getStatusLabel()` 등 `*Label` 을 내려주는데 라인 응답에는 없어 화면이 자체 사전으로 코드를 번역합니다. `ArbitrageCheckStatus` 주석의 "SIR-008: 코드값은 항상 한글 라벨과 함께 응답한다" 와 어긋납니다. 화면은 `lineStatusLabel` 이 오면 바로 우선 사용하도록 이미 짜 두었습니다.
2. **초년도 합계 필드가 없습니다.** 화면정의서 `:775`·`:777-782` 의 귀속일 기준 `[계약일, 1주년일)` 판정은 서버만 할 수 있습니다(라인 응답에 귀속일이 없습니다). `ScheduleHeaderResponse` 에 초년도 합계를 넣어 주시면 화면에서 바로 표시하겠습니다.
3. **SCHE-W01 정책버전 필터가 없습니다.** 화면정의서 `:811` 은 검색 항목에 "계약번호, 지급단계, **정책버전**, 상태, 체계" 를 적는데 IF-API-27 파라미터에는 정책버전이 없고, 대신 문서 검색 항목에 없는 **용도** 필터가 구현되어 있습니다 — 문서·API·구현 3자 불일치입니다.
4. **중복 운영 스케줄 탐지가 페이지 경계를 넘지 못합니다.** `hasDuplicateActiveOperational()` 은 현재 페이지 20행 안에서만 봅니다. 화면정의서 `:817` 은 "두 개가 보이면 데이터 오류" 라고만 하는데, 서버가 전체 기준으로 판정해 플래그를 내려 주는 편이 맞습니다.

### 별도 이슈 필요

1. **SCHE-W02 버전 비교 "나란히"** — 화면정의서 `:856` 은 "이전 버전과 나란히" 비교를 요구하는데 구현은 단순 버전 목록 표입니다. 금액·회차 차이 하이라이트도 없습니다. 변경 규모가 커서 이번 PR 에서 제외했습니다.
2. **`syncTableCellDisclosures` 중복** — 같은 함수가 `audit`·`base`·`cap`·`contract`·`dashboard`·`exception`·`policy`·`reco` 그리고 이번 `schedule` 2곳까지 화면마다 각자 있습니다. 공통 유틸로 뽑는 게 맞지만 10개 파일을 동시에 건드려야 해서 #138 하위의 별도 이슈로 제안합니다.
3. **`publishing-page` 일괄 제거 시점** — 이번에 SCHE-W01·W02 에서 뗐지만 `base`·`policy`·`reco`·`audit`·`contract/form`·`arbitrage` 는 아직 붙어 있습니다. `PublishingTemplateStructureTest:50-55` 주석이 "떼는 시점은 `assets/fgc.css` 정리와 함께 판단한다 (#138 완료 조건)" 로 미뤄 둔 상태라, 남은 화면은 한 번에 정리하는 쪽을 제안합니다.

### 보류

**`components.css:662-679` 의 `[data-schedule-page-numbers]` 이관은 하지 않았습니다.** 해당 블록 주석이 "TRAN 이슈가 먼저 옮기고 SCHE 가 뒤따른다" 고 순서를 명시하고 TRAN(#284)에 아직 PR 이 없습니다. `data-schedule-*` 훅은 그대로 두었으니 TRAN 이 옮긴 뒤 뒤따르면 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 일정 목록 필터와 상세 화면을 공통 레이아웃으로 개선했습니다.
  * 일정 확정·재생성 확인 모달, 상태별 안내, 재시도 기능을 추가했습니다.
  * CSV 내보내기에 진행 상태와 성공·실패 알림을 제공합니다.
  * 정책 버전·계약번호 접기/펴기, 잠금 표시, 접근성 포커스를 지원합니다.
  * 상세 화면에 버전 비교 및 회차 정보를 추가했습니다.

* **개선 사항**
  * 모바일 화면에서 필터와 작업 영역의 반응형 배치를 개선했습니다.
  * 오류·로딩·빈 결과 상태를 명확히 구분해 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->