### PR TITLE
[Refactor] EXCP-W01 예외함 페이지 셸 공통 UI 전환 (#290)

### DIFF
--- a/src/main/resources/static/css/features/exception.css
+++ b/src/main/resources/static/css/features/exception.css
@@ -26,7 +26,7 @@
   white-space: nowrap;
 }
 
-.exception-summary-grid > .publishing-empty-state {
+.exception-summary-empty {
   grid-column: 1 / -1;
 }
 
@@ -37,30 +37,25 @@
   margin-top: var(--space-4);
 }
 
-.exception-table-viewport {
-  overflow-x: auto;
-  overscroll-behavior-inline: contain;
-}
-
-.publishing-page .exception-table {
+.exception-table {
   width: 100%;
   min-width: 75rem;
   table-layout: fixed;
 }
 
-.publishing-page .exception-table th,
-.publishing-page .exception-table td {
+.exception-table th,
+.exception-table td {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.publishing-page .exception-table .exception-title-cell {
+.exception-table .exception-title-cell {
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.publishing-page .exception-table td.exception-disclosure-cell {
+.exception-table td.exception-disclosure-cell {
   height: auto;
   padding-block: var(--space-2);
   overflow: visible;
@@ -477,4 +472,64 @@
   .exception-summary-grid {
     grid-template-columns: minmax(0, 1fr);
   }
+}
+
+/* ───────── 페이지 셸 전환으로 새로 필요한 규칙 (#286 후속 #290) ───────── */
+
+.exception-page {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-4);
+}
+
+/* 공통 filter-bar 위에 폭만 얹는다 — 예전에는 인라인 min-width 였다. */
+.exception-filter-fields {
+  flex: 1 1 auto;
+}
+
+.exception-filter-wide { width: 11.875rem; }
+.exception-filter-mid { width: 9.375rem; }
+.exception-filter-narrow { width: 8.75rem; }
+
+.exception-filter-actions {
+  flex: 0 0 auto;
+}
+
+.exception-summary-empty {
+  grid-column: 1 / -1;
+}
+
+.exception-count-note {
+  font-size: 0.75rem;
+}
+
+.exception-card-note {
+  font-size: 0.6875rem;
+}
+
+.exception-placeholder {
+  font-size: 0.8125rem;
+}
+
+.exception-occurrence-meta {
+  margin-top: var(--space-1);
+}
+
+.exception-history-reason {
+  margin-top: var(--space-1);
+}
+
+.exception-evidence {
+  margin-top: var(--space-1);
+}
+
+.exception-evidence-list {
+  margin-top: var(--space-1);
+  font-size: 0.75rem;
+  list-style: none;
+}
+
+.exception-table-viewport:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: -2px;
 }

--- a/src/main/resources/static/css/features/exception.css
+++ b/src/main/resources/static/css/features/exception.css
@@ -64,6 +64,32 @@
   white-space: normal;
 }
 
+/*
+ * 펼친 내용은 반드시 칸 폭 안에서 줄바꿈한다.
+ *
+ * 이 칸은 세로로 늘어나야 해서 overflow: visible 이라 넘친 내용이 잘리지 않고 그대로 흘러나간다.
+ * 그런데 참조는 마지막 열이라 오른쪽으로 흘러나가면 표 바깥이고, 뷰포트의 가로 스크롤 범위는
+ * 표 너비로만 잡히므로 스크롤을 끝까지 밀어도 닿지 않는 영역에서 잘린다.
+ * (계약·상세 원인 칸도 같은 disclosure 를 쓰므로 함께 묶는다.)
+ */
+.exception-table .table-cell-full {
+  max-width: 100%;
+}
+
+/*
+ * 참조 링크는 버튼 모양인데 .button 의 min-width: 6rem 과 white-space: nowrap 때문에
+ * 8rem 짜리 참조 칸을 그대로 넘어선다. 여기서는 줄바꿈되는 링크로 쓴다.
+ */
+.exception-table .table-cell-full .button {
+  min-width: 0;
+  max-width: 100%;
+  height: auto;
+  padding-block: var(--space-1);
+  overflow-wrap: anywhere;
+  text-align: left;
+  white-space: normal;
+}
+
 .exception-col-number {
   width: 4rem;
 }

--- a/src/main/resources/static/js/features/exception/exception-list.js
+++ b/src/main/resources/static/js/features/exception/exception-list.js
@@ -45,8 +45,27 @@
 
   if (!detailBody || !occurrenceBody || !historyBody || !selectedBadge) return;
 
+  const format = window.FgcUi && window.FgcUi.format;
+
+  /*
+   * 표시 형식은 공통 유틸만 쓴다 (FGC-SIR-008).
+   * 전에는 문자열을 잘라 쓰느라 서버가 UTC 로 준 값이 그대로 노출됐다 — format.dateTime 은
+   * Asia/Seoul 로 환산한다. 유틸이 없으면 예전 동작으로 떨어진다.
+   */
   function formatActionTime(value) {
+    if (format) return format.dateTime(value);
     return value ? value.replace("T", " ").slice(0, 16) : "-";
+  }
+
+  function money(value) {
+    if (format) return format.won(value);
+    return `${Number(value).toLocaleString("ko-KR")}원`;
+  }
+
+  /* 오류 문구에 오류코드와 요청 ID 를 병기한다 (FGC-SIR-007). */
+  function errorText(error, fallback) {
+    if (format) return format.errorText(error, fallback);
+    return (error && error.message) || fallback;
   }
 
   function appendHistory(action, actionLabel) {
@@ -172,7 +191,7 @@
           window.FgcUi.modal.open(`journal-correction-${form.dataset.exceptionId}`);
         }
       }).catch((requestError) => {
-        const message = requestError.message || "처리 내용을 저장하지 못했습니다.";
+        const message = errorText(requestError, "처리 내용을 저장하지 못했습니다.");
         error.textContent = message;
         if (toast) toast(message, "error");
         updateSubmit();
@@ -271,7 +290,7 @@
     date.textContent = `분개일 ${journal.journalDate}`;
     const amount = document.createElement("span");
     amount.className = "fgc-muted";
-    amount.textContent = `차변 ${Number(journal.debitTotal).toLocaleString("ko-KR")}원 · 대변 ${Number(journal.creditTotal).toLocaleString("ko-KR")}원`;
+    amount.textContent = `차변 ${money(journal.debitTotal)} · 대변 ${money(journal.creditTotal)}`;
     const status = document.createElement("span");
     status.className = "fgc-muted";
     status.textContent = `원장상태 ${journal.statusLabel}`;
@@ -312,8 +331,8 @@
       const values = [
         line.lineNo,
         `${line.accountCode} · ${line.accountName || "-"}`,
-        `${Number(line.debitAmount).toLocaleString("ko-KR")}원`,
-        `${Number(line.creditAmount).toLocaleString("ko-KR")}원`,
+        money(line.debitAmount),
+        money(line.creditAmount),
         line.memo || "-"
       ];
       values.forEach((value) => {
@@ -456,7 +475,9 @@
         form.replaceWith(completed);
         if (toast) toast("원장 정정을 완료했습니다.", "success");
       }).catch((requestError) => {
-        error.textContent = requestError.message || "원장 정정을 완료하지 못했습니다.";
+        const message = errorText(requestError, "원장 정정을 완료하지 못했습니다.");
+        error.textContent = message;
+        if (toast) toast(message, "error");
         submitButton.disabled = false;
       });
     });

--- a/src/main/resources/templates/exception/list.html
+++ b/src/main/resources/templates/exception/list.html
@@ -21,10 +21,14 @@
       xmlns:th="http://www.thymeleaf.org"
       xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <body>
-<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-exception"
+<main id="main-content" class="page-content exception-page"
       th:attr="data-selected-exception-id=${selectedExceptionId}">
 
-  <h1 class="fgc-page-title">예외함</h1>
+  <header class="page-header">
+    <div class="page-header-copy">
+      <h1 class="page-title">예외함</h1>
+    </div>
+  </header>
 
   <!-- ① 유형별 미처리 요약 -->
   <section class="exception-summary-grid" id="summary-cards" aria-label="유형별 미처리 요약">
@@ -52,43 +56,45 @@
         <span class="kpi-unit">건</span>
       </div>
       <div class="kpi-card-footer">
-        <span class="kpi-comparison fgc-mono" th:text="${summary.type()}">EXCEPTION_TYPE</span>
+        <span class="kpi-comparison tabular-nums" th:text="${summary.type()}">EXCEPTION_TYPE</span>
       </div>
     </a>
-    <div class="fgc-empty publishing-empty-state" th:if="${casePage.summary().isEmpty()}">미처리 예외가 없습니다.</div>
+    <p class="empty-state exception-summary-empty" th:if="${casePage.summary().isEmpty()}">미처리 예외가 없습니다.</p>
   </section>
 
   <!-- ② 검색 — IF-API-43 쿼리스트링을 그대로 사용해 뒤로가기와 공유가 가능하다. -->
-  <section class="fgc-card" style="margin-top:16px">
-    <form class="fgc-card__body fgc-toolbar" method="get" th:action="@{/exceptions}">
-      <div class="fgc-field" style="min-width:190px">
-        <label class="fgc-label" for="f-type">예외 유형</label>
-        <select class="fgc-select" id="f-type" name="type">
+  <!-- 가이드 §8 표준 필터 구조. name·쿼리 파라미터·id 는 그대로 두고 골격만 바꿨다. -->
+  <form class="filter-bar exception-filter-bar" method="get" th:action="@{/exceptions}"
+        aria-label="예외함 검색 조건">
+    <div class="filter-fields exception-filter-fields">
+      <div class="filter-field exception-filter-wide">
+        <label class="filter-field-label" for="f-type">예외 유형</label>
+        <select class="select-control" id="f-type" name="type">
           <option value="">전체</option>
           <option th:each="type : ${exceptionTypes}" th:value="${type}" th:text="${type.label()}"
                   th:selected="${typeFilter == type}">예외 유형</option>
         </select>
       </div>
-      <div class="fgc-field" style="min-width:190px">
-        <label class="fgc-label" for="f-reason">상세 원인</label>
-        <select class="fgc-select" id="f-reason" name="reasonCode">
+      <div class="filter-field exception-filter-wide">
+        <label class="filter-field-label" for="f-reason">상세 원인</label>
+        <select class="select-control" id="f-reason" name="reasonCode">
           <option value="">전체</option>
           <option th:each="reasonEntry : ${exceptionReasonLabels}" th:value="${reasonEntry.key}"
                   th:text="${reasonEntry.value}"
                   th:selected="${reasonCodeFilter == reasonEntry.key}">상세 원인</option>
         </select>
       </div>
-      <div class="fgc-field" style="min-width:130px">
-        <label class="fgc-label" for="f-severity">심각도</label>
-        <select class="fgc-select" id="f-severity" name="severity">
+      <div class="filter-field exception-filter-narrow">
+        <label class="filter-field-label" for="f-severity">심각도</label>
+        <select class="select-control" id="f-severity" name="severity">
           <option value="">전체</option>
           <option th:each="severity : ${exceptionSeverities}" th:value="${severity}" th:text="${severity.label()}"
                   th:selected="${severityFilter == severity}">심각도</option>
         </select>
       </div>
-      <div class="fgc-field" style="min-width:140px">
-        <label class="fgc-label" for="f-status">상태</label>
-        <select class="fgc-select" id="f-status" name="status" onchange="this.form.submit()">
+      <div class="filter-field exception-filter-narrow">
+        <label class="filter-field-label" for="f-status">상태</label>
+        <select class="select-control" id="f-status" name="status">
           <option value="OPEN" th:selected="${statusFilter == 'OPEN'}">미처리 (신규 + 검토중)</option>
           <option value="" th:selected="${statusFilter == ''}">전체</option>
           <option value="NEW" th:selected="${statusFilter == 'NEW'}">신규</option>
@@ -97,11 +103,11 @@
           <option value="REJECTED" th:selected="${statusFilter == 'REJECTED'}">오탐·반려</option>
         </select>
       </div>
-      <div class="fgc-field" style="min-width:140px">
-        <label class="fgc-label" for="f-assignee">담당자</label>
+      <div class="filter-field exception-filter-narrow">
+        <label class="filter-field-label" for="f-assignee">담당자</label>
         <!-- (미배정)까지 한 select 라 화면 전용 assigneeFilter 로 보내고 서버가
              unassignedOnly/assignee 검색조건으로 푼다. 선택지는 배정 이력이 있는 사용자만. -->
-        <select class="fgc-select" id="f-assignee" name="assigneeFilter">
+        <select class="select-control" id="f-assignee" name="assigneeFilter">
           <option value="">전체</option>
           <option value="unassigned" th:selected="${assigneeFilter == 'unassigned'}">(미배정)</option>
           <option th:each="assigneeOption : ${exceptionAssignees}" th:value="${assigneeOption.userId()}"
@@ -109,41 +115,45 @@
                   th:selected="${assigneeFilter == assigneeOption.userId() + ''}">담당자</option>
         </select>
       </div>
-      <div class="fgc-field" style="min-width:130px">
-        <label class="fgc-label" for="f-validation-month">검증월</label>
+      <div class="filter-field exception-filter-narrow">
+        <label class="filter-field-label" for="f-validation-month">검증월</label>
         <!-- 화면정의서 ② 검색의 '기간' 구현체 — 예외가 검출된 검증월(validation_month) 단위.
              VRUN-W02 '예외함 열기' 링크도 이 파라미터로 들어와 카드 건수와 목록이 일치한다. -->
-        <select class="fgc-select" id="f-validation-month" name="validationMonth">
+        <select class="select-control" id="f-validation-month" name="validationMonth">
           <option value="">전체</option>
           <option th:each="monthOption : ${exceptionValidationMonths}" th:value="${monthOption}"
                   th:text="${#temporals.format(monthOption, 'yyyy-MM')}"
                   th:selected="${validationMonthFilter == monthOption}">검증월</option>
         </select>
       </div>
-      <div class="fgc-field" style="min-width:150px">
-        <label class="fgc-label" for="f-contract">계약번호</label>
-        <input class="fgc-input" id="f-contract" name="contractNo" type="text" placeholder="계약번호 입력"
+      <div class="filter-field exception-filter-mid">
+        <label class="filter-field-label" for="f-contract">계약번호</label>
+        <input class="field-control" id="f-contract" name="contractNo" type="text" placeholder="계약번호 입력"
                th:value="${contractNoFilter}">
       </div>
-      <button class="fgc-btn fgc-btn--primary" type="submit">조회</button>
-      <a class="fgc-btn fgc-btn--ghost" id="f-reset" th:href="@{/exceptions}">
-        <span class="material-symbols-outlined" style="font-size:18px">restart_alt</span> 초기화
+    </div>
+    <div class="filter-actions exception-filter-actions">
+      <a class="button button-secondary" id="f-reset" th:href="@{/exceptions}">
+        <span class="material-symbols-rounded" aria-hidden="true">restart_alt</span>초기화
       </a>
-    </form>
-  </section>
+      <button class="button button-primary" type="submit">
+        <span class="material-symbols-rounded" aria-hidden="true">search</span>조회
+      </button>
+    </div>
+  </form>
 
   <div class="exception-work-grid" id="work-grid">
 
     <!-- ③ 목록 -->
-    <section class="fgc-card">
-      <div class="fgc-card__head">
-        <span class="fgc-card__title">예외 목록</span>
-        <span class="fgc-muted" style="font-size:12px">
+    <section class="surface">
+      <div class="surface-header">
+        <span class="surface-title">예외 목록</span>
+        <span class="text-secondary exception-count-note">
           <span id="row-count" th:text="${casePage.totalElements()}">0</span>건
         </span>
       </div>
-      <div class="exception-table-viewport">
-        <table class="fgc-table exception-table">
+      <div class="data-table-viewport exception-table-viewport" tabindex="0" role="region" aria-label="예외 목록 표">
+        <table class="data-table exception-table">
           <colgroup>
             <col class="exception-col-number">
             <col class="exception-col-type">
@@ -177,15 +187,28 @@
                 th:with="typeCode=${c.type().name()},severityCode=${c.severity().name()},statusCode=${c.status().name()}"
                 tabindex="0" aria-controls="detail-body history-body" aria-selected="false"
                 th:attr="data-exception-id=${c.exceptionCaseId()},data-status=${c.status()},data-exception-type=${c.type()}">
-              <td class="fgc-mono" th:text="${c.exceptionCaseId()}">-</td>
+              <td class="tabular-nums" th:text="${c.exceptionCaseId()}">-</td>
               <td><span class="status-badge"
                         th:classappend="${typeCode == 'CAP_WARNING' or typeCode == 'ARBITRAGE_CANDIDATE' or typeCode == 'ALLOCATION_EVIDENCE_MISSING'} ? ' status-badge-warning' : (${typeCode == 'CAP_VIOLATION' or typeCode == 'RECONCILIATION_MISMATCH' or typeCode == 'JOURNAL_IMBALANCE' or typeCode == 'POLICY_MISSING' or typeCode == 'POLICY_DUPLICATE'} ? ' status-badge-error' : (${typeCode == 'CAP_REVIEW_REQUIRED' or typeCode == 'REFUND_TABLE_MISSING' or typeCode == 'PRODUCT_CODE_MISMATCH' or typeCode == 'DATA_QUALITY'} ? ' status-badge-review' : ' status-badge-neutral'))"
                         th:title="${typeCode}" th:text="${c.type().label()}">-</span></td>
-              <td th:text="${c.reasonLabel()}">-</td>
+              <!-- exception-col-reason 은 좁은 폭인데 disclosure 가 빠져 있어 잘리면 값을 볼 수 없었다 (PR #269 리뷰 지적) -->
+              <td class="exception-disclosure-cell">
+                <div class="table-cell-disclosure">
+                  <span class="table-cell-preview is-single-line" th:text="${c.reasonLabel()} ?: '-'">상세 원인</span>
+                  <details class="table-cell-details" hidden>
+                    <summary>
+                      <span class="table-cell-more">전체 보기</span>
+                      <span class="table-cell-less">접기</span>
+                      <span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span>
+                    </summary>
+                    <p class="table-cell-full" th:text="${c.reasonLabel()} ?: '-'">상세 원인</p>
+                  </details>
+                </div>
+              </td>
               <td><span class="status-badge"
                         th:classappend="${severityCode == 'WARNING'} ? ' status-badge-warning' : (${severityCode == 'HIGH' or severityCode == 'CRITICAL'} ? ' status-badge-error' : ' status-badge-neutral')"
                         th:title="${severityCode}" th:text="${c.severity().label()}">-</span></td>
-              <td class="fgc-mono exception-disclosure-cell">
+              <td class="tabular-nums exception-disclosure-cell">
                 <div class="table-cell-disclosure">
                   <span class="table-cell-preview is-single-line" th:text="${c.contractNo()} ?: '-'">계약번호</span>
                   <details class="table-cell-details" hidden>
@@ -215,10 +238,10 @@
                         th:classappend="${statusCode == 'NEW'} ? ' status-badge-error' : (${statusCode == 'IN_REVIEW'} ? ' status-badge-info' : (${statusCode == 'RESOLVED'} ? ' status-badge-success' : ' status-badge-review'))"
                         th:title="${statusCode}" th:text="${c.status().label()}">-</span></td>
               <td data-role="assignee" th:text="${c.assigneeLoginId()} ?: '미배정'">-</td>
-              <td class="fgc-mono" th:text="${#temporals.format(c.lastDetectedAt(), 'yyyy-MM-dd HH:mm')}">-</td>
-              <td class="fgc-mono" th:text="|${c.detectionCount()}회|">1회</td>
+              <td class="tabular-nums" th:text="${#temporals.format(c.lastDetectedAt(), 'yyyy-MM-dd HH:mm')}">-</td>
+              <td class="tabular-nums" th:text="|${c.detectionCount()}회|">1회</td>
               <!-- 참조 = 원천 화면 링크. 라우트가 없는 원천 유형은 텍스트로만 표시한다. -->
-              <td class="fgc-mono exception-disclosure-cell"
+              <td class="tabular-nums exception-disclosure-cell"
                   th:with="referenceValue=|${c.sourceEntityType()}:${c.sourceEntityId()}|">
                 <div class="table-cell-disclosure">
                   <a class="table-cell-preview is-single-line"
@@ -233,7 +256,7 @@
                       <span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span>
                     </summary>
                     <p class="table-cell-full">
-                      <a class="fgc-btn fgc-btn--ghost" th:if="${c.sourceLink() != null}" th:href="@{${c.sourceLink()}}">
+                      <a class="button button-secondary" th:if="${c.sourceLink() != null}" th:href="@{${c.sourceLink()}}">
                         <span class="material-symbols-outlined" aria-hidden="true">open_in_new</span>
                         <span th:text="${referenceValue}">참조</span>
                       </a>
@@ -243,7 +266,7 @@
                 </div>
               </td>
             </tr>
-            <tr th:if="${cases.isEmpty()}"><td colspan="11"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
+            <tr th:if="${cases.isEmpty()}"><td colspan="11"><p class="empty-state" role="status" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</p></td></tr>
           </tbody>
         </table>
       </div>
@@ -284,33 +307,33 @@
     <!-- ④ 처리 패널 + ⑤ 이력 -->
     <div class="exception-side-panels">
 
-      <section class="fgc-card">
-        <div class="fgc-card__head">
-          <span class="fgc-card__title">검출 이력</span>
-          <span class="fgc-muted" style="font-size:11px">실행별 증거는 고치거나 지울 수 없습니다</span>
+      <section class="surface">
+        <div class="surface-header">
+          <span class="surface-title">검출 이력</span>
+          <span class="text-secondary exception-card-note">실행별 증거는 고치거나 지울 수 없습니다</span>
         </div>
-        <div class="fgc-card__body" id="occurrence-body">
-          <p class="fgc-muted" style="font-size:13px;margin:0">—</p>
+        <div class="surface-body" id="occurrence-body">
+          <p class="text-secondary exception-placeholder">—</p>
         </div>
       </section>
 
-      <section class="fgc-card">
-        <div class="fgc-card__head">
-          <span class="fgc-card__title">처리</span>
+      <section class="surface">
+        <div class="surface-header">
+          <span class="surface-title">처리</span>
           <span id="sel-badge"></span>
         </div>
-        <div class="fgc-card__body" id="detail-body">
-          <p class="fgc-muted" style="font-size:13px;margin:0">왼쪽 목록에서 한 건을 고르세요.</p>
+        <div class="surface-body" id="detail-body">
+          <p class="text-secondary exception-placeholder">왼쪽 목록에서 한 건을 고르세요.</p>
         </div>
       </section>
 
-      <section class="fgc-card">
-        <div class="fgc-card__head">
-          <span class="fgc-card__title">처리 이력</span>
-          <span class="fgc-muted" style="font-size:11px">기록만 쌓입니다. 고치거나 지울 수 없습니다</span>
+      <section class="surface">
+        <div class="surface-header">
+          <span class="surface-title">처리 이력</span>
+          <span class="text-secondary exception-card-note">기록만 쌓입니다. 고치거나 지울 수 없습니다</span>
         </div>
-        <div class="fgc-card__body" id="history-body">
-          <p class="fgc-muted" style="font-size:13px;margin:0">—</p>
+        <div class="surface-body" id="history-body">
+          <p class="text-secondary exception-placeholder">—</p>
         </div>
       </section>
     </div>
@@ -321,7 +344,7 @@
     <template th:id="|exception-detail-${c.exceptionCaseId()}|">
       <dl class="exception-detail-grid"
           th:with="typeCode=${c.type().name()},severityCode=${c.severity().name()},statusCode=${c.status().name()}">
-        <div><dt>예외 번호</dt><dd class="fgc-mono" th:text="${c.exceptionCaseId()}">-</dd></div>
+        <div><dt>예외 번호</dt><dd class="tabular-nums" th:text="${c.exceptionCaseId()}">-</dd></div>
         <div><dt>상태</dt><dd><span class="status-badge" data-role="status"
              th:classappend="${statusCode == 'NEW'} ? ' status-badge-error' : (${statusCode == 'IN_REVIEW'} ? ' status-badge-info' : (${statusCode == 'RESOLVED'} ? ' status-badge-success' : ' status-badge-review'))"
              th:title="${statusCode}" th:text="${c.status().label()}">-</span></dd></div>
@@ -332,21 +355,21 @@
         <div><dt>심각도</dt><dd><span class="status-badge"
              th:classappend="${severityCode == 'WARNING'} ? ' status-badge-warning' : (${severityCode == 'HIGH' or severityCode == 'CRITICAL'} ? ' status-badge-error' : ' status-badge-neutral')"
              th:title="${severityCode}" th:text="${c.severity().label()}">-</span></dd></div>
-        <div><dt>계약번호</dt><dd class="fgc-mono" th:text="${c.contractNo()} ?: '-'">-</dd></div>
+        <div><dt>계약번호</dt><dd class="tabular-nums" th:text="${c.contractNo()} ?: '-'">-</dd></div>
         <div><dt>담당자</dt><dd data-role="assignee" th:text="${c.assigneeLoginId()} ?: '미배정'">-</dd></div>
         <div><dt>설계사</dt><dd th:text="${c.agentName()} ?: '-'">-</dd></div>
-        <div><dt>검증월</dt><dd class="fgc-mono"
+        <div><dt>검증월</dt><dd class="tabular-nums"
              th:text="${c.validationMonth() != null} ? ${#temporals.format(c.validationMonth(), 'yyyy-MM')} : '—'">-</dd></div>
-        <div><dt>최초 검출 실행</dt><dd class="fgc-mono" th:text="${c.firstDetectedRunId()} ?: '—'">-</dd></div>
-        <div><dt>최근 검출 실행</dt><dd class="fgc-mono" th:text="${c.lastDetectedRunId()} ?: '—'">-</dd></div>
-        <div><dt>검출 횟수</dt><dd class="fgc-mono" th:text="|${c.detectionCount()}회|">1회</dd></div>
-        <div><dt>최초 검출</dt><dd class="fgc-mono" th:text="${#temporals.format(c.firstDetectedAt(), 'yyyy-MM-dd HH:mm')}">-</dd></div>
-        <div><dt>최근 검출</dt><dd class="fgc-mono" th:text="${#temporals.format(c.lastDetectedAt(), 'yyyy-MM-dd HH:mm')}">-</dd></div>
+        <div><dt>최초 검출 실행</dt><dd class="tabular-nums" th:text="${c.firstDetectedRunId()} ?: '—'">-</dd></div>
+        <div><dt>최근 검출 실행</dt><dd class="tabular-nums" th:text="${c.lastDetectedRunId()} ?: '—'">-</dd></div>
+        <div><dt>검출 횟수</dt><dd class="tabular-nums" th:text="|${c.detectionCount()}회|">1회</dd></div>
+        <div><dt>최초 검출</dt><dd class="tabular-nums" th:text="${#temporals.format(c.firstDetectedAt(), 'yyyy-MM-dd HH:mm')}">-</dd></div>
+        <div><dt>최근 검출</dt><dd class="tabular-nums" th:text="${#temporals.format(c.lastDetectedAt(), 'yyyy-MM-dd HH:mm')}">-</dd></div>
         <div class="exception-detail-wide"><dt>제목</dt><dd th:text="${c.title()}">-</dd></div>
         <div class="exception-detail-wide"><dt>설명</dt><dd th:text="${c.description()}">-</dd></div>
-        <div class="exception-detail-wide"><dt>참조</dt><dd class="fgc-mono">
-          <a class="fgc-btn fgc-btn--ghost" th:if="${c.sourceLink() != null}" th:href="@{${c.sourceLink()}}">
-            <span class="material-symbols-outlined" aria-hidden="true" style="font-size:16px">open_in_new</span>
+        <div class="exception-detail-wide"><dt>참조</dt><dd class="tabular-nums">
+          <a class="button button-secondary" th:if="${c.sourceLink() != null}" th:href="@{${c.sourceLink()}}">
+            <span class="material-symbols-rounded" aria-hidden="true">open_in_new</span>
             <span th:text="${c.sourceEntityType()} + ':' + ${c.sourceEntityId()}">-</span>
           </a>
           <span th:if="${c.sourceLink() == null}"
@@ -358,9 +381,9 @@
             th:if="${c.status() == newStatus or c.status() == inReviewStatus or c.status() == rejectedStatus}"
             th:attr="data-exception-id=${c.exceptionCaseId()},data-current-status=${c.status()}"
             sec:authorize="hasAnyRole('SETTLEMENT', 'GA_ADMIN', 'SYSTEM_ADMIN')">
-        <label class="fgc-field">
-          <span class="fgc-label">조치</span>
-          <select class="fgc-select" name="actionType" required>
+        <label class="field">
+          <span class="field-label">조치</span>
+          <select class="select-control" name="actionType" required>
             <option value="">조치를 선택하세요</option>
             <option th:each="actionType : ${actionTypes}"
                     th:value="${actionType}" th:text="${actionType.label()}"
@@ -371,19 +394,19 @@
             </option>
           </select>
         </label>
-        <label class="fgc-field">
-          <span class="fgc-label">처리 사유 <span class="field-required" aria-hidden="true">*</span></span>
-          <textarea class="fgc-textarea" name="reason" maxlength="1000" required
+        <label class="field">
+          <span class="field-label">처리 사유 <span class="field-required" aria-hidden="true">*</span></span>
+          <textarea class="textarea-control" name="reason" maxlength="1000" required
                     placeholder="판단 근거와 처리 내용을 입력하세요."></textarea>
         </label>
-        <label class="fgc-field">
-          <span class="fgc-label">증빙</span>
-          <input class="fgc-input" name="evidenceRef" type="text" placeholder="문서번호 또는 링크">
+        <label class="field">
+          <span class="field-label">증빙</span>
+          <input class="field-control" name="evidenceRef" type="text" placeholder="문서번호 또는 링크">
         </label>
-        <p class="fgc-error exception-action-error" data-action-error role="alert"></p>
-        <button class="fgc-btn fgc-btn--primary exception-action-submit" type="submit" disabled>처리 저장</button>
+        <p class="field-error exception-action-error" data-action-error role="alert"></p>
+        <button class="button button-primary exception-action-submit" type="submit" disabled>처리 저장</button>
       </form>
-      <button class="fgc-btn fgc-btn--ghost journal-correction-open"
+      <button class="button button-secondary journal-correction-open"
               type="button" data-journal-correction-open
               th:if="${c.type().name() == 'JOURNAL_CORRECTION_REQUIRED'}"
               th:hidden="${c.status() == newStatus}"
@@ -428,7 +451,7 @@
                     <h3 class="surface-title journal-correction-section-title">원분개 (읽기 전용)</h3>
                   </header>
                   <div class="journal-correction-panel-body" data-original-journal>
-                    <p class="fgc-muted">원분개를 불러오는 중입니다.</p>
+                    <p class="text-secondary">원분개를 불러오는 중입니다.</p>
                   </div>
                 </section>
                 <section class="surface journal-correction-panel" aria-label="신규 재기표 입력"
@@ -437,16 +460,16 @@
                     <h3 class="surface-title journal-correction-section-title">신규 재기표 입력</h3>
                   </header>
                   <div class="journal-correction-panel-body journal-correction-inputs">
-                    <label class="fgc-field">
-                      <span class="fgc-label">새 분개일 <span class="field-required" aria-hidden="true">*</span></span>
-                      <input class="fgc-input" name="journalDate" type="date" required>
+                    <label class="field">
+                      <span class="field-label">새 분개일 <span class="field-required" aria-hidden="true">*</span></span>
+                      <input class="field-control" name="journalDate" type="date" required>
                     </label>
-                    <label class="fgc-field">
-                      <span class="fgc-label">새 분개 설명 <span class="field-required" aria-hidden="true">*</span></span>
-                      <input class="fgc-input" name="description" maxlength="1000" required placeholder="올바른 분개 내용을 입력하세요.">
+                    <label class="field">
+                      <span class="field-label">새 분개 설명 <span class="field-required" aria-hidden="true">*</span></span>
+                      <input class="field-control" name="description" maxlength="1000" required placeholder="올바른 분개 내용을 입력하세요.">
                     </label>
                     <div class="journal-correction-lines" data-correction-lines></div>
-                    <button class="fgc-btn fgc-btn--ghost journal-correction-add-line"
+                    <button class="button button-secondary journal-correction-add-line"
                             type="button" data-add-correction-line disabled>
                       라인 추가
                     </button>
@@ -472,32 +495,32 @@
                 </section>
               </div>
               <div class="surface journal-correction-action-panel" data-correction-editor>
-                <label class="fgc-field">
-                  <span class="fgc-label">정정 사유 <span class="field-required" aria-hidden="true">*</span></span>
-                  <textarea class="fgc-textarea" name="reason" maxlength="1000" required
+                <label class="field">
+                  <span class="field-label">정정 사유 <span class="field-required" aria-hidden="true">*</span></span>
+                  <textarea class="textarea-control" name="reason" maxlength="1000" required
                             placeholder="판단 근거와 실제 정정 내용을 입력하세요."></textarea>
                 </label>
-                <label class="fgc-field">
-                  <span class="fgc-label">증빙</span>
-                  <input class="fgc-input" name="evidenceRef" maxlength="500" type="text" placeholder="문서번호 또는 링크">
+                <label class="field">
+                  <span class="field-label">증빙</span>
+                  <input class="field-control" name="evidenceRef" maxlength="500" type="text" placeholder="문서번호 또는 링크">
                 </label>
-                <p class="fgc-error exception-action-error" data-correction-error role="alert"></p>
-                <button class="fgc-btn fgc-btn--primary exception-action-submit" type="submit" disabled>정정 실행</button>
+                <p class="field-error exception-action-error" data-correction-error role="alert"></p>
+                <button class="button button-primary exception-action-submit" type="submit" disabled>정정 실행</button>
               </div>
             </form>
           </div>
           <footer class="modal-footer journal-correction-modal-footer">
-            <p class="fgc-muted">정정 실행 전 원분개와 신규 분개의 차변·대변을 확인하세요.</p>
-            <button class="fgc-btn fgc-btn--ghost" type="button" data-modal-close>닫기</button>
+            <p class="text-secondary">정정 실행 전 원분개와 신규 분개의 차변·대변을 확인하세요.</p>
+            <button class="button button-secondary" type="button" data-modal-close>닫기</button>
           </footer>
         </section>
       </div>
-      <p class="fgc-muted exception-action-notice"
+      <p class="text-secondary exception-action-notice"
          th:if="${c.status() == newStatus or c.status() == inReviewStatus or c.status() == rejectedStatus}"
          sec:authorize="!hasAnyRole('SETTLEMENT', 'GA_ADMIN', 'SYSTEM_ADMIN')">
         조회 전용 권한입니다.
       </p>
-      <p class="fgc-muted exception-action-notice"
+      <p class="text-secondary exception-action-notice"
          th:unless="${c.status() == newStatus or c.status() == inReviewStatus or c.status() == rejectedStatus}">
         종결된 예외입니다.
       </p>
@@ -506,38 +529,38 @@
       <ol class="exception-history-list" th:if="${!c.occurrences().isEmpty()}">
         <li class="exception-history-item" th:each="occurrence : ${c.occurrences()}">
           <strong th:text="${occurrence.validationMonth()} + ' · ' + ${occurrence.runNo()} + '회차 · ' + ${occurrence.detectionLabel()}">검출</strong>
-          <p class="fgc-muted" style="margin:4px 0 0">
-            실행 <span class="fgc-mono" th:text="${occurrence.validationRunId()}">-</span>
-            · <span class="fgc-mono" th:text="${occurrence.sourceEntityType()} + ':' + ${occurrence.sourceEntityId()}">-</span>
+          <p class="text-secondary exception-occurrence-meta">
+            실행 <span class="tabular-nums" th:text="${occurrence.validationRunId()}">-</span>
+            · <span class="tabular-nums" th:text="${occurrence.sourceEntityType()} + ':' + ${occurrence.sourceEntityId()}">-</span>
           </p>
           <!-- 원시 JSON 대신 알려진 증거 필드만 한글 라벨·콤마 금액으로 푼다.
                전체 스냅샷은 evidence_snapshot 컬럼과 원천 행이 보존한다. -->
-          <details th:if="${!occurrence.evidenceItems().isEmpty()}" style="margin-top:4px">
-            <summary class="fgc-muted">검출 증거</summary>
-            <ul style="margin:4px 0 0;padding:0;list-style:none;font-size:12px">
+          <details class="exception-evidence" th:if="${!occurrence.evidenceItems().isEmpty()}">
+            <summary class="text-secondary">검출 증거</summary>
+            <ul class="exception-evidence-list">
               <li th:each="item : ${occurrence.evidenceItems()}">
-                <span class="fgc-muted" th:text="${item.label()}">항목</span>
-                <span class="fgc-mono" th:text="${item.value()}">값</span>
+                <span class="text-secondary" th:text="${item.label()}">항목</span>
+                <span class="tabular-nums" th:text="${item.value()}">값</span>
               </li>
             </ul>
           </details>
-          <small class="fgc-muted" th:text="${#temporals.format(occurrence.detectedAt(), 'yyyy-MM-dd HH:mm')}">검출 시각</small>
+          <small class="text-secondary" th:text="${#temporals.format(occurrence.detectedAt(), 'yyyy-MM-dd HH:mm')}">검출 시각</small>
         </li>
       </ol>
-      <p class="fgc-muted" style="font-size:13px;margin:0" th:if="${c.occurrences().isEmpty()}">실행별 검출 이력이 없습니다.</p>
+      <p class="text-secondary exception-placeholder" th:if="${c.occurrences().isEmpty()}">실행별 검출 이력이 없습니다.</p>
     </template>
     <template th:id="|exception-history-${c.exceptionCaseId()}|">
       <ol class="exception-history-list" th:if="${!c.actions().isEmpty()}">
         <li class="exception-history-item" th:each="action : ${c.actions()}">
           <strong th:text="|${action.actionSeq()}. ${action.actionTypeLabel()}|">1. 조치</strong>
-          <span class="fgc-muted"> · <span th:text="${action.fromStatusLabel()}">이전 상태</span> → <span th:text="${action.toStatusLabel()}">현재 상태</span></span>
-          <p style="margin:4px 0 0" th:text="${action.reason()}">사유</p>
-          <p class="fgc-muted" style="margin:4px 0 0" th:if="${action.evidenceRef() != null and !action.evidenceRef().isBlank()}"
+          <span class="text-secondary"> · <span th:text="${action.fromStatusLabel()}">이전 상태</span> → <span th:text="${action.toStatusLabel()}">현재 상태</span></span>
+          <p class="exception-history-reason" th:text="${action.reason()}">사유</p>
+          <p class="text-secondary exception-occurrence-meta" th:if="${action.evidenceRef() != null and !action.evidenceRef().isBlank()}"
              th:text="|증빙: ${action.evidenceRef()}|">증빙</p>
-          <small class="fgc-muted"><span th:text="${action.actionByLoginId()}">처리자</span> · <span th:text="${#temporals.format(action.actionAt(), 'yyyy-MM-dd HH:mm')}">처리 시각</span></small>
+          <small class="text-secondary"><span th:text="${action.actionByLoginId()}">처리자</span> · <span th:text="${#temporals.format(action.actionAt(), 'yyyy-MM-dd HH:mm')}">처리 시각</span></small>
         </li>
       </ol>
-      <p class="fgc-muted" style="font-size:13px;margin:0" th:if="${c.actions().isEmpty()}">처리 이력이 없습니다.</p>
+      <p class="text-secondary exception-placeholder" th:if="${c.actions().isEmpty()}">처리 이력이 없습니다.</p>
     </template>
   </th:block>
 

--- a/src/main/resources/templates/exception/list.html
+++ b/src/main/resources/templates/exception/list.html
@@ -256,8 +256,8 @@
                       <span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span>
                     </summary>
                     <p class="table-cell-full">
+                      <!-- 아이콘은 두지 않는다 — 참조 값 자체가 링크라 같은 뜻을 두 번 말한다. -->
                       <a class="button button-secondary" th:if="${c.sourceLink() != null}" th:href="@{${c.sourceLink()}}">
-                        <span class="material-symbols-outlined" aria-hidden="true">open_in_new</span>
                         <span th:text="${referenceValue}">참조</span>
                       </a>
                       <span th:if="${c.sourceLink() == null}" th:text="${referenceValue}">참조</span>

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -43,7 +43,6 @@ class PublishingTemplateStructureTest {
             "templates/transaction/form.html",
             "templates/schedule/detail.html",
             "templates/ledger/list.html",
-            "templates/exception/list.html",
             "templates/vrun/list.html",
             "templates/vrun/detail.html"
     );
@@ -61,6 +60,7 @@ class PublishingTemplateStructureTest {
             "templates/audit/list.html",
             "templates/contract/form.html",
             "templates/schedule/list.html",
+            "templates/exception/list.html",
             "templates/arbitrage/list.html",
             "templates/error/403.html",
             "templates/error/404.html",
@@ -408,6 +408,33 @@ class PublishingTemplateStructureTest {
 
     @Test
     void exceptionListUsesFlexibleColumnsSharedBadgesAndProductionToast() throws IOException {
+        // 페이지 셸 전환 (#290) — 전에는 셸이 레거시인 채로 이 테스트를 통과했다.
+        assertThat(resource("templates/exception/list.html"))
+                .contains("class=\"page-content exception-page\"")
+                .contains("class=\"page-header\"")
+                .contains("class=\"page-title\"")
+                .contains("class=\"surface\"")
+                .contains("class=\"filter-bar exception-filter-bar\"")
+                .contains("class=\"filter-field-label\"")
+                .contains("class=\"data-table-viewport exception-table-viewport\"")
+                .contains("class=\"data-table exception-table\"")
+                .contains("class=\"empty-state")
+                // 상세 원인 컬럼에도 disclosure 를 넣었다 (PR #269 리뷰 지적)
+                .contains("th:text=\"${c.reasonLabel()} ?: '-'\"")
+                // 필터·행 선택 계약은 골격이 바뀌어도 그대로여야 한다
+                .contains("data-selected-exception-id=${selectedExceptionId}")
+                .contains("id=\"summary-cards\"")
+                .contains("id=\"f-type\"")
+                .contains("id=\"f-reason\"")
+                .contains("id=\"f-reset\"")
+                // select 변경만으로 제출되던 동작을 조회 버튼으로 바꿨다
+                .doesNotContain("onchange=")
+                .doesNotContain("class=\"fgc-")
+                .doesNotContain("publishing-page")
+                .doesNotContain("style=\"")
+                .doesNotContainPattern("(?i)<style[\s>]")
+                .doesNotContainPattern("(?i)<script[\s>]");
+
         assertThat(resource("templates/exception/list.html"))
                 .contains("<colgroup>")
                 .contains("class=\"exception-col-title\"")
@@ -435,6 +462,11 @@ class PublishingTemplateStructureTest {
                 .doesNotContain("<th style=\"width:");
 
         assertThat(resource("static/css/features/exception.css"))
+                // 공통 data-table-viewport 를 복제하던 정의를 걷어냈다 (가이드 §4.2)
+                .doesNotContain("overscroll-behavior-inline")
+                .doesNotContain(".publishing-page .exception-table")
+                .contains(".exception-page")
+                .contains(".exception-filter-fields")
                 .contains(".exception-col-title")
                 .contains(".journal-correction-original-lines")
                 .contains(".journal-correction-original-line.is-heading")
@@ -460,6 +492,10 @@ class PublishingTemplateStructureTest {
                 .contains("preview.scrollHeight > preview.clientHeight")
                 .contains("document.fonts.ready")
                 .contains("toast(message, \"error\")")
+                // 표시 형식과 오류코드·요청 ID 를 공통 유틸로 통일했다 (#290)
+                .contains("format.dateTime(value)")
+                .contains("format.errorText(error, fallback)")
+                .doesNotContain("Number(journal.debitTotal).toLocaleString")
                 .contains("action.actionType === \"START_REVIEW\"")
                 .contains("action.actionType === \"REOPEN\"")
                 .contains("action.toStatus === \"IN_REVIEW\"")


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- EXCP-W01 예외함의 **페이지 셸**을 공통 UI 컴포넌트로 전환했습니다. PR #269 후속입니다.
- 인라인 `style=` 23줄과 `class="fgc-*"` 112개를 걷어냈습니다.
- `exception-table-viewport` 가 공통 `data-table-viewport` 를 복제하고 있던 것을 없앴습니다.
- **상세 원인 컬럼에 빠져 있던 `table-cell-disclosure` 를 넣었습니다** (PR #269 리뷰 지적).
- 일시·금액을 `js/common/format.js` 로 통일하고 오류 문구에 오류코드·요청 ID 를 병기했습니다.

기준 커밋 `0a2796ae` (`origin/develop`) · 4 files changed, +273 / −138

## 🔗 2. 관련 이슈

* Closes #290
* Refs #138, #269

## 🛠 3. 구현 내용

### 착수 전 재검증

이슈 기준 커밋은 `859adffd` 인데 develop 이 그 뒤로 움직였습니다. 다만 **EXCP-W01 진단은 줄 번호까지 그대로 유효**했습니다 (`:24` 셸, `:27` 제목, `:58` 빈 상태, `:62-63` 필터, `:145` 뷰포트, `:184` 상세 원인). 인라인 `style=` 23줄 · `fgc-*` 112개도 실측과 일치했습니다.

이슈가 "선행 이슈 병합 후에" 로 미뤄 둔 **`publishing-page` 제거는 이번에 했습니다.** 선행 정비(#293)가 이미 병합됐고, 구조 테스트의 `BRIDGE_SCOPED_TEMPLATES` 에서 이 파일을 빼면서 함께 처리했습니다.

### ① 페이지 셸 전환

| 항목 | 전 | 후 |
|---|---|---|
| `<main>` | `fgc-main publishing-page publishing-page-list publishing-page-exception` | `page-content exception-page` |
| 제목 | `<h1 class="fgc-page-title">` — **`page-header` 구조 자체가 없었음** | `page-header` / `page-header-copy` / `page-title` |
| 카드 | `fgc-card` ×5 + `__head` / `__title` / `__body` | `surface` / `surface-header` / `surface-title` / `surface-body` |
| 필터 | `fgc-toolbar` | `filter-bar` + `filter-fields` + `filter-actions` |
| 컨트롤 | `fgc-field`·`fgc-label`·`fgc-select`·`fgc-input`·`fgc-textarea`·`fgc-error` | `filter-field`·`filter-field-label`·`select-control`·`field-control`·`textarea-control`·`field-error` |
| 버튼 | `fgc-btn` ×5 | `button button-primary` / `button-secondary` |
| 표 | `fgc-table` | `data-table` |
| 빈 상태 | `fgc-empty publishing-empty-state` | `empty-state` |
| 텍스트 | `fgc-mono` ×18 / `fgc-muted` ×17 | `tabular-nums` / `text-secondary` |
| 인라인 `style=` | 23줄 | **0줄** |

`data-selected-exception-id`, `id="summary-cards"`, `id="f-type"`, `id="f-reason"`, `id="f-reset"` 등 `id`·`name`·`data-*`·`th:*` 는 전부 보존했습니다.

**상태 select 의 `onchange="this.form.submit()"` 를 제거했습니다.** 키보드로 값을 훑기만 해도 제출됐고, 다른 필터 6종은 조회 버튼을 눌러야 하는데 상태만 즉시 제출이라 동작이 엇갈렸습니다. 조회 버튼으로 통일했습니다.

### ② 공통 컴포넌트 복제 제거

`exception.css:40-43` 의 `.exception-table-viewport` 가 `components.css:519` `.data-table-viewport` 와 사실상 같은 정의였습니다. 가이드 §4.2 "개별 화면 CSS에서 공통 컴포넌트의 디자인을 다시 복사하지 않는다" 위반입니다. 공통 클래스를 쓰고 화면 전용 클래스는 병기만 합니다.

`publishing-page` 를 떼면서 그 안에 갇혀 있던 표 셀렉터 4개(`.publishing-page .exception-table*`)도 스코프를 풀었습니다 — 안 풀면 표 레이아웃이 통째로 죽습니다.

### ③ 상세 원인 컬럼 disclosure

PR #269 가 `.exception-table` 을 `table-layout: fixed` 로 바꾸고 `th/td` 에 `overflow: hidden; text-overflow: ellipsis` 를 넣었는데, `exception-col-reason` 은 좁은 폭인데도 `table-cell-disclosure` 가 빠져 있었습니다. 계약번호·내용·참조 3개 컬럼과 같은 구조를 적용해 4벌이 됐습니다.

### ④ 표시 형식 · 오류코드

- **일시** — `value.replace("T", " ").slice(0, 16)` 로 문자열을 자르고 있었습니다. 서버가 UTC 로 주면 그대로 노출됩니다. `format.dateTime()` 으로 바꿔 `Asia/Seoul` 로 환산합니다
- **금액** — `Number(v).toLocaleString("ko-KR")` 3곳 → `format.won()`
- **오류 문구** — 처리 실패·원장 정정 실패에 `format.errorText()` 로 오류코드·요청 ID 를 병기합니다 (FGC-SIR-007)
- **원장 정정 실패에 Toast 가 없었습니다** — 인라인 오류만 있어서 스크롤 밖이면 놓칩니다. Toast 를 병행합니다
- 사유 미입력 오류는 지시대로 Toast 가 아니라 `field-error` 로 유지했습니다

유틸이 없으면 예전 동작으로 떨어지도록 폴백을 뒀습니다.

### ⑤ 구조 테스트 강화

EXCP-W01 검증에 **셸 존재 단언과 인라인 `style=`·`<script>` 금지가 없어서 레거시 상태가 통과**하고 있었습니다. POL-W01 수준으로 올렸습니다.

기존 `exceptionListUsesFlexibleColumnsSharedBadgesAndProductionToast` 의 `<colgroup>`·`status-badge` 5종·disclosure·Toast 검증은 그대로 유지했습니다.

## 🧪 4. 테스트 방법

1. 전체 테스트를 실행합니다. **Docker Desktop 이 떠 있어야 합니다.**
   ```bash
   ./gradlew build
   ```
   확인된 결과: `BUILD SUCCESSFUL`

2. 구조 테스트와 뷰 렌더링 테스트를 확인합니다. `ExceptionCaseViewControllerTest` 는 템플릿을 **실제로 렌더링**합니다.
   ```bash
   ./gradlew test \
     --tests "com.susukkang.fgc.ui.PublishingTemplateStructureTest" \
     --tests "com.susukkang.fgc.exceptioncase.controller.ExceptionCaseViewControllerTest"
   ```
   확인된 결과: 통과

3. 정적 검사.
   ```bash
   rg -n 'page-description|fgc-page-desc|guidance|fgc-banner' src/main/resources/templates/exception src/main/resources/static/css/features/exception.css
   rg -n 'style=|onclick=|onchange=|<style|<script' src/main/resources/templates/exception
   rg -n 'fgc-main|fgc-card|fgc-btn|fgc-field|fgc-input|fgc-select|fgc-table|fgc-empty|fgc-toolbar|fgc-page-title|fgc-mono|publishing-page' src/main/resources/templates/exception
   ```
   확인된 결과: **모두 0건**

4. JS 문법. **제 환경에 Node 가 없어 실행하지 못했습니다** — 6번 1번 참조.
   ```bash
   node --check src/main/resources/static/js/features/exception/exception-list.js
   ```

5. 브라우저 QA (`./gradlew bootRun`, `/exceptions`, `settle01`). **하지 못했습니다** — 6번 2번 참조. 이슈의 QA 13항목 중 **회귀 확인이 핵심**입니다(요약 카드 필터링, 행 클릭·키보드 선택, 행 내부 링크 클릭이 행 선택으로 전파되지 않는지, disclosure 와 행 선택 충돌, 처리 저장 Toast).

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

1. **`node --check` 를 실행하지 못했습니다.** 제 환경에 Node 가 없습니다. `exception-list.js` 는 31줄이 바뀌었습니다.

2. **브라우저 QA 를 하지 못했습니다.** 이 PR 은 셸만 바꾸고 동작은 그대로 두는 것이 목표라 **회귀 확인이 전부**입니다. 특히 다음을 봐 주세요.
   - 행 클릭·Enter/Space 선택과 행 내부 링크·`details` 클릭 보호 (PR #269 가 만든 것)
   - 새로 넣은 **상세 원인 disclosure 가 행 선택과 충돌하지 않는지**
   - 요약 카드 클릭 필터링과 `aria-current`
   - 필터가 `filter-bar` 로 바뀐 뒤 7개 필드가 좁은 폭에서 접히는 모양

3. **`publishing-page` 를 이번에 제거했습니다.** 이슈는 "선행 이슈 병합 후에" 로 미뤄 뒀는데 그 선행 이슈(#293)가 이미 병합돼 있어 함께 처리했습니다. 다른 화면 담당자와 시점을 맞춰야 한다면 알려 주세요.

4. **상태 select 의 자동 제출 제거**가 괜찮은지 봐 주세요. 나머지 필터 6종과 동작을 맞춘 것인데, 상태만 즉시 조회되는 편이 낫다는 판단이면 되돌리겠습니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다. (기준 커밋 `0a2796ae`)
* [x] 로컬 빌드에 성공했습니다. (`./gradlew build` BUILD SUCCESSFUL)
* [x] 애플리케이션 실행을 확인했습니다. — **못 했습니다.** 6번 2번 참조
* [x] 관련 기능을 직접 테스트했습니다. — **브라우저 수동 테스트를 못 했습니다.** 6번 2번 참조
* [x] 테스트 코드가 필요한 경우 작성했습니다. (EXCP-W01 검증 강화)
* [x] 기존 기능에 영향이 없는지 확인했습니다. (전체 통과, `ExceptionCaseViewControllerTest` 가 실제 렌더링으로 검증)
* [x] 커밋 메시지 컨벤션을 준수했습니다. (`refactor(exception): …`)
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* **EXCP-W01 예외함** (`/exceptions`)
    - 제목이 공통 `page-header` 구조로 바뀌어 상단 여백·정렬이 다른 화면과 같아짐
    - 검색 조건이 카드 → 한 줄 `filter-bar` 형태로. **초기화·조회 버튼이 오른쪽 끝으로 이동**
    - **상태 필터가 선택 즉시 조회 → [조회] 버튼을 눌러야 조회**
    - **상세 원인 컬럼이 잘릴 때 `전체 보기 / 접기` 표시** (기존에는 잘리면 볼 방법 없음)
    - 카드·표·빈 상태가 공통 스타일로 (테두리·여백·폰트 미세 변화)
    - 처리·검출 이력 패널의 여백이 토큰 기준으로 재조정
    - 발생 일시가 KST 로 환산되어 표시 (기존에는 서버 문자열 그대로)
    - 처리 실패·원장 정정 실패 문구에 오류코드·요청 ID 가 붙음
    - **원장 정정 실패 시 Toast 가 새로 뜸** (기존에는 인라인 오류만)

## 💬 9. 참고 사항

### 백엔드 보고 (이 PR 에서 고치지 않음)

**`ExceptionCaseViewController:118` 의 `openCount` 가 죽은 모델 속성입니다.** PR #269 가 상단 고정 문구 배너를 제거하면서 이 값을 쓰는 곳이 사라졌습니다. 템플릿 전체를 검색해도 참조가 0건입니다. 이슈 지시대로 백엔드는 건드리지 않고 보고만 합니다 — 제거해도 안전합니다.

### 유지한 것 (이슈 "하지 말 것")

- PR #269 산출물 전부 — `kpi-card` 요약, `status-badge` 6곳, `table-cell-disclosure` 3곳, `pagination-controls`, 우상단 Toast, 행 클릭·키보드 선택, 행 내부 인터랙션 보호
- `status='OPEN'` 이 화면 묶음 필터라는 동작 (#83)
- `참조` 열 (화면정의서 1349행 필수 원천 링크)
- 요약 카드의 영문 유형 코드
- 상단 고정 문구는 **복원하지 않음** — 화면 설명문 제거 결정과 일치. 산출물 갱신은 별도 [Docs] 이슈(#292)
- `publishing-modal` — 원장 정정 모달은 구조 테스트가 이 클래스를 단언 중이라 유지

### 별도 이슈 필요

**`syncTableCellDisclosures` 중복** — 같은 함수가 화면마다 각자 있습니다. 공통 유틸로 뽑는 게 맞지만 여러 파일을 동시에 건드려야 해서 #138 하위 별도 이슈로 제안합니다.

### 검증 수치

| 지표 | 전 | 후 |
|---|---|---|
| 인라인 `style=` | 23 | 0 |
| `class="fgc-*"` | 112 | 0 |
| `table-cell-disclosure` | 3 | 4 |
| `publishing-page` | 1 | 0 |
| 공통 컴포넌트 복제 (`exception-table-viewport`) | 1 | 0 |
