### PR TITLE
[Refactor] VRUN-W01·W02 월 통합검증 화면 공통 UI 전환 (#286)

### DIFF
--- a/src/main/resources/static/css/features/vrun.css
+++ b/src/main/resources/static/css/features/vrun.css
@@ -205,41 +205,68 @@
  * 원본은 다른 화면이 참조할 수 있으므로 지우지 않고 이름을 바꿔 새로 정의했다.
  * 상태는 색만으로 전달하지 않는다 — 각 칸이 visually-hidden 텍스트로 상태를 함께 읽어 준다.
  */
+/*
+ * 칸을 카드로 나열하지 않고 한 줄로 잇는다 — 10단계가 순서대로 진행된다는 사실이
+ * 형태로 드러나야 한다. 칸마다 테두리를 두면 서로 독립된 항목처럼 읽힌다.
+ * 좁은 화면에서는 줄바꿈 대신 가로 스크롤한다. 줄이 바뀌면 연결선이 끊겨
+ * 순서가 오히려 안 보인다.
+ */
 .vrun-stepper {
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
+  align-items: flex-start;
+  gap: 0;
   padding: var(--space-4);
   list-style: none;
+  overflow-x: auto;
 }
 
 .vrun-stepper-step {
-  display: grid;
-  min-width: 5.5rem;
-  flex: 1 1 5.5rem;
-  justify-items: center;
-  gap: var(--space-1);
-  padding: var(--space-2) var(--space-1);
-  border: 1px solid var(--color-border-subtle);
-  border-radius: var(--radius-8);
-  background: var(--color-bg-surface);
+  position: relative;
+  min-width: 5.75rem;
+  flex: 1 1 0;
   text-align: center;
 }
 
+/*
+ * 단계를 잇는 수평선. 완료된 칸의 선만 초록으로 바뀌므로 채워진 길이가 곧 진행률이다.
+ * 위쪽 진행률 텍스트(current_step/10)와 같은 값을 형태로 한 번 더 보여 주는 것이고,
+ * 판정은 서버가 준 stepClasses 를 그대로 따른다 — 화면에서 다시 계산하지 않는다.
+ */
+.vrun-stepper-step::after {
+  position: absolute;
+  z-index: 0;
+  top: 0.875rem; /* dot 1.75rem 의 세로 중앙 */
+  right: -50%;
+  left: 50%;
+  height: 2px;
+  background: var(--color-border-default);
+  content: "";
+}
+
+.vrun-stepper-step:last-child::after {
+  display: none;
+}
+
 .vrun-stepper-dot {
+  position: relative;
+  z-index: 1;
   display: grid;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.75rem;
+  height: 1.75rem;
+  margin: 0 auto var(--space-1);
   place-items: center;
+  border: 2px solid var(--color-border-default);
   border-radius: var(--radius-full);
   color: var(--color-text-secondary);
-  background: var(--color-bg-subtle);
+  background: var(--color-bg-surface);
   font-size: 0.75rem;
   font-variant-numeric: tabular-nums;
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .vrun-stepper-label {
+  display: block;
+  padding: 0 var(--space-1);
   color: var(--color-text-secondary);
   font-size: 0.6875rem;
   line-height: 1rem;
@@ -260,32 +287,32 @@
  * 이름을 바꾸려면 Controller 를 고쳐야 하는데 이 이슈에서는 백엔드 수정이 금지라
  * (그리고 진행 상태를 화면에서 재계산하는 것도 금지라) 이름은 두고 스타일만 여기로 옮겼다.
  */
-.vrun-stepper-step.fgc-stepper__step--done {
-  border-color: var(--color-status-success-border);
-  background: var(--color-status-success-bg);
+/* 완료된 칸의 오른쪽 선까지 초록으로 채워진다 — 이게 진행 바 역할을 한다. */
+.vrun-stepper-step.fgc-stepper__step--done::after {
+  background: var(--color-status-success-solid);
 }
 
 .vrun-stepper-step.fgc-stepper__step--done .vrun-stepper-dot {
+  border-color: var(--color-status-success-solid);
   color: var(--color-text-inverse);
   background: var(--color-status-success-solid);
 }
 
-.vrun-stepper-step.fgc-stepper__step--running {
-  border-color: var(--color-status-info-border);
-  background: var(--color-status-info-bg);
-}
-
 .vrun-stepper-step.fgc-stepper__step--running .vrun-stepper-dot {
+  border-color: var(--color-status-info-solid);
   color: var(--color-text-inverse);
   background: var(--color-status-info-solid);
 }
 
-.vrun-stepper-step.fgc-stepper__step--failed {
-  border-color: var(--color-status-error-border);
-  background: var(--color-status-error-bg);
+/* 지나온 단계와 지금 단계의 이름은 또렷하게 — 색만으로 구분하지 않는다(규칙 4). */
+.vrun-stepper-step.fgc-stepper__step--done .vrun-stepper-label,
+.vrun-stepper-step.fgc-stepper__step--running .vrun-stepper-label {
+  color: var(--color-text-primary);
+  font-weight: 600;
 }
 
 .vrun-stepper-step.fgc-stepper__step--failed .vrun-stepper-dot {
+  border-color: var(--color-status-error-solid);
   color: var(--color-text-inverse);
   background: var(--color-status-error-solid);
 }
@@ -328,7 +355,14 @@
 .vrun-target-col-refund { width: 6.5rem; }
 .vrun-target-col-reason { width: 12rem; }
 
+/*
+ * 공통 .kpi-grid 는 3열이라 4블록이 3+1 로 떨어져 마지막 칸만 홀로 남는다.
+ * 결과 요약은 항상 4개(1,200%·차익거래·원장·대사)이므로 2열로 고정해 2×2 로 맞춘다.
+ * 좁은 화면 1열 전환은 아래 반응형 블록에서 다시 푼다 — 여기 기본 규칙이
+ * components.css 의 미디어쿼리보다 뒤에 오므로 그쪽 값이 이기지 못한다.
+ */
 .vrun-summary-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   padding: var(--space-3) var(--space-4);
 }
 
@@ -421,6 +455,11 @@
 }
 
 @media (max-width: 47.9375rem) {
+  /* 2열 고정을 여기서 푼다 — 폭이 좁으면 카드 안 숫자가 줄바꿈된다. */
+  .vrun-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
   .vrun-create-month,
   .vrun-create-type,
   .vrun-filter-status {

--- a/src/main/resources/static/css/features/vrun.css
+++ b/src/main/resources/static/css/features/vrun.css
@@ -1,16 +1,443 @@
 /*
- * VRUN-W01·W02 화면 전용 스타일 (#138).
+ * VRUN-W01·W02 화면 전용 스타일 (#286, #138).
  *
- * 지금은 루트 레이아웃만 둔다. 스텝퍼·결과 요약·컬럼 폭은 VRUN 담당 이슈에서 채운다.
- * 공통 컴포넌트(components.css)의 디자인을 여기에 다시 복사하지 않는다.
+ * 선행 정비(#293)가 루트 레이아웃만 두고 나머지를 이 이슈로 넘겼다. 여기서 채운다.
+ *   · templates/vrun/detail.html 의 <style>·<script> 블록
+ *   · 두 템플릿의 인라인 style 60개 이상
+ *   · assets/fgc.css 의 .fgc-stepper (원본은 지우지 않고 .vrun-stepper 로 새로 정의)
+ *   · publishing.css 의 .publishing-result-placeholder 의존 → 공통 kpi-card 로 교체
  *
- * 이관 예정: templates/vrun/detail.html 의 <style>·<script> 블록, 두 템플릿의 인라인 style,
- *           assets/fgc.css 의 .fgc-stepper (원본은 지우지 않고 .vrun-stepper 로 새로 정의),
- *           publishing.css 의 .publishing-result-placeholder 의존 → kpi-card 로 교체.
+ * 공통 컴포넌트(components.css)의 디자인을 여기에 다시 복사하지 않는다 — 폭·간격만 얹는다.
  */
 
 .vrun-page {
   display: grid;
   min-width: 0;
   gap: var(--space-4);
+}
+
+/* ───────────────────────────── 공통 ───────────────────────────── */
+
+.vrun-card-note {
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  line-height: 1.125rem;
+}
+
+/* 규칙 8 확정 후 잠금 — 배지 안 자물쇠. SCHE-W01·W02(#285)와 같은 표현. */
+.vrun-badge-lock {
+  margin-left: 0.125rem;
+  font-size: 0.875rem;
+}
+
+.vrun-kv {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9.375rem, 1fr));
+  gap: 0.75rem 1.25rem;
+  padding: var(--space-3) var(--space-4);
+}
+
+.vrun-kv dt {
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1.125rem;
+}
+
+.vrun-kv dd {
+  margin-top: 0.125rem;
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+  overflow-wrap: anywhere;
+}
+
+/*
+ * 로딩 · 빈 결과 · 오류를 클래스로 구분한다.
+ * 전에는 셋 다 .fgc-empty publishing-empty-state 하나였고 색을 인라인으로 칠했다.
+ */
+.vrun-inline-state {
+  display: grid;
+  min-height: 5rem;
+  place-items: center;
+  gap: var(--space-3);
+  padding: var(--space-6) var(--space-4);
+  color: var(--color-text-secondary);
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+  text-align: center;
+  text-wrap: pretty;
+}
+
+.vrun-inline-state.is-error {
+  color: var(--color-status-error-text);
+}
+
+.vrun-inline-state.is-empty {
+  color: var(--color-text-tertiary);
+}
+
+/*
+ * 비활성 버튼의 사유를 담는 가시 텍스트.
+ * disabled 요소는 포커스가 가지 않아 title 로는 스크린리더에 닿지 않는다 —
+ * 버튼 바깥 텍스트 + aria-describedby 조합으로 옮겼다 (reco/list.html:73-86 패턴).
+ */
+.vrun-action-note {
+  color: var(--color-status-warning-text);
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+}
+
+.vrun-modal {
+  width: min(32rem, 100%);
+}
+
+.vrun-modal-description {
+  margin-bottom: var(--space-4);
+  line-height: 1.65;
+}
+
+.vrun-modal-points {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-8);
+  background: var(--color-bg-subtle);
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+}
+
+/* ─────────────────────── VRUN-W01 실행 목록 ─────────────────────── */
+
+.vrun-create-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4) var(--space-4);
+}
+
+.vrun-create-month {
+  width: 10rem;
+}
+
+.vrun-create-type {
+  width: 12rem;
+}
+
+.vrun-create-hint {
+  flex: 1 1 16rem;
+  align-self: center;
+}
+
+.vrun-filter-fields {
+  flex: 1 1 auto;
+}
+
+.vrun-filter-status {
+  width: 10rem;
+}
+
+.vrun-filter-actions {
+  flex: 0 0 auto;
+}
+
+.vrun-run-table {
+  min-width: 71rem;
+}
+
+.vrun-col-month { width: 5.5rem; }
+.vrun-col-runno { width: 3.5rem; }
+.vrun-col-type { width: 7rem; }
+.vrun-col-status { width: 7rem; }
+.vrun-col-progress { width: 9.5rem; }
+.vrun-col-actor { width: 6rem; }
+.vrun-col-started { width: 8.5rem; }
+.vrun-col-completed { width: 8.5rem; }
+.vrun-col-finalized { width: 10.5rem; }
+.vrun-col-failure { width: 14rem; }
+.vrun-col-open { width: 5rem; }
+
+.vrun-row-button {
+  min-width: 3.75rem;
+  height: 1.75rem;
+  padding-inline: 0.625rem;
+  font-size: 0.75rem;
+}
+
+.vrun-run-table .table-cell-disclosure,
+.vrun-target-table .table-cell-disclosure {
+  font-size: 0.75rem;
+}
+
+.vrun-failure-text {
+  color: var(--color-status-error-text);
+}
+
+.vrun-pagination {
+  display: flex;
+  min-height: 2.5rem;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  border-top: 1px solid var(--color-border-subtle);
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+}
+
+/* ───────────────────── VRUN-W02 상세 · 확정 ───────────────────── */
+
+.vrun-run-picker {
+  gap: 0.25rem;
+}
+
+.vrun-run-picker .select-control {
+  width: min(18rem, 60vw);
+  height: 1.75rem;
+  padding-block: 0;
+  font-size: 0.75rem;
+}
+
+/*
+ * 10단계 스텝퍼.
+ * assets/fgc.css:159-182 의 .fgc-stepper 를 여기로 옮겨 토큰화한 것이다.
+ * 원본은 다른 화면이 참조할 수 있으므로 지우지 않고 이름을 바꿔 새로 정의했다.
+ * 상태는 색만으로 전달하지 않는다 — 각 칸이 visually-hidden 텍스트로 상태를 함께 읽어 준다.
+ */
+.vrun-stepper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  list-style: none;
+}
+
+.vrun-stepper-step {
+  display: grid;
+  min-width: 5.5rem;
+  flex: 1 1 5.5rem;
+  justify-items: center;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-1);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-8);
+  background: var(--color-bg-surface);
+  text-align: center;
+}
+
+.vrun-stepper-dot {
+  display: grid;
+  width: 1.5rem;
+  height: 1.5rem;
+  place-items: center;
+  border-radius: var(--radius-full);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-subtle);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.vrun-stepper-label {
+  color: var(--color-text-secondary);
+  font-size: 0.6875rem;
+  line-height: 1rem;
+  text-wrap: pretty;
+}
+
+.vrun-stepper-manual {
+  display: block;
+  color: var(--color-status-warning-text);
+  font-size: 0.625rem;
+  font-weight: 600;
+}
+
+/*
+ * 상태 수식어는 서버가 주는 이름을 그대로 받는다.
+ * ValidationRunViewController:168-192 의 stepClasses() 가 fgc-stepper__step--* 문자열을
+ * 계산해 내려주고 vrun-detail.js 의 stepClass() 가 폴링 중 같은 이름을 붙인다.
+ * 이름을 바꾸려면 Controller 를 고쳐야 하는데 이 이슈에서는 백엔드 수정이 금지라
+ * (그리고 진행 상태를 화면에서 재계산하는 것도 금지라) 이름은 두고 스타일만 여기로 옮겼다.
+ */
+.vrun-stepper-step.fgc-stepper__step--done {
+  border-color: var(--color-status-success-border);
+  background: var(--color-status-success-bg);
+}
+
+.vrun-stepper-step.fgc-stepper__step--done .vrun-stepper-dot {
+  color: var(--color-text-inverse);
+  background: var(--color-status-success-solid);
+}
+
+.vrun-stepper-step.fgc-stepper__step--running {
+  border-color: var(--color-status-info-border);
+  background: var(--color-status-info-bg);
+}
+
+.vrun-stepper-step.fgc-stepper__step--running .vrun-stepper-dot {
+  color: var(--color-text-inverse);
+  background: var(--color-status-info-solid);
+}
+
+.vrun-stepper-step.fgc-stepper__step--failed {
+  border-color: var(--color-status-error-border);
+  background: var(--color-status-error-bg);
+}
+
+.vrun-stepper-step.fgc-stepper__step--failed .vrun-stepper-dot {
+  color: var(--color-text-inverse);
+  background: var(--color-status-error-solid);
+}
+
+.vrun-progress-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: 0 var(--space-4);
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+}
+
+.vrun-progress-value {
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+/*
+ * ③대상 선별 · ④결과 요약을 나란히 두는 2단 그리드.
+ * 전에는 detail.html 의 인라인 <script> 가 resize 리스너로 폭을 재서 제어했는데,
+ * 그 기준값(1150px)이 프로젝트 브레이크포인트와 달랐고 JS 가 없으면 항상 2단이었다.
+ */
+.vrun-mid-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.vrun-target-table {
+  min-width: 38rem;
+}
+
+.vrun-target-col-contract { width: 8rem; }
+.vrun-target-col-status { width: 6rem; }
+.vrun-target-col-offering { width: 11rem; }
+.vrun-target-col-refund { width: 6.5rem; }
+.vrun-target-col-reason { width: 12rem; }
+
+.vrun-summary-grid {
+  padding: var(--space-3) var(--space-4);
+}
+
+.vrun-exception-grid {
+  grid-template-columns: repeat(auto-fit, minmax(8.125rem, 1fr));
+  padding: var(--space-3) var(--space-4);
+}
+
+.vrun-checklist {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+}
+
+.vrun-checklist-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-8);
+  background: var(--color-bg-surface);
+}
+
+.vrun-checklist-label {
+  min-width: 0;
+  flex: 1 1 18rem;
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+}
+
+.vrun-checklist-result {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 0 0 auto;
+}
+
+.vrun-finalize-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  padding: var(--space-4);
+}
+
+.vrun-finalize-copy {
+  max-width: 40rem;
+}
+
+.vrun-finalize-title {
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 1.25rem;
+}
+
+.vrun-finalize-guide {
+  margin-top: var(--space-1);
+}
+
+/* ─────────────────────────── 포커스 ─────────────────────────── */
+
+/*
+ * 이 화면들에는 :focus-visible 규칙이 하나도 없었다.
+ * 가로 스크롤 뷰포트와 화면 전용 요소는 공통 규칙이 닿지 않아 Tab 위치를 알 수 없었다.
+ */
+.vrun-table-viewport:focus-visible,
+.vrun-row-button:focus-visible,
+.vrun-pagination .pagination-button:focus-visible,
+.vrun-checklist-result a:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: -2px;
+}
+
+.vrun-create-form :focus-visible,
+.vrun-filter-bar :focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 1px;
+}
+
+/* ─────────────────────────── 반응형 ─────────────────────────── */
+
+@media (max-width: 63.9375rem) {
+  .vrun-mid-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 47.9375rem) {
+  .vrun-create-month,
+  .vrun-create-type,
+  .vrun-filter-status {
+    width: 100%;
+  }
+
+  .vrun-filter-bar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .vrun-run-picker .select-control {
+    width: 100%;
+  }
+
+  .vrun-finalize-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
 }

--- a/src/main/resources/static/js/features/vrun/vrun-detail.js
+++ b/src/main/resources/static/js/features/vrun/vrun-detail.js
@@ -14,13 +14,22 @@
 
   var apiClient = window.FgcUi && window.FgcUi.apiClient;
   var toast = window.FgcUi && window.FgcUi.toast;
+  var format = window.FgcUi && window.FgcUi.format;
+  var modal = window.FgcUi && window.FgcUi.modal;
   var executeButton = document.getElementById("btn-execute");
   var refreshButton = document.getElementById("btn-refresh");
   var stepper = document.getElementById("stepper");
-  var statusBadge = document.getElementById("hdr-status");
+  var progressText = document.getElementById("progress-text");
+  var statusBadge = document.querySelector("#hdr-status .status-badge");
   var checklistSummary = document.getElementById("cond-summary");
   var checklistBody = document.getElementById("cond-body");
   var finalizeButton = document.getElementById("btn-finalize");
+  var finalizeLabel = document.getElementById("btn-finalize-label");
+  var finalizeSubmit = document.getElementById("btn-finalize-submit");
+  var finalizedClose = document.getElementById("btn-finalized-close");
+  var finalizeNote = document.getElementById("finalize-action-note");
+  var runPicker = document.getElementById("pick-run");
+  var runPickerButton = document.getElementById("btn-pick-run");
   if (!apiClient || !executeButton || !stepper) {
     return;
   }
@@ -28,17 +37,31 @@
   var runId = executeButton.dataset.runId;
   var runStatus = executeButton.dataset.runStatus;
   var pollTimer = null;
+  var pollFailures = 0;
+  var pollWarned = false;
   var finalizeRequestPending = false;
   var finalizeIdempotencyKey = null;
 
-  var STATUS_TONES = {
-    FAILED: "fgc-badge--violation",
-    FINALIZED: "fgc-badge--review",
-    COMPLETED: "fgc-badge--normal"
+  /*
+   * 상태 배지 톤 — templates/vrun/status-badge.html 의 서버 렌더링 매핑과 같은 클래스를 쓴다.
+   * 전에는 이 파일과 두 템플릿에 각각 4벌이 흩어져 있었고 CREATED 와 RUNNING 이 같은 톤이라
+   * "아직 시작 안 함"과 "돌고 있음"을 구분할 수 없었다.
+   */
+  var STATUS_BADGE_CLASSES = {
+    CREATED: "status-badge-neutral",
+    RUNNING: "status-badge-info",
+    COMPLETED: "status-badge-success",
+    FINALIZED: "status-badge-review",
+    FAILED: "status-badge-error"
   };
 
+  var STATUS_BADGE_CLASS_NAMES = Object.keys(STATUS_BADGE_CLASSES).map(function (key) {
+    return STATUS_BADGE_CLASSES[key];
+  });
+
   /* 서버 렌더링(vrun/detail.html 스텝퍼 th:classappend)과 같은 규칙 —
-     current_step 은 "마지막으로 끝난 단계", RUNNING 중이면 그 다음 칸이 진행 중이다. */
+     current_step 은 "마지막으로 끝난 단계", RUNNING 중이면 그 다음 칸이 진행 중이다.
+     클래스명은 ValidationRunViewController.stepClass() 가 정하는 계약이라 그대로 쓴다. */
   function stepClass(stepNo, status, currentStep) {
     if (status === "FAILED" && stepNo === currentStep) {
       return "fgc-stepper__step--failed";
@@ -55,6 +78,14 @@
     return "";
   }
 
+  /* 색만으로 상태를 전달하지 않도록 칸마다 텍스트 대체도 같이 갱신한다 (규칙 4). */
+  function stepStateText(cls) {
+    if (cls.indexOf("failed") >= 0) return "실패";
+    if (cls.indexOf("done") >= 0) return "완료";
+    if (cls.indexOf("running") >= 0) return "진행 중";
+    return "대기";
+  }
+
   function renderProgress(progress) {
     stepper.querySelectorAll("[data-step]").forEach(function (cell) {
       cell.classList.remove(
@@ -63,10 +94,24 @@
       if (cls) {
         cell.classList.add(cls);
       }
+      var state = cell.querySelector("[data-step-state]");
+      if (state) state.textContent = stepStateText(cls);
     });
+
+    /* 화면정의서 :1442 — 진행률은 current_step/10 × 100. 상세에도 표시한다. */
+    if (progressText) {
+      var step = Number(progress.currentStep) || 0;
+      progressText.textContent = step + "/10 단계 (" + (step * 10) + "%)";
+    }
+
     if (statusBadge) {
-      statusBadge.textContent = progress.statusLabel;
-      statusBadge.className = "fgc-badge " + (STATUS_TONES[progress.status] || "fgc-badge--warning");
+      /* className 통째 덮어쓰기는 병행 클래스를 잃는다 — exception-list.js 처럼 교체만 한다. */
+      statusBadge.classList.remove.apply(statusBadge.classList, STATUS_BADGE_CLASS_NAMES);
+      statusBadge.classList.add(STATUS_BADGE_CLASSES[progress.status] || "status-badge-neutral");
+      var text = statusBadge.querySelector("span:not(.vrun-badge-lock)");
+      if (text) {
+        text.textContent = progress.status === "FINALIZED" ? "확정" : progress.statusLabel;
+      }
     }
   }
 
@@ -74,17 +119,30 @@
     apiClient.request("/api/v1/validation-runs/" + runId + "/progress")
       .then(function (envelope) {
         var progress = envelope.data;
+        pollFailures = 0;
+        if (pollWarned) {
+          pollWarned = false;
+          notify("진행률 조회가 정상으로 돌아왔습니다.", "info", 3000);
+        }
         renderProgress(progress);
         // execute 직후엔 배치가 아직 안 떠서 CREATED 가 조회될 수 있다 — 종료 상태
         // (COMPLETED/FAILED/FINALIZED)에서만 폴링을 멈추고 리로드한다.
         if (progress.status !== "RUNNING" && progress.status !== "CREATED") {
-          window.clearInterval(pollTimer);
-          pollTimer = null;
-          window.location.reload();
+          stopPolling();
+          notify("검증 계산이 끝났습니다. 결과를 불러옵니다.", "success", 3000);
+          window.setTimeout(function () { window.location.reload(); }, 700);
         }
       })
-      .catch(function () {
-        /* 일시 오류(네트워크 등)는 다음 폴링에서 재시도한다 */
+      .catch(function (error) {
+        /*
+         * 전에는 여기가 완전 무음이었다 — 네트워크가 끊겨도 사용자는 스텝퍼가 멈춘 이유를 알 수 없었다.
+         * 일시 오류는 다음 폴링에서 회복되므로 연속 3회(약 6초) 실패해야 한 번만 알린다.
+         */
+        pollFailures += 1;
+        if (pollFailures >= 3 && !pollWarned) {
+          pollWarned = true;
+          notify(errorText(error, "진행률을 불러오지 못하고 있습니다. 연결을 확인해 주세요."), "warning", 6000);
+        }
       });
   }
 
@@ -93,6 +151,11 @@
       return;
     }
     pollTimer = window.setInterval(poll, 2000); // IF-API-49: 2초 폴링
+  }
+
+  function stopPolling() {
+    window.clearInterval(pollTimer);
+    pollTimer = null;
   }
 
   // 2026-08-19 yslee - FUN-044 확정 조건을 IF-API-50 응답으로 표시
@@ -111,72 +174,132 @@
     }
   }
 
-  function setChecklistState(summary, message, tone) {
-    checklistSummary.textContent = summary;
-    checklistSummary.className = tone ? "fgc-badge " + tone : "fgc-muted";
+  function setSummaryBadge(text, tone) {
+    checklistSummary.textContent = text;
+    checklistSummary.className = tone ? "status-badge " + tone : "vrun-card-note";
+  }
+
+  function setChecklistState(summary, message, tone, variant, onRetry) {
+    setSummaryBadge(summary, tone);
     checklistBody.replaceChildren();
-    var empty = document.createElement("div");
-    empty.className = "fgc-empty publishing-empty-state";
-    empty.textContent = message;
-    checklistBody.appendChild(empty);
+    checklistBody.appendChild(stateBlock(message, variant || "is-empty", onRetry));
     finalizeButton.dataset.checklistPassed = "false";
     updateFinalizeButtonState();
   }
 
+  function stateBlock(message, variant, onRetry) {
+    var block = document.createElement("p");
+    block.className = "vrun-inline-state " + variant;
+    block.setAttribute("role", variant === "is-error" ? "alert" : "status");
+    block.appendChild(document.createTextNode(message));
+    if (onRetry) {
+      var retry = document.createElement("button");
+      retry.type = "button";
+      retry.className = "button button-secondary";
+      retry.textContent = "다시 시도";
+      retry.addEventListener("click", onRetry);
+      block.appendChild(retry);
+    }
+    return block;
+  }
+
+  /*
+   * 비활성 사유는 title 이 아니라 버튼 바깥의 가시 텍스트로 전달한다.
+   * disabled 요소는 포커스가 가지 않아 스크린리더가 title 에 닿을 수 없다.
+   */
   function updateFinalizeButtonState() {
     if (!finalizeButton) return;
     var canFinalize = finalizeButton.dataset.canFinalize === "true";
     var checklistPassed = finalizeButton.dataset.checklistPassed === "true";
     finalizeButton.disabled = finalizeRequestPending || runStatus !== "COMPLETED" || !canFinalize || !checklistPassed;
+    finalizeButton.removeAttribute("title");
+
+    var reason = "";
     if (!canFinalize) {
-      finalizeButton.title = "확정 권한은 GA_ADMIN 또는 SYSTEM_ADMIN에게만 있습니다.";
+      reason = "확정 권한은 GA_ADMIN 또는 SYSTEM_ADMIN 에게만 있습니다.";
+    } else if (runStatus === "FINALIZED") {
+      reason = "이미 확정된 실행입니다. 결과를 바꾸려면 새 실행을 만드세요.";
+    } else if (runStatus !== "COMPLETED") {
+      reason = "검증 계산이 끝난 실행만 확정할 수 있습니다.";
     } else if (!checklistPassed) {
-      finalizeButton.title = "확정 조건 6개를 모두 통과해야 합니다.";
-    } else {
-      finalizeButton.removeAttribute("title");
+      reason = "확정 조건 6개를 모두 통과해야 합니다. 아래 체크리스트를 확인하세요.";
+    }
+    if (finalizeNote) {
+      finalizeNote.textContent = reason;
+      finalizeNote.hidden = !reason;
+    }
+    if (finalizeLabel) {
+      finalizeLabel.textContent = runStatus === "FINALIZED" ? "확정됨" : "확정";
     }
   }
 
   function renderChecklist(checklist) {
     checklistBody.replaceChildren();
+    var list = document.createElement("div");
+    list.className = "vrun-checklist";
+
     checklist.conditions.forEach(function (condition) {
-      var row = document.createElement("div");
-      row.className = "publishing-result-placeholder";
+      var item = document.createElement("div");
+      item.className = "vrun-checklist-item";
 
-      var title = document.createElement("strong");
-      title.textContent = condition.no + ". " + condition.label;
-      row.appendChild(title);
+      var label = document.createElement("div");
+      label.className = "vrun-checklist-label";
+      label.appendChild(disclosure(condition.no + ". " + condition.label));
+      item.appendChild(label);
 
-      var result = document.createElement(condition.passed ? "span" : "a");
-      result.className = "fgc-badge " + (condition.passed ? "fgc-badge--normal" : "fgc-badge--violation");
-      result.textContent = condition.passed ? "통과" : "미충족 " + condition.count + "건";
+      var result = document.createElement("div");
+      result.className = "vrun-checklist-result";
+
+      var badge = document.createElement("span");
+      badge.className = "status-badge "
+        + (condition.passed ? "status-badge-success" : "status-badge-error");
+      badge.textContent = condition.passed ? "통과" : "미충족 " + condition.count + "건";
+      result.appendChild(badge);
+
+      /*
+       * 전에는 배지 자체를 <a> 로 만들었다. safeInternalLink 가 null 을 돌려주면
+       * href 없는 유령 링크가 남아 키보드로 닿을 수 없었고, 링크 텍스트도 "미충족 n건" 뿐이라
+       * 어디로 가는지 알 수 없었다. 링크가 실제로 있을 때만 별도 "바로가기" 를 만든다 (목업 :424).
+       */
       if (!condition.passed) {
         var link = safeInternalLink(condition.linkUrl);
-        if (link) result.href = link;
+        if (link) {
+          var anchor = document.createElement("a");
+          anchor.href = link;
+          anchor.textContent = "바로가기";
+          anchor.setAttribute("aria-label", condition.label + " 미충족 건 바로가기");
+          result.appendChild(anchor);
+        }
       }
-      row.appendChild(result);
-      checklistBody.appendChild(row);
+
+      item.appendChild(result);
+      list.appendChild(item);
     });
 
-    checklistSummary.textContent = checklist.passed ? "6개 조건 모두 통과" : "미충족 조건 있음";
-    checklistSummary.className = "fgc-badge "
-      + (checklist.passed ? "fgc-badge--normal" : "fgc-badge--violation");
+    checklistBody.appendChild(list);
+    setSummaryBadge(checklist.passed ? "6개 조건 모두 통과" : "미충족 조건 있음",
+      checklist.passed ? "status-badge-success" : "status-badge-error");
     finalizeButton.dataset.checklistPassed = String(checklist.passed);
     updateFinalizeButtonState();
+    syncDisclosures();
   }
 
   function loadFinalizeChecklist() {
     if (!checklistSummary || !checklistBody || !finalizeButton) return;
     if (runStatus === "FINALIZED") {
-      setChecklistState("확정 완료", "확정된 실행의 결과와 계산 근거가 잠겼습니다.", "fgc-badge--review");
+      setChecklistState("확정 완료", "확정된 실행의 결과와 계산 근거가 잠겼습니다.",
+        "status-badge-review", "is-empty");
+      setBusy(false);
       return;
     }
     if (runStatus !== "COMPLETED") {
-      setChecklistState("확인 대기", "검증 실행이 완료되면 확정 조건을 확인할 수 있습니다.");
+      setChecklistState("확인 대기", "검증 실행이 완료되면 확정 조건을 확인할 수 있습니다.", null, "is-empty");
+      setBusy(false);
       return;
     }
 
-    checklistSummary.textContent = "확인 중";
+    setSummaryBadge("확인 중", null);
+    setBusy(true);
     apiClient.request("/api/v1/validation-runs/" + runId + "/finalize-checklist")
       .then(function (envelope) {
         var checklist = envelope.data;
@@ -186,9 +309,17 @@
         renderChecklist(checklist);
       })
       .catch(function (error) {
-        setChecklistState("조회 실패", error && error.message
-          ? error.message : "확정 조건을 불러오지 못했습니다.", "fgc-badge--violation");
+        var message = errorText(error, "확정 조건을 불러오지 못했습니다.");
+        setChecklistState("조회 실패", message, "status-badge-error", "is-error", loadFinalizeChecklist);
+        notify(message, "error", 5000);
+      })
+      .finally(function () {
+        setBusy(false);
       });
+  }
+
+  function setBusy(busy) {
+    if (checklistBody) checklistBody.setAttribute("aria-busy", busy ? "true" : "false");
   }
 
   // 2026-08-19 yslee - FUN-044 검증 실행 확정 API를 화면 버튼에 연결
@@ -202,24 +333,44 @@
     return "vrun-finalize-" + runId + "-" + Date.now();
   }
 
-  function finalizeRun() {
+  /*
+   * 확정 확인 — 전에는 브라우저 기본 확인 대화상자였다.
+   * 브라우저 기본 대화상자는 화면정의서 :1487 이 요구하는 "검증 결과 잠금이며 실제 송금·회계
+   * 마감이 아닙니다" 문구를 담을 수 없고 포커스 복귀·스타일도 제어할 수 없다.
+   */
+  function openFinalizeDialog() {
     updateFinalizeButtonState();
     if (finalizeButton.disabled || finalizeRequestPending) return;
-    if (!window.confirm("이 검증 실행을 확정하면 결과와 계산 근거를 고칠 수 없습니다. 확정하시겠습니까?")) {
-      return;
-    }
+    if (modal) modal.open("vrun-finalize");
+  }
+
+  function finalizeRun() {
+    if (finalizeRequestPending) return;
 
     finalizeRequestPending = true;
     finalizeIdempotencyKey = finalizeIdempotencyKey || createFinalizeIdempotencyKey();
     updateFinalizeButtonState();
     finalizeButton.setAttribute("aria-busy", "true");
+    if (finalizeSubmit) {
+      finalizeSubmit.disabled = true;
+      finalizeSubmit.setAttribute("aria-busy", "true");
+    }
 
     apiClient.request("/api/v1/validation-runs/" + runId + "/finalize", {
       method: "POST",
       idempotencyKey: finalizeIdempotencyKey
     }).then(function () {
-      if (toast) toast("검증 실행을 확정했습니다.", "success");
-      window.location.reload();
+      /*
+       * 전에는 Toast 를 띄우자마자 reload() 해서 DOM 이 통째로 바뀌어 성공 피드백이 보이지 않았다.
+       * 발표 시연 10컷의 마지막 단계다 — 목업 :195-210 의 확정 완료 모달로 대신하고
+       * 사용자가 닫을 때 리로드한다.
+       */
+      if (modal) {
+        modal.close("vrun-finalize");
+        modal.open("vrun-finalized");
+      } else {
+        window.location.reload();
+      }
     }).catch(function (error) {
       finalizeRequestPending = false;
       finalizeButton.removeAttribute("aria-busy");
@@ -230,32 +381,122 @@
       if (error && error.code === "FGC-VRUN-006") {
         finalizeIdempotencyKey = null;
       }
-      if (toast) toast(error && error.message ? error.message : "검증 실행 확정에 실패했습니다.", "error");
+      if (modal) modal.close("vrun-finalize");
+      notify(errorText(error, "검증 실행 확정에 실패했습니다."), "error", 5000);
       loadFinalizeChecklist();
+    }).finally(function () {
+      if (finalizeSubmit) {
+        finalizeSubmit.disabled = false;
+        finalizeSubmit.removeAttribute("aria-busy");
+      }
     });
+  }
+
+  /* 긴 값 접기·펴기 — components.css:576-653. DOM 으로 만들어 escape 를 따로 하지 않는다. */
+  function disclosure(text) {
+    var value = text == null || text === "" ? "-" : String(text);
+    var root = document.createElement("div");
+    root.className = "table-cell-disclosure";
+
+    var preview = document.createElement("span");
+    preview.className = "table-cell-preview";
+    preview.textContent = value;
+    root.appendChild(preview);
+
+    var details = document.createElement("details");
+    details.className = "table-cell-details";
+    details.hidden = true;
+
+    var summary = document.createElement("summary");
+    var more = document.createElement("span");
+    more.className = "table-cell-more";
+    more.textContent = "전체 보기";
+    var less = document.createElement("span");
+    less.className = "table-cell-less";
+    less.textContent = "접기";
+    var chevron = document.createElement("span");
+    chevron.className = "material-symbols-rounded table-cell-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    chevron.textContent = "expand_more";
+    summary.append(more, less, chevron);
+
+    var full = document.createElement("p");
+    full.className = "table-cell-full";
+    full.textContent = value;
+
+    details.append(summary, full);
+    root.appendChild(details);
+    return root;
+  }
+
+  function syncDisclosures() {
+    window.requestAnimationFrame(function () {
+      document.querySelectorAll(".table-cell-disclosure").forEach(function (root) {
+        var preview = root.querySelector(".table-cell-preview");
+        var details = root.querySelector(".table-cell-details");
+        if (!preview || !details || preview.clientWidth === 0) return;
+        var truncated = preview.scrollWidth > preview.clientWidth + 1
+          || preview.scrollHeight > preview.clientHeight + 1;
+        details.hidden = !truncated;
+        if (!truncated) details.open = false;
+      });
+    });
+  }
+
+  /* 오류 문구에 오류코드(FGC-VRUN-001~006)와 요청 ID 를 함께 붙인다. */
+  function errorText(error, fallback) {
+    if (format && typeof format.errorText === "function") return format.errorText(error, fallback);
+    return (error && error.message) || fallback;
+  }
+
+  function notify(message, tone, duration) {
+    if (typeof toast === "function") toast(message, tone, duration);
   }
 
   executeButton.addEventListener("click", function () {
     executeButton.disabled = true;
+    executeButton.setAttribute("aria-busy", "true");
     apiClient.request("/api/v1/validation-runs/" + runId + "/execute", { method: "POST" })
       .then(function () {
-        if (toast) {
-          toast("검증 실행을 시작했습니다. 진행률을 2초 간격으로 갱신합니다.", "info");
-        }
+        notify("검증 실행을 시작했습니다. 진행률을 2초 간격으로 갱신합니다.", "info");
         startPolling();
       })
       .catch(function (error) {
-        if (toast) {
-          toast(error && error.message ? error.message : "실행 요청에 실패했습니다.", "error");
-        }
+        notify(errorText(error, "실행 요청에 실패했습니다."), "error");
         executeButton.disabled = false;
+      })
+      .finally(function () {
+        executeButton.removeAttribute("aria-busy");
       });
   });
 
   if (refreshButton) {
     refreshButton.addEventListener("click", function () {
+      notify("최신 상태를 불러옵니다.", "info", 2000);
+      window.setTimeout(function () { window.location.reload(); }, 300);
+    });
+  }
+
+  /*
+   * 실행 선택 — 전에는 select 의 change 만으로 곧바로 이동했다.
+   * 키보드로 값을 훑기만 해도 페이지가 바뀌었고 이동한다는 예고도 없었다.
+   */
+  if (runPickerButton && runPicker) {
+    runPickerButton.addEventListener("click", function () {
+      if (runPicker.value) {
+        window.location.assign("/validation-runs/" + encodeURIComponent(runPicker.value));
+      }
+    });
+  }
+
+  if (finalizedClose) {
+    finalizedClose.addEventListener("click", function () {
       window.location.reload();
     });
+  }
+
+  if (finalizeSubmit) {
+    finalizeSubmit.addEventListener("click", finalizeRun);
   }
 
   // 새로고침으로 진입했는데 이미 실행 중이면 폴링을 이어 붙인다
@@ -263,7 +504,7 @@
     startPolling();
   }
   if (finalizeButton) {
-    finalizeButton.addEventListener("click", finalizeRun);
+    finalizeButton.addEventListener("click", openFinalizeDialog);
     updateFinalizeButtonState();
   }
   loadFinalizeChecklist();

--- a/src/main/resources/static/js/features/vrun/vrun-list.js
+++ b/src/main/resources/static/js/features/vrun/vrun-list.js
@@ -1,0 +1,53 @@
+/**
+ * FGC-UI-VRUN-W01 실행 목록 (FUN-041)
+ *
+ * 이 화면은 Ajax 가 없다 (인터페이스정의서 5-2) — 목록·생성 가능 여부·생성(PRG)까지 서버 렌더링이다.
+ * 그래서 이 스크립트가 하는 일은 두 가지뿐이다.
+ *
+ *   ① PRG 결과 Toast
+ *      POST /validation-runs 는 리다이렉트로 돌아오므로 서버가 직접 Toast 를 띄울 수 없다.
+ *      ValidationRunViewController 가 플래시로 넘긴 successMessage / errorMessage 를
+ *      <main data-success-message> · <main data-error-message> 로 받아 한 번만 띄운다.
+ *      전에는 화면 상단 fgc-banner 두 개로 표시했는데, 결과 알림은 Toast 라는 게 가이드 §11 이고
+ *      목업(FGC-UI-VRUN-W01/index.html:149-151)도 FGC.toast 를 쓴다.
+ *      한 번 읽고 data-* 를 지우는 이유는 뒤로가기로 돌아왔을 때 같은 알림이 다시 뜨지 않게 하기 위해서다.
+ *
+ *   ② 긴 값 접기·펴기 동기화
+ *      실패 사유·확정자 셀은 서버가 table-cell-disclosure 마크업까지 그려 두고,
+ *      실제로 잘렸는지는 렌더링 폭을 재야 알 수 있으므로 여기서 판정한다.
+ */
+(function () {
+  "use strict";
+
+  var main = document.getElementById("main-content");
+  if (!main) return;
+
+  var toast = window.FgcUi && window.FgcUi.toast;
+
+  function flash(attribute, tone, duration) {
+    var message = main.dataset[attribute];
+    if (!message) return;
+    delete main.dataset[attribute];
+    if (typeof toast === "function") toast(message, tone, duration);
+  }
+
+  flash("successMessage", "success", 5000);
+  flash("errorMessage", "error", 0);
+
+  function syncDisclosures() {
+    document.querySelectorAll(".table-cell-disclosure").forEach(function (root) {
+      var preview = root.querySelector(".table-cell-preview");
+      var details = root.querySelector(".table-cell-details");
+      if (!preview || !details || preview.clientWidth === 0) return;
+      var truncated = preview.scrollWidth > preview.clientWidth + 1
+        || preview.scrollHeight > preview.clientHeight + 1;
+      details.hidden = !truncated;
+      if (!truncated) details.open = false;
+    });
+  }
+
+  window.requestAnimationFrame(syncDisclosures);
+  window.addEventListener("resize", function () {
+    window.requestAnimationFrame(syncDisclosures);
+  });
+})();

--- a/src/main/resources/templates/layout/default.html
+++ b/src/main/resources/templates/layout/default.html
@@ -67,6 +67,7 @@
   <script th:if="${screenId == 'FGC-UI-POL-W01'}" th:src="@{/js/features/policy/policy-list.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-CONT-W03'}" th:src="@{/js/features/contract/contract-api.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-CONT-W03'}" th:src="@{/js/features/contract/contract-form.js}" defer></script>
+  <script th:if="${screenId == 'FGC-UI-VRUN-W01'}" th:src="@{/js/features/vrun/vrun-list.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-VRUN-W02'}" th:src="@{/js/features/vrun/vrun-detail.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-RECO-W01'}" th:src="@{/js/features/reco/reco.js}" defer></script>
   <script th:if="${screenId == 'FGC-UI-LEDG-W01'}" th:src="@{/js/features/ledger/ledger.js}" defer></script>

--- a/src/main/resources/templates/vrun/detail.html
+++ b/src/main/resources/templates/vrun/detail.html
@@ -6,7 +6,7 @@
           연결 cap_check, arbitrage_check, journal_header, reconciliation_run, exception_case
   API     POST /api/v1/validation-runs/{id}/execute            (IF-API-48 · 202 즉시 반환 · 배치 비동기)
           GET  /api/v1/validation-runs/{id}/progress           (IF-API-49 · 2초 폴링 — /js/features/vrun/vrun-detail.js)
-          GET  /api/v1/validation-runs/{id}/finalize-checklist (IF-API-50 · #172~#175 브랜치에서 연동)
+          GET  /api/v1/validation-runs/{id}/finalize-checklist (IF-API-50)
           POST /api/v1/validation-runs/{id}/finalize           (IF-API-51 · GA_ADMIN · SYSTEM_ADMIN 만)
   배치    IF-BAT-01 MonthlyValidationJob (Spring Batch · Step 1~8)
   라우트  GET /validation-runs/{id} → vrun/detail.html (ValidationRunViewController)
@@ -27,152 +27,269 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-VRUN-W02', '월 통합검증 상세·확정', '월 통합검증 실행 목록', '/validation-runs')}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main id="main-content" class="fgc-main publishing-page publishing-page-detail publishing-page-validation-detail"
-      th:with="st=${detail.header().status().name()}, cs=${detail.header().currentStep()}">
+<main id="main-content" class="page-content vrun-page vrun-detail-page"
+      th:with="st=${detail.header().status().name()}, cs=${detail.header().currentStep()}"
+      th:attr="data-success-message=${successMessage}">
 
-  <style>
-    .kv { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px 20px; }
-    .kv dt { font-size: 11px; color: #43474d; font-weight: 600; }
-    .kv dd { margin: 2px 0 0; font-size: 13px; }
-  </style>
-
-  <div class="publishing-page-head" style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
-    <div>
-      <h1 class="fgc-page-title">월 통합검증 상세 · 확정</h1>
-      <p class="fgc-page-desc">
-        한 달치 계약을 한 번에 검사합니다. 1,200% · 차익거래 · 원장 · 대사를 순서대로 돌리고,
-        문제가 있는 건만 예외함으로 보냅니다.
-      </p>
+  <header class="page-header">
+    <div class="page-header-copy">
+      <h1 class="page-title">월 통합검증 상세 · 확정</h1>
     </div>
-    <div class="publishing-inline-controls" style="display:flex;gap:8px;align-items:center">
-      <label class="fgc-label" for="pick-run" style="margin:0">실행</label>
-      <!-- 최근 실행 20건 — 선택하면 해당 상세로 이동(인라인 스크립트) -->
-      <select class="fgc-select" id="pick-run">
-        <option th:each="opt : ${runOptions.content()}"
-                th:value="${opt.validationRunId()}"
-                th:selected="${opt.validationRunId() == detail.header().validationRunId()}"
-                th:text="${#temporals.format(opt.validationMonth(), 'yyyy-MM')} + ' · ' + ${opt.runNo()} + '회차 · ' + ${opt.statusLabel()}">
-          2026-07 · 1회차 · 생성됨</option>
-      </select>
+    <div class="page-header-actions">
+      <!-- 최근 실행 20건 — 고르고 [이동] 을 눌러야 넘어간다. 전에는 change 만으로 곧바로 이동했다. -->
+      <div class="field vrun-run-picker">
+        <label class="field-label" for="pick-run">실행</label>
+        <select class="select-control" id="pick-run">
+          <option th:each="opt : ${runOptions.content()}"
+                  th:value="${opt.validationRunId()}"
+                  th:selected="${opt.validationRunId() == detail.header().validationRunId()}"
+                  th:text="${#temporals.format(opt.validationMonth(), 'yyyy-MM')} + ' · ' + ${opt.runNo()} + '회차 · ' + ${opt.statusLabel()}">
+            2026-07 · 1회차 · 생성됨</option>
+        </select>
+      </div>
+      <button class="button button-secondary" type="button" id="btn-pick-run">
+        <span class="material-symbols-rounded" aria-hidden="true">open_in_new</span>이동
+      </button>
+    </div>
+  </header>
+
+  <!-- 확정 불가역 경고 — 업무·규제 제약이므로 화면 설명문과 달리 남긴다 (운영정책서 제43조) -->
+  <div class="guidance guidance-warning">
+    <span class="material-symbols-rounded guidance-icon" aria-hidden="true">gavel</span>
+    <div>
+      <p>
+        <strong id="notice-finalize">확정하면 이 실행의 결과는 고칠 수 없습니다.</strong>
+        바로잡으려면 새 실행을 만들어야 합니다. (운영정책서 제43조)
+      </p>
     </div>
   </div>
 
-  <div class="fgc-banner fgc-banner--info" style="margin-top:12px">
-    <span class="material-symbols-outlined" style="font-size:18px">info</span>
-    <!-- 확정 안내 문구 — IF-API-50/51 연동 시 서버 렌더링(메시지 프로퍼티)으로 교체한다 -->
-    <span>
-      <strong id="notice-finalize">확정하면 이 실행의 결과는 고칠 수 없습니다.</strong>
-      바로잡으려면 새 실행을 만들어야 합니다. (운영정책서 제43조)
-    </span>
+  <!--
+    확정 확인 모달 — 전에는 브라우저 기본 확인 대화상자였다.
+    브라우저 기본 대화상자는 화면정의서 :1487 이 요구하는 "검증 결과 잠금이며 실제 송금·회계
+    마감이 아닙니다" 고정 문구를 담을 수 없고 포커스·스타일 제어도 되지 않는다.
+  -->
+  <div class="modal-backdrop" data-modal="vrun-finalize" data-close-on-backdrop="true"
+       hidden aria-hidden="true">
+    <section class="modal vrun-modal" role="dialog" aria-modal="true"
+             aria-labelledby="vrun-finalize-title" aria-describedby="vrun-finalize-description">
+      <header class="modal-header">
+        <h2 id="vrun-finalize-title" class="modal-title">이 검증 실행을 확정할까요?</h2>
+      </header>
+      <div class="modal-body">
+        <p id="vrun-finalize-description" class="vrun-modal-description">
+          확정하면 이 실행의 검증 결과와 그때 쓰인 룰셋·계산근거가 잠깁니다.
+          <strong>되돌릴 수 없습니다.</strong>
+        </p>
+        <div class="vrun-modal-points">
+          <p><strong>검증 결과 잠금이며 실제 송금·회계 마감이 아닙니다.</strong></p>
+          <p>수정 불가 — 확정된 검증 결과입니다. 결과를 바꾸려면 <strong>새 실행</strong>을 만드세요.</p>
+          <p>확정 사실은 감사로그에 실행자·시각과 함께 남습니다.</p>
+        </div>
+        <dl class="vrun-kv">
+          <div><dt>검증월</dt><dd class="tabular-nums"
+               th:text="${#temporals.format(detail.header().validationMonth(), 'yyyy-MM')}">-</dd></div>
+          <div><dt>회차</dt><dd class="tabular-nums" th:text="${detail.header().runNo()}">-</dd></div>
+        </dl>
+      </div>
+      <footer class="modal-footer">
+        <button class="button button-secondary" type="button" data-modal-close
+                data-modal-initial-focus>취소</button>
+        <button class="button button-primary" id="btn-finalize-submit" type="button">확정</button>
+      </footer>
+    </section>
+  </div>
+
+  <!-- 확정 완료 모달 — 목업 :195-210. 리로드로 사라지던 성공 Toast 를 대신한다. -->
+  <div class="modal-backdrop" data-modal="vrun-finalized" data-close-on-backdrop="false"
+       hidden aria-hidden="true">
+    <section class="modal vrun-modal" role="dialog" aria-modal="true"
+             aria-labelledby="vrun-finalized-title" aria-describedby="vrun-finalized-description">
+      <header class="modal-header">
+        <h2 id="vrun-finalized-title" class="modal-title">확정했습니다</h2>
+      </header>
+      <div class="modal-body">
+        <p id="vrun-finalized-description" class="vrun-modal-description">
+          이 실행의 검증 결과와 계산 근거가 잠겼습니다. 확정 사실은 감사로그에 남았습니다.
+        </p>
+        <div class="vrun-modal-points">
+          <p><strong>검증 결과 잠금이며 실제 송금·회계 마감이 아닙니다.</strong></p>
+        </div>
+      </div>
+      <footer class="modal-footer">
+        <button class="button button-primary" id="btn-finalized-close" type="button"
+                data-modal-initial-focus>확인</button>
+      </footer>
+    </section>
   </div>
 
   <!-- ① 실행 헤더 -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__head">
-      <span class="fgc-card__title">실행 <span class="fgc-mono" id="hdr-id"
-            th:text="${detail.header().validationRunId()}">—</span></span>
-      <!-- 톤 매핑은 화면 MVP 와 동일: 실패=violation, 확정=review, 계산완료=normal, 그 외=warning -->
-      <span id="hdr-status" class="fgc-badge"
-            th:classappend="${st == 'FAILED'} ? 'fgc-badge--violation'
-                            : (${st == 'FINALIZED'} ? 'fgc-badge--review'
-                            : (${st == 'COMPLETED'} ? 'fgc-badge--normal' : 'fgc-badge--warning'))"
-            th:text="${detail.header().statusLabel()}">연동 대기</span>
-    </div>
-    <div class="fgc-card__body">
-      <dl class="kv">
-        <div><dt>검증월</dt><dd class="fgc-mono" id="hdr-month"
-             th:text="${#temporals.format(detail.header().validationMonth(), 'yyyy-MM')}">—</dd></div>
-        <div><dt>회차</dt><dd class="fgc-mono" id="hdr-runno" th:text="${detail.header().runNo()}">—</dd></div>
-        <div><dt>실행 유형</dt><dd id="hdr-type" th:text="${detail.header().runTypeLabel()}">—</dd></div>
-        <div><dt>실행자</dt><dd class="fgc-mono" id="hdr-by" th:text="${detail.header().triggeredBy()} ?: '—'">—</dd></div>
-        <div><dt>시작</dt><dd class="fgc-mono" id="hdr-started"
+  <section class="surface" aria-labelledby="vrun-header-title">
+    <header class="surface-header">
+      <h2 class="surface-title" id="vrun-header-title">실행
+        <span class="tabular-nums" id="hdr-id" th:text="${detail.header().validationRunId()}">-</span></h2>
+      <!-- id 는 폴링이 배지를 다시 찾는 훅이다. 프래그먼트는 배지 자체를 그리므로 감싸서 붙인다. -->
+      <span id="hdr-status"
+            th:insert="~{vrun/status-badge :: runStatusBadge(${st}, ${detail.header().statusLabel()})}"></span>
+    </header>
+    <div class="surface-body">
+      <dl class="vrun-kv">
+        <div><dt>검증월</dt><dd class="tabular-nums" id="hdr-month"
+             th:text="${#temporals.format(detail.header().validationMonth(), 'yyyy-MM')}">-</dd></div>
+        <div><dt>회차</dt><dd class="tabular-nums" id="hdr-runno" th:text="${detail.header().runNo()}">-</dd></div>
+        <div><dt>실행 유형</dt><dd id="hdr-type" th:text="${detail.header().runTypeLabel()}">-</dd></div>
+        <div><dt>실행자</dt><dd id="hdr-by" th:text="${detail.header().triggeredBy()} ?: '-'">-</dd></div>
+        <div><dt>시작</dt><dd class="tabular-nums" id="hdr-started"
              th:text="${detail.header().startedAt() != null}
-                      ? ${#temporals.format(detail.header().startedAt(), 'yyyy-MM-dd HH:mm')} : '—'">—</dd></div>
-        <div><dt>완료</dt><dd class="fgc-mono" id="hdr-completed"
+                      ? ${#temporals.format(detail.header().startedAt(), 'yyyy-MM-dd HH:mm')} : '-'">-</dd></div>
+        <div><dt>완료</dt><dd class="tabular-nums" id="hdr-completed"
              th:text="${detail.header().completedAt() != null}
-                      ? ${#temporals.format(detail.header().completedAt(), 'yyyy-MM-dd HH:mm')} : '—'">—</dd></div>
-        <div><dt>확정자 · 확정시각</dt><dd class="fgc-mono" id="hdr-finalized"
+                      ? ${#temporals.format(detail.header().completedAt(), 'yyyy-MM-dd HH:mm')} : '-'">-</dd></div>
+        <div><dt>확정자 · 확정시각</dt><dd class="tabular-nums" id="hdr-finalized"
              th:text="${detail.header().finalizedAt() != null}
-                      ? ${detail.header().finalizedBy()} + ' · ' + ${#temporals.format(detail.header().finalizedAt(), 'yyyy-MM-dd HH:mm')} : '—'">—</dd></div>
+                      ? ${detail.header().finalizedBy()} + ' · ' + ${#temporals.format(detail.header().finalizedAt(), 'yyyy-MM-dd HH:mm')} : '-'">-</dd></div>
       </dl>
-      <p class="fgc-error" id="hdr-failure" style="margin-top:10px"
+      <p class="vrun-inline-state is-error" id="hdr-failure" role="alert"
          th:hidden="${st != 'FAILED'}" th:text="${detail.header().failureMessage()}"></p>
     </div>
   </section>
 
   <!-- ② 10단계 스텝퍼 -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__head">
-      <span class="fgc-card__title">진행 단계 (운영정책서 제43조)</span>
-      <div style="display:flex;gap:8px">
-        <button class="fgc-btn fgc-btn--ghost" id="btn-refresh" type="button" style="padding:4px 10px;font-size:12px">
-          <span class="material-symbols-outlined" style="font-size:16px">refresh</span> 새로고침
+  <section class="surface" aria-labelledby="vrun-stepper-title">
+    <header class="surface-header">
+      <h2 class="surface-title" id="vrun-stepper-title">진행 단계 (운영정책서 제43조)</h2>
+      <div class="page-header-actions">
+        <button class="button button-secondary vrun-row-button" id="btn-refresh" type="button">
+          <span class="material-symbols-rounded" aria-hidden="true">refresh</span>새로고침
         </button>
         <!-- 실행은 SETTLEMENT (화면정의서 :1485, IF-API-48). CREATED 에서만 기동할 수 있다 —
-             1차는 재기동이 없다(실패하면 새 실행). FINALIZED 는 title 로 이유를 알린다. -->
-        <button class="fgc-btn fgc-btn--primary" id="btn-execute" type="button" data-fgc-action="execute"
-                style="padding:4px 12px;font-size:12px"
+             1차는 재기동이 없다(실패하면 새 실행). 비활성 사유는 아래 가시 텍스트로 알린다. -->
+        <button class="button button-primary vrun-row-button" id="btn-execute" type="button" data-fgc-action="execute"
                 th:attr="data-run-id=${detail.header().validationRunId()}, data-run-status=${st}"
                 th:disabled="${!canProcess or st != 'CREATED'}"
-                th:title="${st == 'FINALIZED'} ? '확정된 실행은 다시 돌리지 않습니다. 새 실행을 만드세요.' : null">
-          <span class="material-symbols-outlined" style="font-size:16px">play_arrow</span> 실행
+                aria-describedby="execute-action-note">
+          <span class="material-symbols-rounded" aria-hidden="true">play_arrow</span>실행
         </button>
       </div>
-    </div>
-    <div class="fgc-card__body">
+    </header>
+    <div class="surface-body">
+      <p class="vrun-action-note" id="execute-action-note" role="status"
+         th:hidden="${canProcess and st == 'CREATED'}"
+         th:text="${st == 'FINALIZED'}
+                  ? '확정된 실행은 다시 돌리지 않습니다. 새 실행을 만드세요.'
+                  : (${!canProcess}
+                     ? '실행 기동은 정산 담당자만 할 수 있습니다.'
+                     : '생성됨 상태의 실행만 기동할 수 있습니다.')"></p>
+
+      <!-- 진행률 — 화면정의서 :1442 는 current_step/10 × 100 을 상세에도 표시하라고 한다.
+           전에는 목록에만 있었다. 폴링 중 갱신 사실을 aria-live 로 함께 알린다. -->
+      <p class="vrun-progress-line">
+        <span>진행률</span>
+        <span class="vrun-progress-value" id="progress-text" role="status" aria-live="polite"
+              th:text="|${cs}/10 단계 (${cs * 10}%)|">0/10 단계 (0%)</span>
+      </p>
+
       <!-- 진행률은 운영정책서 제43조 모델(current_step, 9단계는 저장하지 않음)을 따른다. batch_step_execution 에서 역산하지 않는다. -->
       <!-- 칸 CSS 는 컨트롤러(stepClasses)가 계산한다 — "__"가 Thymeleaf 전처리 구분자라 식 안에 못 쓴다.
            폴링(IF-API-49) 중에는 vrun-detail.js 가 같은 규칙으로 칸 클래스를 갱신한다 -->
-      <div class="fgc-stepper" id="stepper">
-        <div class="fgc-stepper__step" th:each="stepName, iter : ${stepNames}"
-             th:attr="data-step=${iter.count}"
-             th:classappend="${stepClasses[iter.index]}">
-          <div class="fgc-stepper__dot" th:text="${iter.count}">1</div>
-          <div class="fgc-stepper__label">
+      <ol class="vrun-stepper" id="stepper" aria-label="월 통합검증 10단계 진행 상태">
+        <li class="vrun-stepper-step" th:each="stepName, iter : ${stepNames}"
+            th:attr="data-step=${iter.count}"
+            th:classappend="${stepClasses[iter.index]}">
+          <span class="vrun-stepper-dot" aria-hidden="true" th:text="${iter.count}">1</span>
+          <span class="vrun-stepper-label">
             <span th:text="${stepName}">실행 생성</span>
-            <th:block th:if="${iter.count >= 9}"><br><span style="font-size:10px;color:#B45309">사람이 수행</span></th:block>
-          </div>
+            <th:block th:if="${iter.count >= 9}"><span class="vrun-stepper-manual">사람이 수행</span></th:block>
+          </span>
+          <!--
+            상태를 색만으로 전달하지 않는다 (규칙 4). 칸마다 텍스트 대체를 함께 둔다.
+            판정을 다시 하지 않고 서버가 내려준 stepClasses 문자열을 읽어 옮기기만 한다.
+          -->
+          <span class="visually-hidden" data-step-state
+                th:text="${#strings.contains(stepClasses[iter.index], 'failed')} ? '실패'
+                         : (${#strings.contains(stepClasses[iter.index], 'done')} ? '완료'
+                         : (${#strings.contains(stepClasses[iter.index], 'running')} ? '진행 중' : '대기'))">대기</span>
+        </li>
+      </ol>
+
+      <div class="guidance guidance-neutral">
+        <span class="material-symbols-rounded guidance-icon" aria-hidden="true">engineering</span>
+        <div>
+          <p>
+            1~8단계는 <strong>Spring Batch</strong>(정해진 작업을 단계별로 나눠 돌리는 스프링 기능)의
+            <span class="tabular-nums">MonthlyValidationJob</span>이 수행합니다.
+            <strong>9단계 담당자 검토와 10단계 확정은 사람이 합니다.</strong>
+            실패하면 새 실행을 만들어 다시 돌립니다.
+          </p>
         </div>
-      </div>
-      <div class="fgc-banner fgc-banner--muted" style="margin-top:16px">
-        <span class="material-symbols-outlined" style="font-size:18px">engineering</span>
-        <span>
-          1~8단계는 <strong>Spring Batch</strong>(정해진 작업을 단계별로 나눠 돌리는 스프링 기능)의
-          <span class="fgc-mono">MonthlyValidationJob</span>이 수행합니다.
-          <strong>9단계 담당자 검토와 10단계 확정은 사람이 합니다.</strong>
-          실패하면 새 실행을 만들어 다시 돌립니다.
-        </span>
       </div>
     </div>
   </section>
 
-  <div style="margin-top:16px;display:grid;grid-template-columns:1fr 1fr;gap:16px" id="mid-grid">
+  <div class="vrun-mid-grid" id="mid-grid">
 
     <!-- ③ 대상 선별 결과 -->
-    <section class="fgc-card">
-      <div class="fgc-card__head">
-        <span class="fgc-card__title">③ 대상 선별 결과</span>
-        <span class="fgc-muted" style="font-size:11px"
-              th:text="'선정 ' + ${detail.targetSummary().selectedCount()} + ' · 제외 ' + ${detail.targetSummary().excludedCount()} + ' · 검토필요 ' + ${detail.targetSummary().reviewRequiredCount()}">validation_target</span>
-      </div>
-      <div style="overflow-x:auto">
-        <table class="fgc-table">
+    <section class="surface" aria-labelledby="vrun-target-title">
+      <header class="surface-header">
+        <h2 class="surface-title" id="vrun-target-title">③ 대상 선별 결과</h2>
+        <p class="vrun-card-note"
+           th:text="'선정 ' + ${detail.targetSummary().selectedCount()} + ' · 제외 ' + ${detail.targetSummary().excludedCount()} + ' · 검토필요 ' + ${detail.targetSummary().reviewRequiredCount()}">validation_target</p>
+      </header>
+      <div class="data-table-viewport vrun-table-viewport" tabindex="0" role="region"
+           aria-label="대상 선별 결과 표">
+        <table class="data-table vrun-target-table">
+          <caption class="visually-hidden">이번 실행의 검증 대상 선별 결과</caption>
+          <colgroup>
+            <col class="vrun-target-col-contract">
+            <col class="vrun-target-col-status">
+            <col class="vrun-target-col-offering">
+            <col class="vrun-target-col-refund">
+            <col class="vrun-target-col-reason">
+          </colgroup>
           <thead>
-            <tr><th>계약</th><th>선별</th><th>상품 판매버전</th><th>환급률표</th><th>사유</th></tr>
+            <tr>
+              <th scope="col">계약</th>
+              <th scope="col" class="is-center">선별</th>
+              <th scope="col">상품 판매버전</th>
+              <th scope="col">환급률표</th>
+              <th scope="col">사유</th>
+            </tr>
           </thead>
           <tbody id="target-body">
             <tr th:each="t : ${detail.targets()}">
-              <td class="fgc-mono" th:text="${t.contractNo()}">-</td>
-              <td><span class="fgc-badge"
-                        th:classappend="${t.selectionStatus() == 'REVIEW_REQUIRED'} ? 'fgc-badge--review'
-                                        : (${t.selectionStatus() == 'EXCLUDED'} ? 'fgc-badge--neutral' : 'fgc-badge--normal')"
-                        th:text="${t.selectionStatusLabel()}">선정</span></td>
-              <td th:text="|${t.productName()} ${t.offeringVersion()}|">-</td>
-              <td class="fgc-mono" th:text="${t.refundRateTableId()} ?: '—'">—</td>
-              <td th:text="${t.selectionReason()} ?: '—'">—</td>
+              <td class="tabular-nums" th:text="${t.contractNo()}">-</td>
+              <td class="is-center">
+                <span class="status-badge"
+                      th:classappend="${t.selectionStatus() == 'REVIEW_REQUIRED'} ? 'status-badge-review'
+                                      : (${t.selectionStatus() == 'EXCLUDED'} ? 'status-badge-neutral' : 'status-badge-success')"
+                      th:text="${t.selectionStatusLabel()}">선정</span>
+              </td>
+              <td>
+                <div class="table-cell-disclosure" th:with="offering=|${t.productName()} ${t.offeringVersion()}|">
+                  <span class="table-cell-preview is-single-line" th:text="${offering}">-</span>
+                  <details class="table-cell-details" hidden>
+                    <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span><span
+                          class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                    <p class="table-cell-full" th:text="${offering}">-</p>
+                  </details>
+                </div>
+              </td>
+              <td class="tabular-nums" th:text="${t.refundRateTableId()} ?: '-'">-</td>
+              <td>
+                <div class="table-cell-disclosure" th:with="reason=${t.selectionReason()} ?: '-'">
+                  <span class="table-cell-preview is-single-line" th:text="${reason}">-</span>
+                  <details class="table-cell-details" hidden>
+                    <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span><span
+                          class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                    <p class="table-cell-full" th:text="${reason}">-</p>
+                  </details>
+                </div>
+              </td>
             </tr>
             <tr th:if="${detail.targets().isEmpty()}">
-              <td colspan="5"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td>
+              <td colspan="5">
+                <p class="vrun-inline-state is-empty" role="status" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</p>
+              </td>
             </tr>
           </tbody>
         </table>
@@ -180,31 +297,39 @@
     </section>
 
     <!-- ④ 결과 요약 4블록 — 결과 테이블을 실행 스코프로 매번 집계(FUN-043, 복제 저장 없음) -->
-    <section class="fgc-card">
-      <div class="fgc-card__head"><span class="fgc-card__title">④ 결과 요약</span></div>
-      <div class="fgc-card__body" style="display:grid;grid-template-columns:1fr 1fr;gap:10px" id="result-blocks">
+    <section class="surface" aria-labelledby="vrun-summary-title">
+      <header class="surface-header">
+        <h2 class="surface-title" id="vrun-summary-title">④ 결과 요약</h2>
+      </header>
+      <!-- 전에는 퍼블리싱 플레이스홀더 클래스였다 — 실제 값이 들어오는 자리인데
+           클래스명이 "플레이스홀더" 라 미구현으로 읽혔다. 공통 kpi-card 로 바꿨다. -->
+      <div class="kpi-grid vrun-summary-grid" id="result-blocks">
         <th:block th:if="${st == 'CREATED'}">
-          <div class="publishing-result-placeholder"><strong>1,200%</strong><span>실행 전</span></div>
-          <div class="publishing-result-placeholder"><strong>차익거래</strong><span>실행 전</span></div>
-          <div class="publishing-result-placeholder"><strong>원장</strong><span>실행 전</span></div>
-          <div class="publishing-result-placeholder"><strong>대사</strong><span>실행 전</span></div>
+          <div class="kpi-card"><p class="kpi-label">1,200%</p><p class="kpi-value-row"><span class="kpi-unit">실행 전</span></p></div>
+          <div class="kpi-card"><p class="kpi-label">차익거래</p><p class="kpi-value-row"><span class="kpi-unit">실행 전</span></p></div>
+          <div class="kpi-card"><p class="kpi-label">원장</p><p class="kpi-value-row"><span class="kpi-unit">실행 전</span></p></div>
+          <div class="kpi-card"><p class="kpi-label">대사</p><p class="kpi-value-row"><span class="kpi-unit">실행 전</span></p></div>
         </th:block>
         <th:block th:unless="${st == 'CREATED'}">
-          <div class="publishing-result-placeholder">
-            <strong>1,200%</strong>
-            <span th:text="'검사 ' + ${detail.capSummary().checkedCount()} + '건 · 위반 ' + ${detail.capSummary().violationCount()} + ' · 주의 ' + ${detail.capSummary().warningCount()} + ' · 검토 ' + ${detail.capSummary().reviewRequiredCount()}">-</span>
+          <div class="kpi-card">
+            <p class="kpi-label">1,200%</p>
+            <p class="kpi-value-row"><span class="kpi-value tabular-nums" th:text="${detail.capSummary().checkedCount()}">0</span><span class="kpi-unit">건 검사</span></p>
+            <p class="kpi-card-footer" th:text="'위반 ' + ${detail.capSummary().violationCount()} + ' · 주의 ' + ${detail.capSummary().warningCount()} + ' · 검토 ' + ${detail.capSummary().reviewRequiredCount()}">-</p>
           </div>
-          <div class="publishing-result-placeholder">
-            <strong>차익거래</strong>
-            <span th:text="'검사 ' + ${detail.arbitrageSummary().checkedCount()} + '건 · 검토대상 ' + ${detail.arbitrageSummary().candidateCount()} + ' · 검토 ' + ${detail.arbitrageSummary().reviewRequiredCount()}">-</span>
+          <div class="kpi-card">
+            <p class="kpi-label">차익거래</p>
+            <p class="kpi-value-row"><span class="kpi-value tabular-nums" th:text="${detail.arbitrageSummary().checkedCount()}">0</span><span class="kpi-unit">건 검사</span></p>
+            <p class="kpi-card-footer" th:text="'검토대상 ' + ${detail.arbitrageSummary().candidateCount()} + ' · 검토 ' + ${detail.arbitrageSummary().reviewRequiredCount()}">-</p>
           </div>
-          <div class="publishing-result-placeholder">
-            <strong>원장</strong>
-            <span th:text="'분개 ' + ${detail.ledgerSummary().journalCount()} + '건 · 불균형 ' + ${detail.ledgerSummary().imbalanceCount()}">-</span>
+          <div class="kpi-card">
+            <p class="kpi-label">원장</p>
+            <p class="kpi-value-row"><span class="kpi-value tabular-nums" th:text="${detail.ledgerSummary().journalCount()}">0</span><span class="kpi-unit">건 분개</span></p>
+            <p class="kpi-card-footer" th:text="'불균형 ' + ${detail.ledgerSummary().imbalanceCount()}">-</p>
           </div>
-          <div class="publishing-result-placeholder">
-            <strong>대사</strong>
-            <span th:text="'결과 ' + ${detail.reconciliationSummary().resultCount()} + '건 · 불일치 ' + ${detail.reconciliationSummary().mismatchCount()}">-</span>
+          <div class="kpi-card">
+            <p class="kpi-label">대사</p>
+            <p class="kpi-value-row"><span class="kpi-value tabular-nums" th:text="${detail.reconciliationSummary().resultCount()}">0</span><span class="kpi-unit">건 결과</span></p>
+            <p class="kpi-card-footer" th:text="'불일치 ' + ${detail.reconciliationSummary().mismatchCount()}">-</p>
           </div>
         </th:block>
       </div>
@@ -212,87 +337,68 @@
   </div>
 
   <!-- SRC-032: 실행별 검출과 관리자 업무건을 분리해 재실행이 업무량을 부풀리지 않게 한다. -->
-  <section class="fgc-card" style="margin-top:16px" id="exception-detection-summary">
-    <div class="fgc-card__head">
-      <span class="fgc-card__title">예외 생성 결과</span>
+  <section class="surface" id="exception-detection-summary" aria-labelledby="vrun-exception-title">
+    <header class="surface-header">
+      <h2 class="surface-title" id="vrun-exception-title">예외 생성 결과</h2>
       <!-- validationMonth 는 예외함의 검증월 검색조건 — 아래 '미처리 업무건'(월 스코프)과
            열린 목록 건수가 일치한다. 셸 기준월 month 와는 별개 파라미터다. -->
-      <a class="fgc-btn fgc-btn--ghost"
-         th:href="@{/exceptions(status='OPEN',validationMonth=${detail.header().validationMonth()})}"
-         style="padding:4px 10px;font-size:12px">예외함 열기</a>
-    </div>
-    <div class="fgc-card__body" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:10px">
-      <div class="publishing-result-placeholder"><strong th:text="${detail.exceptionSummary().detectedCount()}">0</strong><span>이번 실행 검출</span></div>
-      <div class="publishing-result-placeholder"><strong th:text="${detail.exceptionSummary().newCount()}">0</strong><span>신규 업무건</span></div>
-      <div class="publishing-result-placeholder"><strong th:text="${detail.exceptionSummary().recurringCount()}">0</strong><span>기존 업무건 재검출</span></div>
-      <div class="publishing-result-placeholder"><strong th:text="${detail.exceptionSummary().reopenedCount()}">0</strong><span>해결 후 재발</span></div>
-      <div class="publishing-result-placeholder"><strong th:text="${detail.exceptionSummary().notDetectedCount()}">0</strong><span>이번 실행 미검출</span></div>
-      <div class="publishing-result-placeholder"><strong th:text="${detail.exceptionSummary().openWorkItemCount()}">0</strong><span>미처리 업무건</span></div>
+      <a class="button button-secondary vrun-row-button"
+         th:href="@{/exceptions(status='OPEN',validationMonth=${detail.header().validationMonth()})}">예외함 열기</a>
+    </header>
+    <div class="kpi-grid vrun-exception-grid">
+      <div class="kpi-card"><p class="kpi-label">이번 실행 검출</p><p class="kpi-value-row"><span class="kpi-value tabular-nums" th:text="${detail.exceptionSummary().detectedCount()}">0</span><span class="kpi-unit">건</span></p></div>
+      <div class="kpi-card"><p class="kpi-label">신규 업무건</p><p class="kpi-value-row"><span class="kpi-value tabular-nums" th:text="${detail.exceptionSummary().newCount()}">0</span><span class="kpi-unit">건</span></p></div>
+      <div class="kpi-card"><p class="kpi-label">기존 업무건 재검출</p><p class="kpi-value-row"><span class="kpi-value tabular-nums" th:text="${detail.exceptionSummary().recurringCount()}">0</span><span class="kpi-unit">건</span></p></div>
+      <div class="kpi-card"><p class="kpi-label">해결 후 재발</p><p class="kpi-value-row"><span class="kpi-value tabular-nums" th:text="${detail.exceptionSummary().reopenedCount()}">0</span><span class="kpi-unit">건</span></p></div>
+      <div class="kpi-card"><p class="kpi-label">이번 실행 미검출</p><p class="kpi-value-row"><span class="kpi-value tabular-nums" th:text="${detail.exceptionSummary().notDetectedCount()}">0</span><span class="kpi-unit">건</span></p></div>
+      <div class="kpi-card"><p class="kpi-label">미처리 업무건</p><p class="kpi-value-row"><span class="kpi-value tabular-nums" th:text="${detail.exceptionSummary().openWorkItemCount()}">0</span><span class="kpi-unit">건</span></p></div>
     </div>
   </section>
 
   <!-- ⑤ 확정 조건 체크리스트 — IF-API-50 응답의 문서 순서·문구를 그대로 표시한다. -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__head">
-      <span class="fgc-card__title">⑤ 확정 조건 (운영정책서 제44조 · 6개 전부 통과해야 함)</span>
-      <span id="cond-summary" class="fgc-muted" style="font-size:12px">확인 중</span>
-    </div>
-    <div class="fgc-card__body" id="cond-body" aria-live="polite">
-      <div class="fgc-empty publishing-empty-state">확정 조건을 불러오는 중입니다.</div>
+  <section class="surface" aria-labelledby="vrun-checklist-title">
+    <header class="surface-header">
+      <h2 class="surface-title" id="vrun-checklist-title">⑤ 확정 조건 (운영정책서 제44조 · 6개 전부 통과해야 함)</h2>
+      <span id="cond-summary" class="vrun-card-note">확인 중</span>
+    </header>
+    <div class="surface-body" id="cond-body" aria-live="polite" aria-busy="true">
+      <p class="vrun-inline-state is-loading" role="status">확정 조건을 불러오는 중입니다.</p>
     </div>
   </section>
 
   <!-- ⑥ 확정 -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__body" style="display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap">
-      <div style="max-width:640px">
-        <div style="font-weight:700;font-size:14px">⑥ 확정 (FINALIZED)</div>
+  <section class="surface" aria-labelledby="vrun-finalize-section-title">
+    <div class="vrun-finalize-row">
+      <div class="vrun-finalize-copy">
+        <p class="vrun-finalize-title" id="vrun-finalize-section-title">⑥ 확정 (FINALIZED)</p>
         <!-- 2026-08-19 yslee - #238 병합 잔재를 제거하고 VRUN-W02 확정 안내 고정 문구 적용 -->
         <!-- 기존 코드: 신·구 안내 p 요소가 중첩되고 송금·회계 마감 아님 안내가 누락됨 -->
         <!-- 문제: aria-describedby가 빈 p를 가리켜 접근성 안내가 제공되지 않고 확정을 송금 마감으로 오인할 수 있음 -->
         <!-- 개선: 단일 안내 요소에 검증 결과 잠금이며 실제 송금·회계 마감이 아니라는 고정 문구를 표시 -->
-        <p class="fgc-help" id="finalize-action-guide" style="margin-top:4px">
+        <p class="field-helper vrun-finalize-guide" id="finalize-action-guide">
           위 6개 조건이 모두 통과한 실행만 확정할 수 있습니다.<br>
           확정하면 이 실행의 검증 결과와 그때 쓰인 룰셋·계산근거가 <strong>잠깁니다</strong>.
           <strong>검증 결과 잠금이며 실제 송금·회계 마감이 아닙니다.</strong><br>
           <strong>되돌릴 수 없습니다.</strong> 결과를 바꾸려면 새 실행을 만드세요.
-          확정 권한은 <span class="fgc-mono">GA_ADMIN</span> · <span class="fgc-mono">SYSTEM_ADMIN</span> 에게만 있습니다.
+          확정 권한은 <span class="tabular-nums">GA_ADMIN</span> · <span class="tabular-nums">SYSTEM_ADMIN</span> 에게만 있습니다.
         </p>
+        <!-- 비활성 사유를 가시 텍스트로 둔다 — disabled 버튼은 포커스가 가지 않아 title 로는 닿지 않는다. -->
+        <p class="vrun-action-note" id="finalize-action-note" role="status" hidden></p>
         <!--
           [의도적으로 만들지 않은 것] "확정 취소" · "되돌리기" 버튼
           확정된 결과는 DB 트리거가 물리적으로 수정을 막습니다.
         -->
       </div>
       <!-- 서버 권한과 IF-API-50 체크리스트가 모두 통과해야 스크립트가 활성화한다. -->
-      <button class="fgc-btn fgc-btn--primary" id="btn-finalize" type="button" data-fgc-action="finalize" disabled
+      <button class="button button-primary" id="btn-finalize" type="button" data-fgc-action="finalize" disabled
               data-checklist-passed="false"
               th:attr="data-can-finalize=${roleCode == 'GA_ADMIN' or roleCode == 'SYSTEM_ADMIN'}"
-              aria-describedby="finalize-action-guide" style="padding:10px 20px">
-        <span class="material-symbols-outlined" style="font-size:18px">lock</span> 확정
+              aria-describedby="finalize-action-guide finalize-action-note">
+        <span class="material-symbols-rounded" aria-hidden="true">lock</span><span id="btn-finalize-label">확정</span>
       </button>
     </div>
   </section>
 
-<!-- 스크립트는 main 안에 둔다 - 셸의 page()는 ~{::main}만 삽입하므로 main 밖 스크립트는 렌더링에서 사라진다 -->
-<script>
-/* 화면 폭이 좁으면 중간 2단 그리드를 세로로. 실행 선택은 해당 상세로 이동.
-   실행 버튼·진행률 폴링은 /js/features/vrun/vrun-detail.js (IF-API-48·49) */
-(function () {
-  "use strict";
-  function reflow() {
-    document.getElementById("mid-grid").style.gridTemplateColumns =
-      window.innerWidth < 1150 ? "1fr" : "1fr 1fr";
-  }
-  reflow();
-  window.addEventListener("resize", reflow);
-
-  document.getElementById("pick-run").addEventListener("change", function () {
-    if (this.value) {
-      window.location.assign("/validation-runs/" + this.value);
-    }
-  });
-})();
-</script>
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/vrun/list.html
+++ b/src/main/resources/templates/vrun/list.html
@@ -16,54 +16,58 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-VRUN-W01', '월 통합검증 실행 목록', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-validation-list">
+<main id="main-content" class="page-content vrun-page vrun-list-page"
+      th:attr="data-success-message=${successMessage},data-error-message=${errorMessage}">
 
-  <h1 class="fgc-page-title">월 통합검증 실행 목록</h1>
-  <p class="fgc-page-desc">
-    한 달치 계약을 한 번에 검사하는 작업을 <strong>실행</strong>이라고 부릅니다.
-    같은 달을 여러 번 돌릴 수 있고, 각각을 <strong>회차</strong>로 구분합니다.
-  </p>
+  <header class="page-header">
+    <div class="page-header-copy">
+      <h1 class="page-title">월 통합검증 실행 목록</h1>
+    </div>
+  </header>
 
-  <!-- PRG 플래시 배너 — 생성 성공/실패(VRUN_001 등)를 500 화면 대신 여기로 안내 -->
-  <div class="fgc-banner fgc-banner--info" style="margin-top:12px" th:if="${successMessage}">
-    <span class="material-symbols-outlined" style="font-size:18px">check_circle</span>
-    <span th:text="${successMessage}">실행이 생성되었습니다.</span>
-  </div>
-  <div class="fgc-banner fgc-banner--error" style="margin-top:12px" th:if="${errorMessage}">
-    <span class="material-symbols-outlined" style="font-size:18px">error</span>
-    <span th:text="${errorMessage}">실행 생성에 실패했습니다.</span>
-  </div>
-
-  <div class="fgc-banner fgc-banner--info" style="margin-top:12px">
-    <span class="material-symbols-outlined" style="font-size:18px">engineering</span>
-    <span>
-      실행을 만들면 <strong>Spring Batch</strong>의 <span class="fgc-mono">MonthlyValidationJob</span>이
-      1~8단계를 순서대로 돌립니다. 9단계(담당자 검토)와 10단계(확정)는 사람이 합니다.
-      실패하면 새 실행을 만들어 다시 돌립니다.
-    </span>
+  <!--
+    PRG 결과는 배너가 아니라 Toast 로 알린다 (가이드 §11).
+    문구는 위 <main> 의 data-*-message 로 넘기고 vrun-list.js 가 한 번 꺼내 띄운다 —
+    리다이렉트로 들어오는 화면이라 서버가 직접 Toast 를 띄울 수 없다.
+    상시 설명이던 Spring Batch 안내는 결과 알림이 아니므로 guidance 로 역할을 옮겼다.
+  -->
+  <div class="guidance guidance-neutral">
+    <span class="material-symbols-rounded guidance-icon" aria-hidden="true">engineering</span>
+    <div>
+      <p>
+        실행을 만들면 <strong>Spring Batch</strong>의 <span class="tabular-nums">MonthlyValidationJob</span>이
+        1~8단계를 순서대로 돌립니다. 9단계(담당자 검토)와 10단계(확정)는 사람이 합니다.
+        실패하면 새 실행을 만들어 다시 돌립니다.
+      </p>
+    </div>
   </div>
 
   <!-- ① 새 실행 만들기 — 폼 제출(PRG), Thymeleaf 가 CSRF hidden 을 자동 삽입한다 -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__head"><span class="fgc-card__title">① 새 실행 만들기</span></div>
-    <form class="fgc-card__body fgc-toolbar" th:action="@{/validation-runs}" method="post">
-      <div class="fgc-field" style="min-width:150px">
-        <label class="fgc-label fgc-label--required" for="new-month">검증월</label>
-        <input class="fgc-input" id="new-month" name="month" type="month" th:value="${month}" value="2026-08" required>
+  <section class="surface" aria-labelledby="vrun-create-title">
+    <header class="surface-header">
+      <h2 class="surface-title" id="vrun-create-title">① 새 실행 만들기</h2>
+    </header>
+    <form class="vrun-create-form" th:action="@{/validation-runs}" method="post">
+      <div class="field vrun-create-month">
+        <label class="field-label" for="new-month">검증월
+          <span class="field-required" aria-hidden="true">*</span></label>
+        <input class="field-control" id="new-month" name="month" type="month" th:value="${month}"
+               value="2026-08" required>
       </div>
-      <div class="fgc-field" style="min-width:170px">
-        <label class="fgc-label fgc-label--required" for="new-type">실행 유형</label>
-        <select class="fgc-select" id="new-type" name="runType">
+      <div class="field vrun-create-type">
+        <label class="field-label" for="new-type">실행 유형
+          <span class="field-required" aria-hidden="true">*</span></label>
+        <select class="select-control" id="new-type" name="runType">
           <option value="MONTHLY">월간 (MONTHLY)</option>
           <option value="MANUAL_CONTRACT">계약 수동 (MANUAL_CONTRACT)</option>
         </select>
       </div>
       <!-- 실행 생성은 SETTLEMENT (화면정의서 :1379, IF-API-45). 기준월에 활성 MONTHLY 가 있으면 비활성 -->
-      <button class="fgc-btn fgc-btn--primary" id="btn-create" data-fgc-action="create" type="submit"
+      <button class="button button-primary" id="btn-create" data-fgc-action="create" type="submit"
               aria-describedby="create-hint" th:disabled="${!canProcess or existsActiveMonthly}">
-        <span class="material-symbols-outlined" style="font-size:18px">add</span> 실행 생성
+        <span class="material-symbols-rounded" aria-hidden="true">add</span>실행 생성
       </button>
-      <p class="fgc-help" id="create-hint" style="margin:0;padding-bottom:6px"
+      <p class="field-helper vrun-create-hint" id="create-hint"
          th:text="${existsActiveMonthly}
                   ? '기준월에 진행 중인 월간 실행이 있어 새로 만들 수 없습니다.'
                   : '같은 달에 진행 중인 월간 실행이 있으면 새로 만들 수 없습니다.'">
@@ -72,86 +76,141 @@
   </section>
 
   <!-- ② 실행 목록 — 서버 렌더링, 상태 필터는 GET 폼 리로드(Ajax 없음) -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__head">
-      <span class="fgc-card__title">② 실행 목록</span>
-      <form class="publishing-inline-controls" style="display:flex;gap:8px;align-items:center"
-            th:action="@{/validation-runs}" method="get">
-        <label class="fgc-label" for="f-status" style="margin:0">상태</label>
-        <select class="fgc-select" id="f-status" name="status" style="padding:4px 8px" onchange="this.form.submit()">
-          <option value="">전체</option>
-          <option th:each="opt : ${statusOptions}" th:value="${opt.name()}" th:text="${opt.label()}"
-                  th:selected="${opt.name() == statusFilter}">생성됨</option>
-        </select>
-      </form>
-    </div>
-    <div style="overflow-x:auto">
-      <table class="fgc-table" style="min-width:1080px">
+  <section class="surface" aria-labelledby="vrun-list-title">
+    <header class="surface-header">
+      <h2 class="surface-title" id="vrun-list-title">② 실행 목록</h2>
+    </header>
+
+    <!--
+      전에는 select 의 onchange 가 곧바로 폼을 제출했다. 키보드로 값을 훑기만 해도 제출되고
+      JS 가 없으면 조회할 방법 자체가 없었다. LEDG-W01 선례대로 명시적 조회 버튼을 둔다.
+    -->
+    <form class="filter-bar vrun-filter-bar" th:action="@{/validation-runs}" method="get"
+          aria-label="실행 목록 검색 조건">
+      <div class="filter-fields vrun-filter-fields">
+        <div class="filter-field vrun-filter-status">
+          <label class="filter-field-label" for="f-status">상태</label>
+          <select class="select-control" id="f-status" name="status">
+            <option value="">전체</option>
+            <option th:each="opt : ${statusOptions}" th:value="${opt.name()}" th:text="${opt.label()}"
+                    th:selected="${opt.name() == statusFilter}">생성됨</option>
+          </select>
+        </div>
+      </div>
+      <div class="filter-actions vrun-filter-actions">
+        <button class="button button-primary" type="submit">
+          <span class="material-symbols-rounded" aria-hidden="true">search</span>조회
+        </button>
+      </div>
+    </form>
+
+    <div class="data-table-viewport vrun-table-viewport" tabindex="0" role="region"
+         aria-label="월 통합검증 실행 목록 표">
+      <table class="data-table vrun-run-table">
+        <caption class="visually-hidden">월 통합검증 실행 목록</caption>
+        <colgroup>
+          <col class="vrun-col-month">
+          <col class="vrun-col-runno">
+          <col class="vrun-col-type">
+          <col class="vrun-col-status">
+          <col class="vrun-col-progress">
+          <col class="vrun-col-actor">
+          <col class="vrun-col-started">
+          <col class="vrun-col-completed">
+          <col class="vrun-col-finalized">
+          <col class="vrun-col-failure">
+          <col class="vrun-col-open">
+        </colgroup>
         <thead>
           <tr>
-            <th style="width:80px">검증월</th>
-            <th style="width:56px">회차</th>
-            <th style="width:110px">실행 유형</th>
-            <th style="width:100px">상태</th>
-            <th style="width:130px">진행</th>
-            <th style="width:80px">실행자</th>
-            <th style="width:130px">시작</th>
-            <th style="width:130px">완료</th>
-            <th style="width:150px">확정자 · 확정시각</th>
-            <th>실패 사유</th>
-            <th style="width:70px"></th>
+            <th scope="col">검증월</th>
+            <th scope="col" class="is-number">회차</th>
+            <th scope="col">실행 유형</th>
+            <th scope="col" class="is-center">상태</th>
+            <th scope="col">진행</th>
+            <th scope="col">실행자</th>
+            <th scope="col">시작</th>
+            <th scope="col">완료</th>
+            <th scope="col">확정자 · 확정시각</th>
+            <th scope="col">실패 사유</th>
+            <th scope="col" class="is-center">상세</th>
           </tr>
         </thead>
         <tbody id="list-body">
           <tr th:each="run : ${runs.content()}">
-            <td class="fgc-mono" th:text="${#temporals.format(run.validationMonth(), 'yyyy-MM')}">2026-07</td>
-            <td class="fgc-mono" th:text="${run.runNo()}">1</td>
+            <td class="tabular-nums" th:text="${#temporals.format(run.validationMonth(), 'yyyy-MM')}">2026-07</td>
+            <td class="is-number tabular-nums" th:text="${run.runNo()}">1</td>
             <td th:text="${run.runTypeLabel()}">월간</td>
-            <td>
-              <!-- 톤 매핑은 화면 MVP(FGC-UI-VRUN-W01)와 동일: 실패=violation, 확정=review, 계산완료=normal, 그 외=warning -->
-              <span class="fgc-badge"
-                    th:classappend="${run.status().name() == 'FAILED'} ? 'fgc-badge--violation'
-                                    : (${run.status().name() == 'FINALIZED'} ? 'fgc-badge--review'
-                                    : (${run.status().name() == 'COMPLETED'} ? 'fgc-badge--normal' : 'fgc-badge--warning'))"
-                    ><span th:text="${run.status().name() == 'FINALIZED' ? '확정' : run.statusLabel()}">생성됨</span><span class="material-symbols-outlined"
-                    style="font-size:14px;vertical-align:-2px;margin-left:2px"
-                    th:if="${run.status().name() == 'FINALIZED'}">lock</span></span>
+            <td class="is-center">
+              <th:block th:replace="~{vrun/status-badge :: runStatusBadge(${run.status().name()}, ${run.statusLabel()})}"></th:block>
             </td>
-            <td class="fgc-mono"
+            <td class="tabular-nums"
                 th:text="|${run.currentStep()}/10 단계 (${run.currentStep() * 10}%)|">0/10 단계 (0%)</td>
-            <td class="fgc-mono" th:text="${run.triggeredBy()} ?: '—'">admin</td>
-            <td class="fgc-mono"
-                th:text="${run.startedAt() != null} ? ${#temporals.format(run.startedAt(), 'MM-dd HH:mm')} : '—'">—</td>
-            <td class="fgc-mono"
-                th:text="${run.completedAt() != null} ? ${#temporals.format(run.completedAt(), 'MM-dd HH:mm')} : '—'">—</td>
-            <td class="fgc-mono"
-                th:text="${run.finalizedAt() != null}
-                         ? ${run.finalizedBy()} + ' · ' + ${#temporals.format(run.finalizedAt(), 'MM-dd HH:mm')} : '—'">—</td>
+            <td th:text="${run.triggeredBy()} ?: '-'">admin</td>
+            <!-- 목록·상세의 일시 포맷을 yyyy-MM-dd HH:mm 하나로 통일했다 (FGC-SIR-008) -->
+            <td class="tabular-nums"
+                th:text="${run.startedAt() != null} ? ${#temporals.format(run.startedAt(), 'yyyy-MM-dd HH:mm')} : '-'">-</td>
+            <td class="tabular-nums"
+                th:text="${run.completedAt() != null} ? ${#temporals.format(run.completedAt(), 'yyyy-MM-dd HH:mm')} : '-'">-</td>
             <td>
-              <span class="fgc-error" th:if="${run.status().name() == 'FAILED'}"
-                    th:text="${run.failureMessage()}">실패 사유</span>
+              <div class="table-cell-disclosure"
+                   th:with="finalized=${run.finalizedAt() != null}
+                            ? ${run.finalizedBy()} + ' · ' + ${#temporals.format(run.finalizedAt(), 'yyyy-MM-dd HH:mm')} : '-'">
+                <span class="table-cell-preview is-single-line tabular-nums" th:text="${finalized}">-</span>
+                <details class="table-cell-details" hidden>
+                  <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span><span
+                        class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                  <p class="table-cell-full" th:text="${finalized}">-</p>
+                </details>
+              </div>
             </td>
-            <td><a class="fgc-btn fgc-btn--ghost" style="padding:2px 10px;font-size:12px"
-                   th:href="@{/validation-runs/{id}(id=${run.validationRunId()})}">열기</a></td>
+            <td>
+              <div class="table-cell-disclosure" th:if="${run.status().name() == 'FAILED'}">
+                <span class="table-cell-preview is-single-line vrun-failure-text"
+                      th:text="${run.failureMessage()} ?: '-'">실패 사유</span>
+                <details class="table-cell-details" hidden>
+                  <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span><span
+                        class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                  <p class="table-cell-full" th:text="${run.failureMessage()} ?: '-'">실패 사유</p>
+                </details>
+              </div>
+              <span th:unless="${run.status().name() == 'FAILED'}">-</span>
+            </td>
+            <td class="is-center">
+              <a class="button button-secondary vrun-row-button"
+                 th:href="@{/validation-runs/{id}(id=${run.validationRunId()})}"
+                 th:aria-label="|${#temporals.format(run.validationMonth(), 'yyyy-MM')} ${run.runNo()}회차 실행 열기|">열기</a>
+            </td>
           </tr>
           <tr th:if="${runs.content().isEmpty()}">
-            <td colspan="11"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td>
+            <td colspan="11">
+              <p class="vrun-inline-state is-empty" role="status" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</p>
+            </td>
           </tr>
         </tbody>
       </table>
     </div>
-    <!-- 페이징 — audit/list.html 과 같은 링크 방식 -->
-    <div class="fgc-card__body" style="display:flex;gap:8px;justify-content:center"
-         th:if="${runs.totalPages() > 1}">
-      <a class="fgc-btn fgc-btn--ghost" style="padding:4px 12px;font-size:12px"
-         th:if="${runs.page() > 1}"
-         th:href="@{/validation-runs(status=${statusFilter}, page=${runs.page() - 1})}">이전</a>
-      <span class="fgc-muted" style="font-size:12px;align-self:center"
-            th:text="|${runs.page()} / ${runs.totalPages()}|">1 / 1</span>
-      <a class="fgc-btn fgc-btn--ghost" style="padding:4px 12px;font-size:12px"
-         th:if="${runs.page() lt runs.totalPages()}"
-         th:href="@{/validation-runs(status=${statusFilter}, page=${runs.page() + 1})}">다음</a>
-    </div>
+
+    <!-- 페이징 — 공통 pagination-controls. 전에는 레거시 버튼 링크 2개로 수제 구현이었다. -->
+    <nav class="vrun-pagination" aria-label="월 통합검증 실행 목록 페이지" th:if="${runs.totalPages() > 1}">
+      <div class="pagination-controls">
+        <a class="pagination-button" th:if="${runs.page() > 1}"
+           th:href="@{/validation-runs(status=${statusFilter}, page=${runs.page() - 1})}" aria-label="이전 페이지">
+          <span class="material-symbols-rounded" aria-hidden="true">chevron_left</span>
+        </a>
+        <span class="pagination-button is-disabled" th:unless="${runs.page() > 1}" aria-hidden="true">
+          <span class="material-symbols-rounded">chevron_left</span>
+        </span>
+        <span class="tabular-nums" th:text="|${runs.page()} / ${runs.totalPages()}|">1 / 1</span>
+        <a class="pagination-button" th:if="${runs.page() lt runs.totalPages()}"
+           th:href="@{/validation-runs(status=${statusFilter}, page=${runs.page() + 1})}" aria-label="다음 페이지">
+          <span class="material-symbols-rounded" aria-hidden="true">chevron_right</span>
+        </a>
+        <span class="pagination-button is-disabled" th:unless="${runs.page() lt runs.totalPages()}" aria-hidden="true">
+          <span class="material-symbols-rounded">chevron_right</span>
+        </span>
+      </div>
+    </nav>
   </section>
 
 </main>

--- a/src/main/resources/templates/vrun/status-badge.html
+++ b/src/main/resources/templates/vrun/status-badge.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!--
+  VRUN 실행 상태 배지 — 서버 렌더링 쪽 단일 매핑 (#286)
+
+  전에는 같은 매핑이 4벌 있었다.
+    vrun/list.html:112-118 · vrun/detail.html:75-79 · vrun/detail.html:166-169 · vrun-detail.js:34-38
+  그중 CREATED 와 RUNNING 이 같은 톤(warning)이라 "아직 시작 안 함"과 "돌고 있음"을 구분할 수 없었다.
+
+  톤은 화면정의서 4장 규칙 4(:212 "정상=초록, 주의=주황, 위반·차단=빨강, 검토필요=회색, 진행중=파랑")와
+  common/code/ValidationRunStatus.java 의 label()·canTransitionTo() 가 정의한 상태 흐름을 따른다.
+    CREATED   생성됨      → neutral  (아직 실행 전)
+    RUNNING   실행중      → info     (진행중)
+    COMPLETED 계산완료    → success  (정상 종료)
+    FINALIZED 확정(잠김)  → review + 자물쇠  (규칙 8 확정 후 잠금)
+    FAILED    실패        → error    (차단)
+
+  FINALIZED 만 라벨을 "확정" 으로 줄인다 — "(잠김)" 은 자물쇠 아이콘이 대신하므로 배지가 짧아진다.
+  이 처리는 PR #316 이 목록에서 먼저 넣은 것을 그대로 이어받았다.
+
+  JS 쪽(vrun-detail.js 의 STATUS_BADGE_CLASSES)이 같은 클래스명을 쓴다. 한쪽만 고치면 폴링 도중
+  배지 색이 서버 렌더링과 어긋나므로 두 곳을 함께 고쳐야 한다.
+-->
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+
+<span th:fragment="runStatusBadge(status, label)"
+      class="status-badge"
+      th:classappend="${status == 'FAILED'} ? 'status-badge-error'
+                      : (${status == 'FINALIZED'} ? 'status-badge-review'
+                      : (${status == 'COMPLETED'} ? 'status-badge-success'
+                      : (${status == 'RUNNING'} ? 'status-badge-info' : 'status-badge-neutral')))"
+      ><span th:text="${status == 'FINALIZED'} ? '확정' : ${label}">생성됨</span><span
+        class="material-symbols-rounded vrun-badge-lock" aria-hidden="true"
+        th:if="${status == 'FINALIZED'}">lock</span></span>
+
+</body>
+</html>

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -43,9 +43,7 @@ class PublishingTemplateStructureTest {
             "templates/transaction/form.html",
             "templates/schedule/detail.html",
             "templates/ledger/list.html",
-            "templates/exception/list.html",
-            "templates/vrun/list.html",
-            "templates/vrun/detail.html"
+            "templates/exception/list.html"
     );
 
     /*
@@ -61,6 +59,8 @@ class PublishingTemplateStructureTest {
             "templates/audit/list.html",
             "templates/contract/form.html",
             "templates/schedule/list.html",
+            "templates/vrun/list.html",
+            "templates/vrun/detail.html",
             "templates/arbitrage/list.html",
             "templates/error/403.html",
             "templates/error/404.html",
@@ -184,7 +184,10 @@ class PublishingTemplateStructureTest {
                 .contains("error.code === \"FGC-VRUN-006\"")
                 .contains("finalizeIdempotencyKey = null")
                 .contains("runStatus !== \"COMPLETED\"")
-                .contains("window.confirm")
+                // 확정 확인이 브라우저 기본 대화상자에서 공통 Modal 로 바뀌었다 (#286).
+                // 기본 대화상자는 화면정의서 :1487 의 송금·회계 마감 아님 문구를 담을 수 없다.
+                .contains("modal.open(\"vrun-finalize\")")
+                .doesNotContain("window.confirm")
                 .doesNotContain("fetch(");
     }
 
@@ -789,6 +792,122 @@ class PublishingTemplateStructureTest {
                 .contains("passwordToggle.setAttribute(\"aria-label\", willShow ? \"비밀번호 숨기기\" : \"비밀번호 표시\")")
                 .doesNotContain("FGC-AUTH-")
                 .doesNotContain("fetch(");
+    }
+
+    /*
+     * VRUN-W01·W02 월 통합검증 화면 (#286).
+     *
+     * 두 화면 모두 레거시 골격 그대로였다. 회귀 방지가 특히 중요한 두 가지를 인수조건으로 고정한다.
+     *   · 비가역인 확정을 브라우저 기본 대화상자로 확인했다 — 규제 고정 문구를 담을 수 없다
+     *   · 확정 성공 Toast 를 띄우자마자 reload() 해서 사용자에게 보이지 않았다
+     */
+    @Test
+    void validationRunScreensUseCommonComponentsWithoutInlinePresentation() throws IOException {
+        assertThat(resource("templates/vrun/list.html"))
+                .contains("class=\"page-content vrun-page vrun-list-page\"")
+                .contains("class=\"filter-bar vrun-filter-bar\"")
+                .contains("class=\"data-table-viewport vrun-table-viewport\" tabindex=\"0\" role=\"region\"")
+                .contains("<colgroup>")
+                .contains("scope=\"col\"")
+                .contains("class=\"visually-hidden\">월 통합검증 실행 목록")
+                .contains("class=\"table-cell-disclosure\"")
+                .contains("class=\"pagination-controls\"")
+                .contains("aria-label=\"월 통합검증 실행 목록 페이지\"")
+                // PRG 결과는 배너가 아니라 Toast 로 — 문구를 data-* 로 넘긴다
+                .contains("data-success-message=${successMessage}")
+                .contains("data-error-message=${errorMessage}")
+                // 폼 계약은 골격이 바뀌어도 그대로여야 한다
+                .contains("id=\"btn-create\"")
+                .contains("data-fgc-action=\"create\"")
+                .contains("name=\"month\"")
+                .contains("name=\"runType\"")
+                .contains("name=\"status\"")
+                // select 변경만으로 제출되던 동작을 명시적 조회 버튼으로 바꿨다 (LEDG-W01 선례)
+                .doesNotContain("onchange=")
+                .doesNotContain("class=\"fgc-")
+                .doesNotContain("fgc-banner")
+                .doesNotContain("publishing-page")
+                .doesNotContain("<th style=\"width:")
+                .doesNotContain("style=\"");
+
+        assertThat(resource("templates/vrun/detail.html"))
+                .contains("class=\"page-content vrun-page vrun-detail-page\"")
+                // 확정 확인 모달 — 규제 고정 문구를 담는다
+                .contains("data-modal=\"vrun-finalize\"")
+                .contains("id=\"btn-finalize-submit\"")
+                .contains("data-modal-initial-focus")
+                // 확정 완료 모달 — reload 로 사라지던 성공 피드백을 대신한다 (목업 :195-210)
+                .contains("data-modal=\"vrun-finalized\"")
+                .contains("id=\"btn-finalized-close\"")
+                // 결과 요약이 "플레이스홀더" 클래스가 아니라 공통 KPI 카드다
+                .contains("class=\"kpi-grid vrun-summary-grid\"")
+                .contains("class=\"kpi-card\"")
+                // 스텝퍼는 색만으로 상태를 전달하지 않는다 (규칙 4)
+                .contains("class=\"vrun-stepper\"")
+                .contains("data-step-state")
+                // 진행률 % 를 상세에도 표시한다 (화면정의서 :1442)
+                .contains("id=\"progress-text\"")
+                // 비활성 사유는 title 이 아니라 가시 텍스트 + aria-describedby
+                .contains("id=\"finalize-action-note\"")
+                .contains("id=\"execute-action-note\"")
+                .contains("aria-describedby=\"finalize-action-guide finalize-action-note\"")
+                // 기존 구조 테스트가 고정하던 계약은 그대로 유지한다
+                .contains("id=\"cond-body\" aria-live=\"polite\"")
+                .contains("data-checklist-passed=\"false\"")
+                .contains("data-can-finalize=${roleCode == 'GA_ADMIN' or roleCode == 'SYSTEM_ADMIN'}")
+                .contains("검증 결과 잠금이며 실제 송금·회계 마감이 아닙니다.")
+                .containsOnlyOnce("id=\"finalize-action-guide\"")
+                .containsOnlyOnce("id=\"btn-finalize\"")
+                .doesNotContain("class=\"fgc-")
+                .doesNotContain("publishing-result-placeholder")
+                .doesNotContain("publishing-page")
+                .doesNotContain("style=\"")
+                .doesNotContainPattern("(?i)<style[\\s>]")
+                .doesNotContain("<script>");
+
+        // 서버 렌더링 배지 매핑을 한 곳으로 모았다 — 전에는 두 템플릿과 JS 에 4벌이 흩어져 있었다
+        assertThat(resource("templates/vrun/status-badge.html"))
+                .contains("th:fragment=\"runStatusBadge(status, label)\"")
+                .contains("status-badge-error")
+                .contains("status-badge-review")
+                .contains("status-badge-success")
+                .contains("status-badge-info")
+                .contains("status-badge-neutral")
+                .contains("vrun-badge-lock");
+
+        assertThat(resource("static/js/features/vrun/vrun-detail.js"))
+                // JS 배지가 서버 렌더링과 같은 클래스를 쓴다. CREATED 와 RUNNING 을 구분한다
+                .contains("STATUS_BADGE_CLASSES")
+                .contains("CREATED: \"status-badge-neutral\"")
+                .contains("RUNNING: \"status-badge-info\"")
+                .contains("statusBadge.classList.remove.apply(statusBadge.classList, STATUS_BADGE_CLASS_NAMES)")
+                .doesNotContain("statusBadge.className =")
+                // 폴링 오류가 더는 무음이 아니다
+                .contains("pollFailures >= 3")
+                // 확정 성공은 완료 모달로 알린다 — Toast 직후 reload 하지 않는다
+                .contains("modal.open(\"vrun-finalized\")")
+                // 비활성 사유는 title 이 아니다
+                .doesNotContain("finalizeButton.title =")
+                .contains("finalizeNote.textContent = reason");
+
+        assertThat(resource("static/js/features/vrun/vrun-list.js"))
+                .contains("main.dataset[attribute]")
+                .contains("delete main.dataset[attribute]")
+                .contains("flash(\"successMessage\", \"success\", 5000)")
+                .contains("flash(\"errorMessage\", \"error\", 0)")
+                .doesNotContain("fetch(");
+
+        assertThat(resource("static/css/features/vrun.css"))
+                .contains(".vrun-stepper")
+                .contains(".vrun-inline-state")
+                .contains(".vrun-kv")
+                .contains(".vrun-mid-grid")
+                // 인라인 <script> 의 resize 리스너를 CSS 미디어쿼리로 대체했다
+                .contains("@media (max-width: 63.9375rem)")
+                .contains(":focus-visible");
+
+        assertThat(resource("templates/layout/default.html"))
+                .contains("th:src=\"@{/js/features/vrun/vrun-list.js}\" defer");
     }
 
     private static String resource(String path) throws IOException {


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- 월 통합검증 2화면(VRUN-W01 실행 목록 · W02 상세·확정)을 공통 UI 컴포넌트로 전환했습니다. 두 화면 모두 레거시 골격 그대로였습니다.
- 되돌릴 수 없는 **확정**의 확인 절차를 브라우저 기본 대화상자에서 공통 Modal 로 바꿨습니다. 기본 대화상자로는 규제 고정 문구를 담을 수 없습니다.
- **확정 성공 피드백을 복구했습니다.** Toast 를 띄우자마자 `reload()` 해서 발표 시연 마지막 단계의 성공 알림이 사용자에게 보이지 않았습니다.
- 인라인 `style=` 65개와 `class="fgc-*"` 101개를 걷어내고 `<style>`·`<script>` 블록을 제거했습니다.
- 4벌로 흩어져 서로 다르던 상태 배지 매핑을 서버용 프래그먼트 1벌 + JS 상수 1벌로 모았습니다.

기준 커밋 `0a2796ae` (`origin/develop`) · 8 files changed, +1292 / −339
새 파일 — `templates/vrun/status-badge.html`, `static/js/features/vrun/vrun-list.js`

## 🔗 2. 관련 이슈

* Closes #286
* Refs #138

## 🛠 3. 구현 내용

### 착수 전 재검증 — 이슈와 달라진 점

이슈는 기준 커밋이 `859adffd` 인데 그 뒤로 develop 이 30커밋 넘게 움직였습니다.

| 이슈 진단 | 실제 |
|---|---|
| **⓪ "`static/css/features/` 에 `vrun.css` 가 없습니다"** · To-do "`vrun.css` 신설" | **이미 있습니다.** 선행 정비(`1577955f`)가 16줄짜리 스텁으로 만들면서 주석에 "스텝퍼·결과 요약·컬럼 폭은 VRUN 담당 이슈에서 채운다" 고 적어 뒀습니다. 신설이 아니라 **채우는** 작업이었습니다 |
| **③ "`PublishingTemplateStructureTest:102` 의 `window.confirm` assert 동반 수정"** | 해당 단언은 지금 **`:187`** 입니다 (파일이 늘어나며 밀림). 지시대로 함께 고쳤습니다 |
| ⑥ `list.html:112-118` 배지 · `:117-118` 자물쇠에 `aria-hidden` 없음 | PR #316(`cda2ac87`)이 자물쇠를 배지 **안쪽**으로 옮기고 FINALIZED 라벨을 "확정" 으로 줄여 놨습니다. 그 처리를 프래그먼트로 이어받았습니다 |

`list.html` 159줄 · `detail.html` 298줄은 이슈 기재와 정확히 일치해 나머지 줄 번호 진단은 그대로 유효했습니다.

### ① ★ 확정 확인 모달

`vrun-detail.js:208` 이 `window.confirm` 으로 확인받고 있었습니다. 브라우저 기본 대화상자의 문제는 디자인 이탈만이 아닙니다.

- 화면정의서 `:1487` · 인터페이스정의서 `:956` 이 요구하는 **"검증 결과 잠금이며 실제 송금·회계 마감이 아닙니다"** 고정 문구를 담을 수 없습니다
- 포커스 반환·다국어·스타일을 제어할 수 없습니다

공통 `js/common/modal.js` + `components.css:829-887` 로 교체했습니다 (`data-modal="vrun-finalize"`). 모달 본문에 규제 문구 3줄과 검증월·회차를 담았고, `data-modal-initial-focus` 는 **취소** 버튼에 뒀습니다 — 비가역 동작에 기본 포커스를 주지 않습니다. Esc·포커스 트랩·닫은 뒤 포커스 복귀는 `modal.js` 가 처리합니다.

### ② ★ 확정 성공 피드백 복구

```js
if (toast) toast("검증 실행을 확정했습니다.", "success");
window.location.reload();   // ← Toast 를 띄운 DOM 을 통째로 날린다
```

발표 시연 10컷의 **마지막 단계**에서 성공 알림이 보이지 않았습니다. 이슈가 제시한 두 방안 중 "목업 의도에 가까운" 2번을 택했습니다 — 목업 `:195-210` 의 **확정 완료 모달**(`data-modal="vrun-finalized"`)을 띄우고, 사용자가 [확인] 을 눌러 닫을 때 리로드합니다. 모달에도 송금·회계 마감 아님 문구를 다시 넣었습니다.

### ③ 상태 배지 4벌 → 서버 1벌 + JS 1벌

전에는 같은 매핑이 `list.html:112-118` · `detail.html:75-79` · `detail.html:166-169` · `vrun-detail.js:34-38` 에 흩어져 있었습니다.

서버 렌더링 쪽은 새 Thymeleaf 프래그먼트 **`templates/vrun/status-badge.html`** (`runStatusBadge(status, label)`) 한 벌로 모아 두 템플릿이 함께 씁니다. JS 는 `STATUS_BADGE_CLASSES` 로 **같은 클래스명**을 씁니다.

| 상태 | `ValidationRunStatus.label()` | 전 | 후 |
|---|---|---|---|
| `CREATED` | 생성됨 | `warning` | **`status-badge-neutral`** |
| `RUNNING` | 실행중 | `warning` | **`status-badge-info`** (진행중=파랑) |
| `COMPLETED` | 계산완료 | `normal` | `status-badge-success` |
| `FINALIZED` | 확정(잠김) | `review` | `status-badge-review` + 자물쇠 |
| `FAILED` | 실패 | `violation` | `status-badge-error` |

`CREATED` 와 `RUNNING` 이 같은 톤이라 **"아직 시작 안 함"과 "돌고 있음"을 구분할 수 없었습니다.** 규칙 4(`:212`)가 진행중=파랑을 정하고 있어 나눴습니다.

`FINALIZED` 를 `review` 로 둔 것은 규칙 8(`:216` 확정 후 잠금) 기준이며, 같은 캠페인의 SCHE-W02(#285)에서 `CONFIRMED` 를 `review` + 자물쇠로 둔 것과 같은 판단입니다.

`vrun-detail.js:69` 의 `statusBadge.className = "fgc-badge " + …` 통째 덮어쓰기는 병행 클래스를 잃습니다. `exception-list.js` 패턴대로 `classList.remove(...)` + `add` 로 바꿨습니다(구조 테스트 `:267` 이 강제하는 방식).

### ④ VRUN-W01 실행 목록

| 항목 | 전 | 후 |
|---|---|---|
| 인라인 `style=` | 33개 | **0개** |
| `class="fgc-*"` | 40개 | **0개** |
| `<th style="width:">` | 11개 | **0개** → `<colgroup>` + `.vrun-col-*` |
| 공통 컴포넌트 | 0개 | `page-header`·`surface`·`filter-bar`·`field`·`button`·`data-table`·`empty-state`·`pagination-controls` |

- **`:81` `onchange="this.form.submit()"` 제거 → 명시적 조회 버튼.** 키보드로 select 값을 훑기만 해도 제출됐고, JS 가 없으면 조회할 방법 자체가 없었습니다 (LEDG-W01 선례)
- **PRG 플래시 배너 2개(`:28`, `:32`)를 Toast 로 이관.** 리다이렉트로 들어오는 화면이라 서버가 직접 Toast 를 띄울 수 없어, 문구를 `<main data-success-message>` · `data-error-message` 로 넘기고 새 `vrun-list.js` 가 한 번 꺼내 띄운 뒤 `data-*` 를 지웁니다(뒤로가기로 재표시 방지). 목업 `:149-151` 도 `FGC.toast` 를 씁니다
- `:37` 의 Spring Batch 상시 설명은 결과 알림이 아니므로 `guidance guidance-neutral` 로 역할만 옮겼습니다
- 수제 페이지네이션(`:144-154`) → `pagination-controls` / `pagination-button` + `<nav aria-label>`
- 실패 사유·확정자 컬럼에 `table-cell-disclosure`

### ⑤ VRUN-W02 상세·확정

| 항목 | 전 | 후 |
|---|---|---|
| 인라인 `style=` | 32개 | **0개** |
| `class="fgc-*"` | 61개 | **0개** |
| `<style>` 블록 (하드코딩 HEX 1건) | 33-37행 | `vrun.css` 의 `.vrun-kv`, 색은 `--color-text-secondary` |
| `<script>` 블록 | 277-295행 (19줄) | **0줄** |
| `publishing-result-placeholder` | 14개 | **0개** → `kpi-grid` / `kpi-card` |
| `:133` `#B45309` | 하드코딩 | `.vrun-stepper-manual` + `--color-status-warning-text` |

- **`<script>` 의 `resize` 리스너 제거** — `mid-grid` 2단/1단 전환을 CSS 미디어쿼리로 옮겼습니다. 기존 기준값 `1150px` 이 프로젝트 브레이크포인트(`63.9375rem`=1023px)와 달랐고, JS 가 없으면 좁은 폭에서도 항상 2단이었습니다
- **`#pick-run` change 즉시 이동 → [이동] 버튼.** 키보드로 값을 훑기만 해도 페이지가 바뀌었고 이동한다는 예고도 없었습니다
- **진행률 % 를 상세에도 표시** (화면정의서 `:1442`). 전에는 목록에만 있었고 상세에는 스텝퍼 색만 있었습니다. 폴링 중 갱신을 `role="status" aria-live="polite"` 로 고지합니다
- 스텝퍼를 `<div>` → `<ol>`/`<li>` 로 바꾸고 `aria-label` 을 줬습니다. 칸마다 `visually-hidden` 텍스트로 **완료 / 진행 중 / 실패 / 대기**를 함께 읽어 줍니다 — 색만으로 상태를 전달하지 않습니다(규칙 4)
- 확정 불가역 경고(`:60`)는 업무·규제 제약이라 삭제하지 않고 `guidance guidance-warning` 으로 역할을 옮겼습니다

**스텝퍼 상태 클래스명은 그대로 뒀습니다.** `ValidationRunViewController:168-192` 의 `stepClasses()` 가 `fgc-stepper__step--*` 문자열을 계산해 내려주는데, 이름을 바꾸려면 Controller 를 고쳐야 하고 그건 이 이슈의 "하지 말 것" 입니다. 화면에서 다시 계산하는 것도 금지라 **서버가 주는 이름을 받고 스타일만 `.vrun-stepper-step` 아래로 옮겼습니다.** `assets/fgc.css` 의 원본도 지시대로 지우지 않았습니다.

### ⑥ Toast · 로딩/빈/오류

| 동작 | 전 | 후 |
|---|---|---|
| **폴링 오류** | **완전 무음** (`catch {}` 주석만) | 연속 3회(약 6초) 실패 시 1회 경고 Toast, 회복되면 복구 알림 |
| 확정 성공 | `reload()` 로 즉시 소멸 | 확정 완료 모달 |
| 확정 실패 | 메시지만 | 오류코드(`FGC-VRUN-001~006`)·요청 ID 병기 |
| 폴링 종료(계산완료) | Toast 없이 reload | 3초 안내 후 리로드 (목업 `:498`) |
| 새로고침 버튼 | Toast 없이 reload | 2초 안내 (목업 `:508`) |
| 체크리스트 조회 실패 | 인라인 배지만, 재시도 없음 | 인라인 오류 + **재시도 버튼** + Toast |
| VRUN-W01 전체 | **Toast 0건** | PRG 성공·실패 Toast |

로딩·빈·오류를 `.vrun-inline-state` + `is-loading` / `is-empty` / `is-error` 로 나누고 `role="status"` / `role="alert"` 를 부여했습니다. 전에는 셋 다 `.fgc-empty publishing-empty-state` 하나였습니다.

### ⑦ 접근성

- **아이콘 22곳에 `aria-hidden="true"`** — 전에는 **0곳**이라 스크린리더가 "check_circle", "engineering", "lock", "play_arrow" 를 읽었습니다
- **비활성 사유를 `title` 에서 가시 텍스트 + `aria-describedby` 로.** `vrun-detail.js:132,134` 가 `title` 로만 사유를 줬는데 `disabled` 요소는 포커스가 가지 않아 도달할 수 없습니다. 권한 / 상태 / 체크리스트 3가지 사유를 구분해 `#finalize-action-note`·`#execute-action-note` 에 적습니다 (`reco/list.html:73-86` 패턴)
- **체크리스트 유령 링크 제거** — 전에는 미통과 시 배지 자체가 `<a>` 가 됐고, `safeInternalLink` 가 `null` 을 반환하면 **`href` 없는 `<a>`** 가 남아 키보드로 닿을 수 없었습니다. 링크가 실제로 있을 때만 별도 **"바로가기"** 를 만들고 `aria-label` 에 목적지를 담습니다 (목업 `:424`)
- 표 2개에 `<caption class="visually-hidden">` + `<th scope="col">` + `<colgroup>`
- 가로 스크롤 뷰포트에 `tabindex="0"` + `role="region"` + `aria-label`
- "열기" 링크에 행 컨텍스트 `aria-label` (`2026-07 1회차 실행 열기`)
- `vrun.css` 에 `:focus-visible` 규칙 신설 — 전에는 파일 자체가 스텁이라 0건
- 확정 후 버튼 라벨을 **"확정됨"** 으로 전환 (목업 `:442`)

### ⑧ 표시 형식

목록 `'MM-dd HH:mm'` vs 상세 `'yyyy-MM-dd HH:mm'` 로 **같은 데이터가 화면마다 달랐습니다.** `yyyy-MM-dd HH:mm` 하나로 통일하고 `tabular-nums` 를 적용했습니다.

## 🧪 4. 테스트 방법

1. 전체 테스트를 실행합니다. **Docker Desktop 이 떠 있어야 합니다** — Testcontainers 가 PostgreSQL 을 띄웁니다.
   ```bash
   ./gradlew build
   ```
   확인된 결과: `BUILD SUCCESSFUL` · **1151 tests, 0 failed**

2. VRUN 관련 테스트만 따로 확인합니다. `ValidationRunViewControllerTest` 는 두 템플릿을 **실제로 렌더링**하므로 새 Thymeleaf 프래그먼트가 정상 해석되는지까지 확인됩니다.
   ```bash
   ./gradlew test \
     --tests "com.susukkang.fgc.ui.PublishingTemplateStructureTest" \
     --tests "com.susukkang.fgc.ui.PendingActionButtonStructureTest" \
     --tests "com.susukkang.fgc.validation.controller.ValidationRunViewControllerTest"
   ```
   확인된 결과: 23 + 2 + 11 tests 통과

3. 정적 검사로 레거시 잔존이 0건인지 봅니다.
   ```bash
   rg -n 'page-description|fgc-page-desc|fgc-banner' src/main/resources/templates/vrun
   rg -n 'style=|onclick=|onchange=|<style|<script' src/main/resources/templates/vrun
   rg -n 'fgc-card|fgc-btn|fgc-field|fgc-select|fgc-table|fgc-badge|fgc-empty|fgc-toolbar|fgc-stepper|publishing-result-placeholder|publishing-page' src/main/resources/templates/vrun
   rg -n '<th style="width:' src/main/resources/templates/vrun
   rg -n 'window.confirm' src/main/resources/static/js/features/vrun src/main/resources/templates/vrun
   ```
   확인된 결과: **5종 모두 0건**

4. JS 문법을 확인합니다. **제 환경에 Node 가 없어 실행하지 못했습니다** — 6번 리뷰 요구사항 1번 참조.
   ```bash
   node --check src/main/resources/static/js/features/vrun/vrun-detail.js
   node --check src/main/resources/static/js/features/vrun/vrun-list.js
   ```

5. 앱을 띄워 두 화면을 확인합니다. **브라우저 QA 는 하지 못했습니다** — 6번 리뷰 요구사항 2번 참조.
   ```bash
   ./gradlew bootRun
   ```
   - `/validation-runs` — 상태 필터가 **select 변경만으로 제출되지 않고 조회 버튼으로** 동작하는지 / 실행 생성 성공·실패 Toast / 긴 실패 사유 `전체 보기` / 상태 배지 5종 구분 / 페이지네이션 / 표 내부에서만 가로 스크롤
   - `/validation-runs/{id}` — 스텝퍼 + **진행률 %** / 폴링 중 `aria-live` 고지 / 폴링 오류 시 사용자 인지 / 실행 버튼 `aria-busy` / **확정 확인 모달** Esc·포커스 복귀·송금 마감 아님 문구 / **확정 성공 모달이 실제로 보이는지** / 체크리스트 6개 조건 순서·바로가기 / 확정 후 "확정됨" + 자물쇠 / `settle01` 계정에서 확정 버튼 비활성 + **사유가 스크린리더에 전달되는지**
   - 공통 — 1440px / 900px / 720px, 키보드 Tab 과 `:focus-visible`, 본문 가로 넘침 없음, Console 오류 없음

   **확정은 되돌릴 수 없으므로 테스트 데이터로만 수행해 주세요.**

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

1. **`node --check` 를 실행하지 못했습니다.** 제 환경에 Node 가 설치되어 있지 않습니다. `src/test/js/*.cjs` 는 `build.gradle` 과 `ci.yml` 어디에서도 실행되지 않아(CI 는 `./gradlew build` 만 돌립니다) JS 문법은 자동 검증이 없습니다. `vrun-detail.js` 는 355줄이 바뀌었으니 한 번 돌려 봐 주세요.

2. **브라우저 QA 를 하지 못했습니다** — 1440px / 900px / 720px 세 폭 모두입니다. 특히 다음을 봐 주세요.
   - **확정 흐름 전체** — 확인 모달 → 확정 → 완료 모달 → [확인] → 리로드. 발표 시연 마지막 단계라 여기가 제일 중요합니다
   - **스텝퍼가 `<ol>`/`<li>` 로 바뀐 뒤 10칸 레이아웃** — 좁은 폭에서 어떻게 감기는지
   - **`mid-grid` 2단 전환 기준이 1150px → 1023px 로 바뀌었습니다.** 1024~1150px 구간에서 예전에는 1단이던 것이 이제 2단입니다. 의도한 변경이지만(프로젝트 브레이크포인트에 맞춤) 실제로 보기에 좁지 않은지 확인 부탁드립니다
   - 폴링 오류 경고가 실제로 뜨는지 (네트워크를 잠깐 끊어 보면 됩니다)

3. **`CREATED` / `RUNNING` 톤 분리와 `FINALIZED` 유지 판단**을 봐 주세요 (3번 ③). VRUN 상태 배지는 목업(`FGC-UI-VRUN-W01`)이 정한 4색을 그대로 쓰고 있었는데, 규칙 4 의 5색으로 늘렸습니다. 목업을 정본으로 볼지 화면정의서를 정본으로 볼지 판단이 필요하면 알려 주세요.

4. **스텝퍼 상태 클래스명(`fgc-stepper__step--*`)을 남긴 판단**을 봐 주세요 (3번 ⑤). Controller 가 계산해 내려주는 문자열이라 이름을 바꾸려면 백엔드를 고쳐야 하는데 이 이슈에서는 금지입니다. 후속 이슈로 Controller 와 함께 정리하는 것을 제안합니다(9번 별도 이슈 2번).

5. **PRG Toast 를 `data-*` 로 넘기는 방식**이 괜찮은지 봐 주세요. 뒤로가기 재표시를 막으려고 읽은 뒤 `delete main.dataset[...]` 로 지웁니다. 서버 플래시 자체는 그대로 두었으므로 JS 가 죽으면 알림이 사라집니다(전에는 배너라 남았습니다) — 이 트레이드오프가 맞는지 확인 부탁드립니다.

6. **재실행 멱등성 확인 카드는 만들지 않았습니다.** 목업 `:170-171` 과 화면정의서 `:198` ⑩ 이 발표 시연 포인트로 지목하지만, API 응답에 "중복 0건" 정보가 없습니다. 이슈의 "API 가 주지 않는 값을 만들어 넣지 않는다" 에 따라 백엔드 요청 항목으로 올렸습니다(9번).

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다. (기준 커밋 `0a2796ae` = 작업 시점 `origin/develop` HEAD)
* [x] 로컬 빌드에 성공했습니다. (`./gradlew build` BUILD SUCCESSFUL)
* [ ] 애플리케이션 실행을 확인했습니다. — **못 했습니다.** 6번 2번 참조
* [ ] 관련 기능을 직접 테스트했습니다. — **브라우저 수동 테스트를 못 했습니다.** 6번 2번 참조
* [x] 테스트 코드가 필요한 경우 작성했습니다. (구조 테스트 1건 신설, 기존 단언 교체)
* [x] 기존 기능에 영향이 없는지 확인했습니다. (전체 1151건 통과, 두 템플릿은 `ValidationRunViewControllerTest` 가 실제 렌더링으로 검증)
* [x] 커밋 메시지 컨벤션을 준수했습니다. (`refactor(vrun): …`)
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다. (DB 관련 파일 미변경)
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

**구조 테스트**

- `validationRunScreensUseCommonComponentsWithoutInlinePresentation()` — **신설**. 두 템플릿의 공통 컴포넌트 전환·`onchange` 재발 방지·모달 2종·KPI 카드·스텝퍼 텍스트 대체·비활성 사유 전달, 프래그먼트와 JS 배지 매핑 일치, `vrun-list.js` 의 플래시 소비, `vrun.css` 의 미디어쿼리·`:focus-visible` 을 고정
- 기존 `.contains("window.confirm")` → `.contains("modal.open(\"vrun-finalize\"))` + `.doesNotContain("window.confirm")` 으로 교체 (이슈 지시)
- `templates/vrun/{list,detail}.html` 을 `BRIDGE_SCOPED_TEMPLATES` → `FULLY_MIGRATED_TEMPLATES` 로 이동
- 기존 계약은 전부 유지 — `id="cond-body" aria-live="polite"`, `data-checklist-passed`, `data-can-finalize`, `id="finalize-action-guide"`·`id="btn-finalize"` 유일성, `/finalize-checklist`·`/finalize"`, `safeInternalLink`, `checklist.conditions.length !== 6`, `idempotencyKey`, `error.code === "FGC-VRUN-006"`, `runStatus !== "COMPLETED"`, 송금·회계 마감 아님 문구, `doesNotContain("fetch(")`

## 🖼️ 8. 화면 변경

* **VRUN-W01 월 통합검증 실행 목록** (`/validation-runs`)
    - 화면 설명문 삭제, Spring Batch 안내가 `guidance` 톤으로 변경
    - **실행 생성 성공·실패가 상단 배너 → 우상단 Toast 로**
    - **상태 필터가 선택 즉시 조회 → [조회] 버튼을 눌러야 조회**
    - 표가 공통 스타일로 바뀌고 컬럼 폭이 `<colgroup>` 기준으로 재조정
    - 상태 배지 색 변경 — 생성됨(주황→회색), 실행중(주황→파랑), 확정에 자물쇠
    - 실패 사유·확정자가 길면 `전체 보기 / 접기`
    - 시작·완료 일시가 `MM-dd HH:mm` → `yyyy-MM-dd HH:mm`
    - 페이지네이션이 [이전]/[다음] 텍스트 버튼 → 공통 화살표 버튼
* **VRUN-W02 월 통합검증 상세·확정** (`/validation-runs/{id}`)
    - 화면 설명문 삭제, 확정 경고 배너가 `guidance-warning` 톤으로 변경
    - **실행 선택이 고르면 즉시 이동 → [이동] 버튼을 눌러야 이동**
    - **진행률 % 텍스트가 새로 표시됨** (스텝퍼 위)
    - 스텝퍼 카드 디자인 변경, "사람이 수행" 표기가 별도 줄로
    - ③대상 선별 표에 컬럼 폭 지정 + 긴 사유 `전체 보기`
    - **④결과 요약·예외 생성 결과가 KPI 카드로** (숫자가 크게, 부가 설명이 아래로)
    - ⑤체크리스트가 카드 목록으로, 미통과 항목에 **[바로가기] 링크가 별도 표시**
    - **[확정] 을 누르면 확인 모달이 뜹니다** (기존에는 브라우저 기본 대화상자)
    - **확정 성공 시 완료 모달이 뜹니다** (기존에는 알림이 보이지 않았음)
    - 확정 후 버튼 라벨이 "확정" → **"확정됨"**
    - 비활성 버튼의 사유가 툴팁 → **버튼 아래 가시 텍스트**
    - **2단 그리드가 1단으로 접히는 폭이 1150px → 1023px 로 변경**

## 💬 9. 참고 사항

### 백엔드 요청 (이 PR 에서 고치지 않음)

1. **MPA PRG 경로가 오류코드 매핑표를 타지 못합니다.** `GlobalExceptionHandler` 가 `@RestController` 로만 범위 제한되어 있어 `POST /validation-runs` 의 `FGC-VRUN-001` 이 서버 `errorMessage` 문자열로만 내려옵니다. Toast 로 옮겼지만 **코드는 여전히 화면에 나타나지 않습니다** — 인터페이스정의서 `:236-241` 과 어긋납니다. 플래시에 `errorCode` 를 함께 담아 주시면 화면에서 바로 병기하겠습니다.
2. **재실행 멱등성 정보가 없습니다.** 화면정의서 `:198` ⑩ "다시 실행해도 중복 0건" 이 발표 시연 포인트이고 목업 `:170-171` 에 카드가 있는데, IF-API-47/49 응답 어디에도 중복 검출 수가 없습니다. 값을 만들어 넣지 않고 보고합니다.

### 별도 이슈 필요

1. **`syncTableCellDisclosures` 중복** — 같은 함수가 `audit`·`base`·`cap`·`contract`·`dashboard`·`exception`·`policy`·`reco`, 그리고 이번 `vrun` 2곳까지 화면마다 각자 있습니다. 공통 유틸로 뽑는 게 맞지만 10개 파일을 동시에 건드려야 해서 #138 하위 별도 이슈로 제안합니다.
2. **스텝퍼 클래스명 정리** — `ValidationRunViewController.stepClass()` 가 `fgc-stepper__step--*` 를 내려주는 한 프론트만으로는 이름을 못 바꿉니다. Controller 와 `vrun-detail.js`, `vrun.css` 를 한 번에 고치는 이슈가 필요합니다. `assets/fgc.css:159-182` 의 원본 `.fgc-stepper` 도 그때 함께 정리하면 됩니다.
3. **`publishing-page` 일괄 제거 시점** — 이번에 VRUN 2화면에서 뗐지만 `transaction`·`ledger`·`exception` 등은 아직 붙어 있습니다. `PublishingTemplateStructureTest:51-56` 주석이 "떼는 시점은 `assets/fgc.css` 정리와 함께 판단한다 (#138 완료 조건)" 로 미뤄 둔 상태라, 남은 화면은 한 번에 정리하는 쪽을 제안합니다.

### 검증 수치

| 지표 | 전 | 후 |
|---|---|---|
| `detail.html` 인라인 `style=` | 32 | 0 |
| `list.html` 인라인 `style=` | 33 | 0 |
| `detail.html` `class="fgc-*"` | 61 | 0 |
| `list.html` `class="fgc-*"` | 40 | 0 |
| `publishing-result-placeholder` | 14 | 0 |
| 두 템플릿 `aria-hidden` | 0 | 22 |
| `vrun.css` 줄수 / 토큰 사용 | 16 / 3 | 443 / 66 |
| `vrun.css` `:focus-visible` | 0 | 6 |
| 상태 배지 매핑 벌수 | 4 | 2 (서버 프래그먼트 1 + JS 1) |

`rg '#[0-9a-fA-F]{3,8}'` 를 `vrun.css` 에 돌리면 3건이 나오는데 전부 주석의 이슈 번호(`#286`·`#293`·`#285`)입니다. **색상 하드코딩은 0건**입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * VRUN 실행 목록과 상세 화면을 공통 UI로 개편했습니다.
  * 실행 상태, 진행률, 단계별 진행 상황과 결과 요약을 확인할 수 있습니다.
  * 확정 조건 체크리스트와 확인·완료 모달을 추가했습니다.
  * 상태별 배지, 필터, 페이지네이션, 확장 가능한 사유 표시를 제공합니다.

* **개선 사항**
  * 실행 선택 및 상태 필터를 명시적으로 적용하도록 변경했습니다.
  * 처리 실패·복구 상황과 확정 조건을 안내하고, 완료 시 화면을 갱신합니다.
  * 키보드 접근성, 포커스 표시와 반응형 화면 구성을 강화했습니다.
  * 성공·오류 메시지를 Toast로 표시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->