### PR TITLE
[Refactor] LEDG-W01 검증원장 화면 공통 UI 전환 

### DIFF
--- a/src/main/resources/static/css/features/ledger.css
+++ b/src/main/resources/static/css/features/ledger.css
@@ -1,15 +1,242 @@
 /*
- * LEDG-W01 화면 전용 스타일 (#138).
+ * LEDG-W01 화면 전용 스타일.
  *
- * 지금은 루트 레이아웃만 둔다. 목록·상세 2단 Grid 와 컬럼 폭은 LEDG 담당 이슈에서 채운다.
- * 공통 컴포넌트(components.css)의 디자인을 여기에 다시 복사하지 않는다.
- *
- * 이관 예정: templates/ledger/list.html 의 <script> 블록(2단 Grid → CSS 미디어쿼리)과
- *           인라인 style 37줄.
+ * 공통 컴포넌트의 디자인은 다시 정의하지 않고, 원장 화면의 폭·배치·상태만 ledger- 스코프로
+ * 제한한다. 템플릿에 있던 인라인 스타일과 resize 스크립트는 이 파일의 미디어쿼리로 옮겼다.
  */
 
 .ledger-page {
   display: grid;
   min-width: 0;
   gap: var(--space-4);
+}
+
+.ledger-filter-fields {
+  flex: 1 1 auto;
+}
+
+.ledger-filter-actions {
+  flex: 0 0 auto;
+}
+
+.ledger-filter-date {
+  width: 8.125rem;
+}
+
+.ledger-filter-type {
+  width: 13.75rem;
+}
+
+.ledger-filter-account {
+  width: 9.375rem;
+}
+
+.ledger-filter-contract,
+.ledger-filter-status {
+  width: 7.5rem;
+}
+
+.ledger-work-grid {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(0, 1.35fr) minmax(20rem, 1fr);
+  gap: var(--space-4);
+  align-items: start;
+}
+
+.ledger-count-note {
+  font-size: 0.75rem;
+}
+
+.ledger-table {
+  min-width: 76.25rem;
+}
+
+.ledger-col-number { width: 7.875rem; }
+.ledger-col-date { width: 5.75rem; }
+.ledger-col-type { width: 10.625rem; }
+.ledger-col-source { width: 10.625rem; }
+.ledger-col-contract { width: 5rem; }
+.ledger-col-amount { width: 6.5rem; }
+.ledger-col-status { width: 5.5rem; }
+.ledger-col-reversal { width: 7.875rem; }
+
+.ledger-table td.ledger-disclosure-cell,
+.ledger-detail-table td.ledger-disclosure-cell {
+  height: auto;
+  padding-block: var(--space-2);
+  overflow: visible;
+  white-space: normal;
+}
+
+.ledger-row {
+  cursor: pointer;
+}
+
+.ledger-row:focus-visible,
+.ledger-table-viewport:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: -2px;
+}
+
+.ledger-imbalanced-amount {
+  color: var(--color-status-error-text);
+  font-weight: 700;
+  text-decoration: underline wavy;
+  text-decoration-thickness: 0.0625rem;
+}
+
+.ledger-pagination {
+  min-height: 2.75rem;
+  justify-content: flex-end;
+  padding: var(--space-2) var(--space-4);
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.ledger-pagination-text {
+  width: auto;
+  min-width: var(--control-height-sm);
+  padding-inline: var(--space-2);
+}
+
+.ledger-detail-panel {
+  min-width: 0;
+}
+
+.ledger-detail-body {
+  min-height: 12rem;
+}
+
+.ledger-placeholder {
+  margin: 0;
+  font-size: 0.8125rem;
+}
+
+.ledger-detail-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+  margin: 0 0 var(--space-4);
+}
+
+.ledger-detail-summary > div {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-1);
+}
+
+.ledger-detail-summary dt {
+  color: var(--color-text-tertiary);
+  font-size: 0.6875rem;
+  line-height: 1.125rem;
+}
+
+.ledger-detail-summary dd {
+  min-width: 0;
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+}
+
+.ledger-detail-wide {
+  grid-column: 1 / -1;
+}
+
+.ledger-detail-table {
+  min-width: 53rem;
+}
+
+.ledger-detail-col-line { width: 4rem; }
+.ledger-detail-col-account { width: 11rem; }
+.ledger-detail-col-amount { width: 7rem; }
+.ledger-detail-col-agent { width: 8rem; }
+.ledger-detail-col-item { width: 9rem; }
+.ledger-detail-col-memo { width: 10rem; }
+
+.ledger-detail-empty {
+  min-height: 7rem;
+}
+
+.ledger-detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}
+
+.ledger-action-guide {
+  flex-basis: 100%;
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+}
+
+.ledger-modal-target {
+  margin-top: 0;
+}
+
+.ledger-reverse-modal {
+  width: min(32.5rem, 100%);
+}
+
+.ledger-correction-modal {
+  width: min(35rem, 100%);
+}
+
+.ledger-modal-field {
+  display: grid;
+  gap: var(--space-1);
+  margin-top: var(--space-4);
+}
+
+.ledger-page :is(a, button, input, select, textarea, summary, [tabindex]):focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+}
+
+@media (max-width: 63.9375rem) {
+  .ledger-work-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 47.9375rem) {
+  .ledger-filter-bar,
+  .ledger-filter-fields,
+  .ledger-filter-actions {
+    width: 100%;
+  }
+
+  .ledger-filter-fields {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .ledger-filter-date,
+  .ledger-filter-type,
+  .ledger-filter-account,
+  .ledger-filter-contract,
+  .ledger-filter-status {
+    width: 100%;
+  }
+
+  .ledger-filter-actions {
+    justify-content: flex-end;
+  }
+
+  .ledger-detail-summary {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .ledger-detail-wide {
+    grid-column: auto;
+  }
+
+  .ledger-reverse-modal,
+  .ledger-correction-modal {
+    width: 100%;
+  }
 }

--- a/src/main/resources/static/js/features/ledger/ledger.js
+++ b/src/main/resources/static/js/features/ledger/ledger.js
@@ -1,193 +1,359 @@
 /**
  * FGC-UI-LEDG-W01 검증원장 목록·상세·역분개 (FUN-046·047)
- * GET  /journals                                (IF-API-34 · MPA)
- * GET  /api/v1/journals/{id}                    (IF-API-35)
- * POST /api/v1/journals/{id}/reverse            (IF-API-36)
+ * GET  /journals                                   (IF-API-34 · MPA)
+ * GET  /api/v1/journals/{id}                       (IF-API-35)
+ * POST /api/v1/journals/{id}/reverse               (IF-API-36)
  * POST /api/v1/journals/{id}/correction-exceptions (IF-API-36A)
- * GET  /api/v1/journals/imbalances              (IF-API-37)
+ * GET  /api/v1/journals/imbalances                 (IF-API-37)
  */
 (function () {
   "use strict";
 
-  var apiClient = window.FgcUi && window.FgcUi.apiClient;
-  var root = document.querySelector(".publishing-page-ledger");
+  const apiClient = window.FgcUi && window.FgcUi.apiClient;
+  const format = window.FgcUi && window.FgcUi.format;
+  const root = document.querySelector(".ledger-page");
   if (!apiClient || !root) return;
 
-  var listBody = document.getElementById("list-body");
-  var detailBody = document.getElementById("detail-body");
-  var detailBadge = document.getElementById("detail-badge");
-  var imbalanceBanner = document.getElementById("imbalance-banner");
-  var imbalanceText = document.getElementById("imbalance-text");
-  var balanceBanner = document.getElementById("balance-banner");
-  var reverseTarget = document.getElementById("journal-reverse-target");
-  var reverseReason = document.getElementById("journal-reverse-reason");
-  var reverseEvidence = document.getElementById("journal-reverse-evidence");
-  var reverseReasonError = document.getElementById("journal-reverse-reason-error");
-  var reverseSubmit = document.getElementById("journal-reverse-submit");
-  var correctionTarget = document.getElementById("journal-correction-target");
-  var correctionReason = document.getElementById("journal-correction-reason");
-  var correctionEvidence = document.getElementById("journal-correction-evidence");
-  var correctionReasonError = document.getElementById("journal-correction-reason-error");
-  var correctionSubmit = document.getElementById("journal-correction-submit");
-  var canReverse = root.dataset.canReverse === "true";
-  var state = { selectedId: null, selected: null, pending: false };
+  const listBody = document.getElementById("list-body");
+  const detailBody = document.getElementById("detail-body");
+  const detailBadge = document.getElementById("detail-badge");
+  const imbalanceBanner = document.getElementById("imbalance-banner");
+  const imbalanceText = document.getElementById("imbalance-text");
+  const balanceBanner = document.getElementById("balance-banner");
+  const balanceMessage = balanceBanner && balanceBanner.querySelector("[data-balance-message]");
+  const reverseTarget = document.getElementById("journal-reverse-target");
+  const reverseReason = document.getElementById("journal-reverse-reason");
+  const reverseEvidence = document.getElementById("journal-reverse-evidence");
+  const reverseReasonError = document.getElementById("journal-reverse-reason-error");
+  const reverseSubmit = document.getElementById("journal-reverse-submit");
+  const correctionTarget = document.getElementById("journal-correction-target");
+  const correctionReason = document.getElementById("journal-correction-reason");
+  const correctionEvidence = document.getElementById("journal-correction-evidence");
+  const correctionReasonError = document.getElementById("journal-correction-reason-error");
+  const correctionSubmit = document.getElementById("journal-correction-submit");
+
+  if (!listBody || !detailBody || !detailBadge || !imbalanceBanner || !balanceBanner
+    || !balanceMessage || !reverseReason || !reverseSubmit || !correctionReason || !correctionSubmit) return;
+
+  const canReverse = root.dataset.canReverse === "true";
+  const SUCCESS_TOAST_KEY = "fgc.ledger.success-toast";
+  const state = { selectedId: null, selected: null, pending: false };
 
   function text(value) {
     return value === null || value === undefined || value === "" ? "—" : String(value);
   }
 
-  function won(value) {
-    var amount = Number(value || 0);
-    return Number.isFinite(amount) ? amount.toLocaleString("ko-KR") + "원" : "—";
+  /*
+   * 표시 형식은 공통 유틸만 쓴다 (FGC-SIR-008).
+   * format.won() 은 음수 괄호까지 만들고, 호출부가 isNegative() 로 빨강을 함께 적용한다.
+   */
+  function money(value) {
+    return format ? format.won(value) : text(value) + "원";
+  }
+
+  function date(value) {
+    return format ? format.date(value) : text(value);
+  }
+
+  function errorText(error, fallback) {
+    return format ? format.errorText(error, fallback) : ((error && error.message) || fallback);
   }
 
   function element(tag, className, content) {
-    var node = document.createElement(tag);
+    const node = document.createElement(tag);
     if (className) node.className = className;
     if (content !== undefined) node.textContent = content;
     return node;
   }
 
-  function cell(content, className) {
-    return element("td", className, content);
+  function amountClass(value, imbalanced) {
+    const classes = ["is-number", "tabular-nums"];
+    if (format && format.isNegative(value)) classes.push("is-negative-amount");
+    if (imbalanced) classes.push("ledger-imbalanced-amount");
+    return classes.join(" ");
   }
 
   function statusTone(status) {
-    if (status === "POSTED") return "fgc-badge--normal";
-    if (status === "REVERSED") return "fgc-badge--review";
-    return "fgc-badge--neutral";
+    if (status === "POSTED") return "status-badge-success";
+    if (status === "REVERSED") return "status-badge-review";
+    return "status-badge-neutral";
   }
 
-  function appendKeyValue(container, label, value) {
-    var item = element("div", "");
-    item.appendChild(element("strong", "", label));
-    item.appendChild(element("span", "fgc-muted", text(value)));
-    container.appendChild(item);
-  }
+  /*
+   * 긴 값은 textContent 로만 넣어 HTML 을 해석하지 않는다. 실제로 잘린 경우에만
+   * 공통 table-cell-disclosure 의 전체 보기 버튼을 노출한다.
+   */
+  function disclosure(value, singleLine, valueClass) {
+    const displayed = text(value);
+    const wrapper = element("div", "table-cell-disclosure");
+    const previewClass = "table-cell-preview" + (singleLine ? " is-single-line" : "")
+      + (valueClass ? " " + valueClass : "");
+    wrapper.appendChild(element("span", previewClass, displayed));
 
-  function renderLines(lines) {
-    var wrapper = element("div", "");
-    wrapper.style.overflowX = "auto";
-    var table = element("table", "fgc-table");
-    var head = document.createElement("thead");
-    var headerRow = document.createElement("tr");
-    ["번호", "계정", "차변", "대변", "설계사", "항목"].forEach(function (label) {
-      headerRow.appendChild(element("th", "", label));
-    });
-    head.appendChild(headerRow);
-    table.appendChild(head);
-    var body = document.createElement("tbody");
-    lines.forEach(function (line) {
-      var row = document.createElement("tr");
-      row.appendChild(cell(text(line.lineNo)));
-      row.appendChild(cell(text(line.accountName || line.accountCode)));
-      row.appendChild(cell(won(line.debitAmount), "fgc-td-num"));
-      row.appendChild(cell(won(line.creditAmount), "fgc-td-num"));
-      row.appendChild(cell(text(line.agentName)));
-      row.appendChild(cell(text(line.commissionItemName)));
-      body.appendChild(row);
-    });
-    table.appendChild(body);
-    wrapper.appendChild(table);
+    const details = element("details", "table-cell-details");
+    details.hidden = true;
+    const summary = document.createElement("summary");
+    summary.appendChild(element("span", "table-cell-more", "전체 보기"));
+    summary.appendChild(element("span", "table-cell-less", "접기"));
+    const chevron = element("span", "material-symbols-rounded table-cell-chevron", "expand_more");
+    chevron.setAttribute("aria-hidden", "true");
+    summary.appendChild(chevron);
+    details.appendChild(summary);
+    details.appendChild(element("p", "table-cell-full" + (valueClass ? " " + valueClass : ""), displayed));
+    wrapper.appendChild(details);
     return wrapper;
   }
 
-  function reverseAllowed(detail) {
-    return canReverse && detail.status === "POSTED" && detail.journalType !== "REVERSAL"
+  function syncTableCellDisclosures() {
+    root.querySelectorAll(".table-cell-disclosure").forEach(function (item) {
+      const preview = item.querySelector(".table-cell-preview");
+      const details = item.querySelector(".table-cell-details");
+      if (!preview || !details || preview.clientWidth === 0) return;
+      const isTruncated = preview.scrollWidth > preview.clientWidth + 1
+        || preview.scrollHeight > preview.clientHeight + 1;
+      details.hidden = !isTruncated;
+      if (!isTruncated) details.open = false;
+    });
+  }
+
+  function scheduleDisclosureSync() {
+    window.requestAnimationFrame(syncTableCellDisclosures);
+  }
+
+  function appendDetailItem(container, label, value, options) {
+    const item = element("div", options && options.wide ? "ledger-detail-wide" : "");
+    item.appendChild(element("dt", "", label));
+    const definition = document.createElement("dd");
+    if (options && options.disclosure) {
+      definition.appendChild(disclosure(value, options.singleLine !== false, options.valueClass));
+    } else {
+      definition.className = options && options.valueClass ? options.valueClass : "";
+      definition.textContent = text(value);
+    }
+    item.appendChild(definition);
+    container.appendChild(item);
+  }
+
+  function cell(content, className) {
+    const node = element("td", className);
+    if (content instanceof Node) node.appendChild(content);
+    else node.textContent = content;
+    return node;
+  }
+
+  function renderLines(lines) {
+    if (!lines.length) {
+      const empty = element("p", "empty-state ledger-detail-empty", "분개 상세행이 없습니다.");
+      empty.setAttribute("role", "status");
+      return empty;
+    }
+
+    const viewport = element("div", "data-table-viewport ledger-detail-table-viewport");
+    viewport.tabIndex = 0;
+    viewport.setAttribute("role", "region");
+    viewport.setAttribute("aria-label", "분개 상세행 표");
+
+    const table = element("table", "data-table ledger-detail-table");
+    const caption = element("caption", "visually-hidden", "선택한 분개의 차변·대변 상세행");
+    table.appendChild(caption);
+
+    const colgroup = document.createElement("colgroup");
+    [
+      "ledger-detail-col-line",
+      "ledger-detail-col-account",
+      "ledger-detail-col-amount",
+      "ledger-detail-col-amount",
+      "ledger-detail-col-agent",
+      "ledger-detail-col-item",
+      "ledger-detail-col-memo"
+    ].forEach(function (className) {
+      colgroup.appendChild(element("col", className));
+    });
+    table.appendChild(colgroup);
+
+    const head = document.createElement("thead");
+    const headerRow = document.createElement("tr");
+    ["번호", "계정과목", "차변", "대변", "설계사", "항목", "적요"].forEach(function (label, index) {
+      const header = element("th", index === 2 || index === 3 ? "is-number" : "", label);
+      header.setAttribute("scope", "col");
+      headerRow.appendChild(header);
+    });
+    head.appendChild(headerRow);
+    table.appendChild(head);
+
+    const body = document.createElement("tbody");
+    lines.forEach(function (line) {
+      const row = document.createElement("tr");
+      const account = text(line.accountCode) + " · " + text(line.accountName);
+      row.appendChild(cell(text(line.lineNo), "tabular-nums"));
+      row.appendChild(cell(disclosure(account, true), "ledger-disclosure-cell"));
+      row.appendChild(cell(money(line.debitAmount), amountClass(line.debitAmount)));
+      row.appendChild(cell(money(line.creditAmount), amountClass(line.creditAmount)));
+      row.appendChild(cell(text(line.agentName)));
+      row.appendChild(cell(disclosure(line.commissionItemName, true), "ledger-disclosure-cell"));
+      row.appendChild(cell(disclosure(line.memo, true), "ledger-disclosure-cell"));
+      body.appendChild(row);
+    });
+    table.appendChild(body);
+    viewport.appendChild(table);
+    return viewport;
+  }
+
+  function reverseEligible(detail) {
+    return detail.status === "POSTED" && detail.journalType !== "REVERSAL"
       && !detail.reversedByJournalHeaderId;
   }
 
+  function reverseAllowed(detail) {
+    return canReverse && reverseEligible(detail);
+  }
+
+  function renderActions(detail) {
+    const actions = element("div", "ledger-detail-actions");
+    if (reverseEligible(detail)) {
+      const reverseButton = element("button", "button button-primary", "역분개");
+      reverseButton.type = "button";
+      reverseButton.dataset.reverseJournal = detail.journalHeaderId;
+
+      const correctionButton = element("button", "button button-secondary", "역분개 + 재기표");
+      correctionButton.type = "button";
+      correctionButton.dataset.correctionJournal = detail.journalHeaderId;
+
+      if (!canReverse) {
+        const guideId = "ledger-reverse-disabled-reason";
+        reverseButton.disabled = true;
+        correctionButton.disabled = true;
+        reverseButton.setAttribute("aria-describedby", guideId);
+        correctionButton.setAttribute("aria-describedby", guideId);
+        const guide = element("p", "ledger-action-guide",
+          "역분개는 SETTLEMENT·GA_ADMIN·SYSTEM_ADMIN 권한이 필요합니다.");
+        guide.id = guideId;
+        actions.append(reverseButton, correctionButton, guide);
+      } else {
+        actions.append(reverseButton, correctionButton);
+      }
+    } else {
+      actions.appendChild(element("p", "ledger-action-guide",
+        "POSTED 상태이고 아직 역분개되지 않은 원분개만 처리할 수 있습니다."));
+    }
+    return actions;
+  }
+
+  function setBalanceMessage(className, message, role) {
+    balanceBanner.className = "guidance " + className;
+    balanceBanner.hidden = false;
+    balanceBanner.setAttribute("role", role);
+    balanceMessage.textContent = message;
+  }
+
   function showBalanceResult(totalCount) {
-    var hasImbalance = Number(totalCount) > 0;
+    const hasImbalance = Number(totalCount) > 0;
     imbalanceBanner.hidden = !hasImbalance;
     imbalanceText.textContent = hasImbalance
       ? "이 검증 실행에 차변·대변이 맞지 않는 분개가 " + totalCount + "건 있습니다."
       : "";
     balanceBanner.hidden = hasImbalance;
     if (!hasImbalance) {
-      balanceBanner.className = "fgc-banner fgc-banner--success";
-      balanceBanner.querySelector("span:last-child").textContent =
-        "선택한 분개의 검증 실행은 원장 불균형이 0건입니다.";
+      setBalanceMessage("guidance-info", "선택한 분개의 검증 실행은 원장 불균형이 0건입니다.", "status");
     }
   }
 
-  // 2026-08-19 yslee - 상세 분개의 검증실행 기준 불균형 배너를 IF-API-37과 연동
-  // 기존 코드: 배너 요소와 연동 주석만 있고 항상 hidden 상태로 남아 있었음
-  // 문제: 사용자가 POSTED 전 필수 조건인 원장 불균형 0건 여부를 화면에서 확인할 수 없음
-  // 개선: 상세의 validationRunId로 불균형 뷰를 조회해 오류 건수와 0건 결과를 구분 표시
+  // 상세 분개의 검증실행 기준 불균형 배너를 IF-API-37과 연동한다.
   function loadImbalance(validationRunId) {
     imbalanceBanner.hidden = true;
-    balanceBanner.hidden = false;
-    balanceBanner.className = "fgc-banner fgc-banner--muted";
-    balanceBanner.querySelector("span:last-child").textContent = validationRunId
-      ? "원장 불균형 여부를 확인하는 중입니다."
-      : "이 분개에는 연결된 검증 실행이 없어 실행 단위 불균형을 조회할 수 없습니다.";
-    if (!validationRunId) return Promise.resolve();
+    balanceBanner.removeAttribute("aria-busy");
 
+    if (!validationRunId) {
+      setBalanceMessage("guidance-neutral",
+        "이 분개에는 연결된 검증 실행이 없어 실행 단위 불균형을 조회할 수 없습니다.", "status");
+      return Promise.resolve();
+    }
+
+    setBalanceMessage("guidance-neutral", "원장 불균형 여부를 확인하는 중입니다.", "status");
+    balanceBanner.setAttribute("aria-busy", "true");
     return apiClient.request("/api/v1/journals/imbalances?validationRunId="
       + encodeURIComponent(validationRunId))
       .then(function (envelope) {
         showBalanceResult(envelope.data.totalCount);
-      }).catch(function () {
+      }).catch(function (error) {
+        const message = errorText(error,
+          "원장 불균형 결과를 불러오지 못했습니다. 잠시 후 다시 확인해 주세요.");
         imbalanceBanner.hidden = true;
-        balanceBanner.hidden = false;
-        balanceBanner.className = "fgc-banner fgc-banner--muted";
-        balanceBanner.querySelector("span:last-child").textContent =
-          "원장 불균형 결과를 불러오지 못했습니다. 잠시 후 다시 확인해 주세요.";
+        setBalanceMessage("guidance-warning", message, "alert");
+        if (window.FgcUi.toast) window.FgcUi.toast(message, "error");
+      }).finally(function () {
+        balanceBanner.removeAttribute("aria-busy");
       });
   }
 
   function renderDetail(detail) {
     state.selected = detail;
     detailBody.replaceChildren();
-    detailBadge.replaceChildren(element("span", "fgc-badge " + statusTone(detail.status), detail.statusLabel));
+    detailBadge.replaceChildren(element("span",
+      "status-badge " + statusTone(detail.status), detail.statusLabel));
 
-    var summary = element("div", "kv");
-    appendKeyValue(summary, "분개번호", detail.journalNo);
-    appendKeyValue(summary, "분개일", detail.journalDate);
-    appendKeyValue(summary, "유형", detail.journalTypeLabel);
-    appendKeyValue(summary, "계약", detail.contractNo || detail.contractId);
-    appendKeyValue(summary, "차변 합계", won(detail.debitTotal));
-    appendKeyValue(summary, "대변 합계", won(detail.creditTotal));
-    appendKeyValue(summary, "원분개", detail.reversalOfJournalNo);
-    appendKeyValue(summary, "역분개", detail.reversedByJournalNo);
+    const summary = element("dl", "ledger-detail-summary");
+    appendDetailItem(summary, "분개번호", detail.journalNo,
+      { disclosure: true, valueClass: "tabular-nums" });
+    appendDetailItem(summary, "분개일", date(detail.journalDate),
+      { valueClass: "tabular-nums" });
+    appendDetailItem(summary, "유형", detail.journalTypeLabel);
+    appendDetailItem(summary, "계약", detail.contractNo || detail.contractId,
+      { valueClass: "tabular-nums" });
+    appendDetailItem(summary, "차변 합계", money(detail.debitTotal),
+      { valueClass: amountClass(detail.debitTotal, !detail.balanced) });
+    appendDetailItem(summary, "대변 합계", money(detail.creditTotal),
+      { valueClass: amountClass(detail.creditTotal, !detail.balanced) });
+    appendDetailItem(summary, "원분개", detail.reversalOfJournalNo,
+      { disclosure: true, valueClass: "tabular-nums" });
+    appendDetailItem(summary, "역분개", detail.reversedByJournalNo,
+      { disclosure: true, valueClass: "tabular-nums" });
+    appendDetailItem(summary, "재기표", detail.repostedJournalNo,
+      { disclosure: true, valueClass: "tabular-nums" });
+    appendDetailItem(summary, "정정그룹", detail.correctionGroupKey,
+      { disclosure: true, valueClass: "tabular-nums" });
+    appendDetailItem(summary, "적요", detail.description,
+      { disclosure: true, singleLine: false, wide: true });
     detailBody.appendChild(summary);
     detailBody.appendChild(renderLines(detail.lines || []));
-
-    var actions = element("div", "", "");
-    actions.style.marginTop = "16px";
-    if (reverseAllowed(detail)) {
-      var button = element("button", "fgc-btn fgc-btn--primary", "역분개");
-      button.type = "button";
-      button.dataset.reverseJournal = detail.journalHeaderId;
-      actions.appendChild(button);
-      var correctionButton = element("button", "fgc-btn fgc-btn--ghost", "역분개 + 재기표");
-      correctionButton.type = "button";
-      correctionButton.dataset.correctionJournal = detail.journalHeaderId;
-      correctionButton.style.marginLeft = "8px";
-      actions.appendChild(correctionButton);
-    } else if (detail.status === "POSTED" && !canReverse) {
-      actions.appendChild(element("p", "fgc-muted", "역분개는 SETTLEMENT·GA_ADMIN·SYSTEM_ADMIN 권한이 필요합니다."));
-    } else {
-      actions.appendChild(element("p", "fgc-muted", "POSTED 원분개만 역분개할 수 있습니다."));
-    }
-    detailBody.appendChild(actions);
+    detailBody.appendChild(renderActions(detail));
+    scheduleDisclosureSync();
     loadImbalance(detail.validationRunId);
+  }
+
+  function selectRow(journalId) {
+    listBody.querySelectorAll("tr[data-journal-id]").forEach(function (row) {
+      const selected = row.dataset.journalId === String(journalId);
+      row.classList.toggle("is-selected", selected);
+      row.setAttribute("aria-selected", String(selected));
+    });
   }
 
   function loadDetail(journalId) {
     state.selectedId = journalId;
-    detailBody.replaceChildren(element("p", "fgc-muted", "분개 상세를 불러오는 중입니다."));
+    selectRow(journalId);
+    detailBody.setAttribute("aria-busy", "true");
+    const loading = element("p", "text-secondary ledger-placeholder", "분개 상세를 불러오는 중입니다.");
+    loading.setAttribute("role", "status");
+    detailBody.replaceChildren(loading);
+
     return apiClient.request("/api/v1/journals/" + encodeURIComponent(journalId))
       .then(function (envelope) {
         renderDetail(envelope.data);
-        listBody.querySelectorAll("tr[data-journal-id]").forEach(function (row) {
-          row.classList.toggle("is-selected", row.dataset.journalId === String(journalId));
-        });
       }).catch(function (error) {
-        detailBody.replaceChildren(element("p", "fgc-error", error && error.message
-          ? error.message : "분개 상세를 불러오지 못했습니다."));
+        const message = errorText(error, "분개 상세를 불러오지 못했습니다.");
+        const failure = element("p", "field-error ledger-placeholder", message);
+        failure.setAttribute("role", "alert");
+        detailBody.replaceChildren(failure);
+        if (window.FgcUi.toast) window.FgcUi.toast(message, "error");
+      }).finally(function () {
+        detailBody.removeAttribute("aria-busy");
       });
+  }
+
+  function setReasonError(field, error, visible) {
+    error.hidden = !visible;
+    field.setAttribute("aria-invalid", String(visible));
   }
 
   function openReverseModal() {
@@ -195,7 +361,7 @@
     reverseTarget.textContent = state.selected.journalNo + " · " + state.selected.journalTypeLabel;
     reverseReason.value = "";
     reverseEvidence.value = "";
-    reverseReasonError.hidden = true;
+    setReasonError(reverseReason, reverseReasonError, false);
     window.FgcUi.modal.open("journal-reverse");
   }
 
@@ -204,18 +370,14 @@
     correctionTarget.textContent = state.selected.journalNo + " · " + state.selected.journalTypeLabel;
     correctionReason.value = "";
     correctionEvidence.value = "";
-    correctionReasonError.hidden = true;
+    setReasonError(correctionReason, correctionReasonError, false);
     window.FgcUi.modal.open("journal-correction-request");
   }
 
-  // 2026-08-19 yslee - FUN-047 원분개 역분개 API를 LEDG-W01에 연결
-  // 기존 코드: 목록·상세가 정적 빈 화면이고 역분개 입력 및 호출 동작이 없음
-  // 문제: 구현된 IF-API-36을 정산담당자가 화면에서 사용할 수 없음
-  // 개선: POSTED 원분개만 선택해 필수 사유와 증빙을 보내고 서버 결과로 목록·상세를 갱신
   function submitReverse() {
-    var reason = reverseReason.value.trim();
+    const reason = reverseReason.value.trim();
     if (!reason) {
-      reverseReasonError.hidden = false;
+      setReasonError(reverseReason, reverseReasonError, true);
       reverseReason.focus();
       return;
     }
@@ -228,14 +390,15 @@
       method: "POST",
       body: { reason: reason, evidenceRef: reverseEvidence.value.trim() || null }
     }).then(function (envelope) {
-      var result = envelope.data;
+      const result = envelope.data;
       window.FgcUi.modal.close("journal-reverse");
-      if (window.FgcUi.toast) window.FgcUi.toast("역분개 " + result.journalHeaderId + "을 생성했습니다.", "success");
+      sessionStorage.setItem(SUCCESS_TOAST_KEY,
+        "역분개 " + result.journalHeaderId + "을 생성했습니다.");
       window.location.reload();
       return result;
     }).catch(function (error) {
-      if (window.FgcUi.toast) window.FgcUi.toast(error && error.message
-        ? error.message : "역분개 생성에 실패했습니다.", "error");
+      const message = errorText(error, "역분개 생성에 실패했습니다.");
+      if (window.FgcUi.toast) window.FgcUi.toast(message, "error");
     }).finally(function () {
       state.pending = false;
       reverseSubmit.disabled = false;
@@ -243,14 +406,10 @@
     });
   }
 
-  // 2026-08-20 yslee - LEDG-W01 정정 요청을 원장 정정 예외와 연결
-  // 기존 코드: 단순 역분개 버튼만 있어 올바른 신규 분개를 입력할 업무 화면으로 이동할 수 없음
-  // 문제: 역분개+재기표 내부 서비스가 있어도 사용자는 예외 처리 흐름에서 실제 정정을 수행할 수 없음
-  // 개선: IF-API-36A로 예외를 멱등 생성한 뒤 서버가 반환한 EXCP-W01 선택 주소로 이동
   function submitCorrectionRequest() {
-    var reason = correctionReason.value.trim();
+    const reason = correctionReason.value.trim();
     if (!reason) {
-      correctionReasonError.hidden = false;
+      setReasonError(correctionReason, correctionReasonError, true);
       correctionReason.focus();
       return;
     }
@@ -266,8 +425,8 @@
     }).then(function (envelope) {
       window.location.assign(envelope.data.redirectUrl);
     }).catch(function (error) {
-      if (window.FgcUi.toast) window.FgcUi.toast(error && error.message
-        ? error.message : "원장 정정 요청을 만들지 못했습니다.", "error");
+      const message = errorText(error, "원장 정정 요청을 만들지 못했습니다.");
+      if (window.FgcUi.toast) window.FgcUi.toast(message, "error");
     }).finally(function () {
       state.pending = false;
       correctionSubmit.disabled = false;
@@ -276,29 +435,49 @@
   }
 
   listBody.addEventListener("click", function (event) {
-    var row = event.target.closest("tr[data-journal-id]");
+    if (event.target.closest("a, button, details, input, select, textarea")) return;
+    const row = event.target.closest("tr[data-journal-id]");
     if (row) loadDetail(row.dataset.journalId);
   });
+
   listBody.addEventListener("keydown", function (event) {
+    if (event.target.closest("a, button, details, input, select, textarea")) return;
     if (event.key !== "Enter" && event.key !== " ") return;
-    var row = event.target.closest("tr[data-journal-id]");
+    const row = event.target.closest("tr[data-journal-id]");
     if (!row) return;
     event.preventDefault();
     loadDetail(row.dataset.journalId);
   });
+
   detailBody.addEventListener("click", function (event) {
     if (event.target.closest("[data-reverse-journal]")) openReverseModal();
     if (event.target.closest("[data-correction-journal]")) openCorrectionModal();
   });
-  reverseReason.addEventListener("input", function () { reverseReasonError.hidden = Boolean(reverseReason.value.trim()); });
+
+  reverseReason.addEventListener("input", function () {
+    setReasonError(reverseReason, reverseReasonError, !reverseReason.value.trim());
+  });
   reverseSubmit.addEventListener("click", submitReverse);
   correctionReason.addEventListener("input", function () {
-    correctionReasonError.hidden = Boolean(correctionReason.value.trim());
+    setReasonError(correctionReason, correctionReasonError, !correctionReason.value.trim());
   });
   correctionSubmit.addEventListener("click", submitCorrectionRequest);
+
+  scheduleDisclosureSync();
+  window.addEventListener("load", scheduleDisclosureSync, { once: true });
+  window.addEventListener("resize", scheduleDisclosureSync);
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(scheduleDisclosureSync);
+  }
+
+  // 새 목록을 서버에서 다시 렌더링한 뒤에도 성공 Toast 가 사라지지 않게 한 번만 복원한다.
+  const successMessage = sessionStorage.getItem(SUCCESS_TOAST_KEY);
+  if (successMessage) {
+    sessionStorage.removeItem(SUCCESS_TOAST_KEY);
+    if (window.FgcUi.toast) window.FgcUi.toast(successMessage, "success");
+  }
 
   if (root.dataset.selectedJournalId) {
     loadDetail(root.dataset.selectedJournalId);
   }
-
 })();

--- a/src/main/resources/templates/ledger/list.html
+++ b/src/main/resources/templates/ledger/list.html
@@ -20,224 +20,268 @@
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-LEDG-W01', '검증원장 조회', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-ledger"
+<main id="main-content" class="page-content ledger-page"
       th:attr="data-can-reverse=${roleCode == 'SETTLEMENT' or roleCode == 'GA_ADMIN' or roleCode == 'SYSTEM_ADMIN'},data-selected-journal-id=${selectedJournalId}">
 
-  <h1 class="fgc-page-title">검증원장 조회</h1>
-  <p class="fgc-page-desc">
-    <strong>복식부기</strong>(하나의 거래를 차변·대변 두 쪽에 같은 금액으로 적는 방식)로
-    돈의 흐름을 기록해 두고, 양쪽 합계가 맞는지 확인합니다.
-  </p>
+  <header class="page-header">
+    <div class="page-header-copy">
+      <h1 class="page-title">검증원장 조회</h1>
+    </div>
+  </header>
 
-  <!-- 상단 고정 안내 -->
-  <div class="fgc-banner fgc-banner--muted" style="margin-top:12px">
-    <span class="material-symbols-outlined" style="font-size:18px">menu_book</span>
-    <!-- 원장 안내 문구(FGC.NOTICE.LEDGER)는 메시지 프로퍼티로 채운다 -->
-    <span><strong id="notice-ledger">이 원장은 회사의 정식 회계장부가 아닙니다. 정산이 맞는지 확인하려고 FGC가 따로 만드는 보조 장부입니다.</strong></span>
-  </div>
+  <!-- 정식 회계장부 오인 방지 문구는 인터페이스정의서가 지정한 고정 안내라 삭제하지 않는다. -->
+  <aside class="guidance guidance-neutral" aria-labelledby="notice-ledger">
+    <span class="material-symbols-rounded guidance-icon" aria-hidden="true">menu_book</span>
+    <div>
+      <strong class="guidance-title" id="notice-ledger">이 원장은 회사의 정식 회계장부가 아닙니다. 정산이 맞는지 확인하려고 FGC가 따로 만드는 보조 장부입니다.</strong>
+    </div>
+  </aside>
 
-  <!-- ② 불균형 경고 배너 — validationRunId가 있는 상세 조회 후 IF-API-37로 확인한다. -->
-  <div class="fgc-banner fgc-banner--error" id="imbalance-banner" style="margin-top:10px" hidden>
-    <span class="material-symbols-outlined" style="font-size:18px">error</span>
-    <span id="imbalance-text"></span>
-  </div>
-  <!-- 데이터 미연동 상태를 검증 완료(0건 성공)로 표시하지 않는다 — 집계 결과가 있을 때만 성공/오류 배너로 전환 -->
-  <div class="fgc-banner fgc-banner--muted" id="balance-banner" style="margin-top:10px">
-    <span class="material-symbols-outlined" style="font-size:18px">info</span>
-    <span>
-      원장 균형(차변=대변, <span class="fgc-mono">vw_journal_imbalance</span> 0건 여부)은 상세 분개의 검증실행 기준으로 표시합니다.
-      기표(POSTED) 전에는 반드시 0건이어야 하며 월 통합검증 확정 조건 ②번입니다.
-    </span>
-  </div>
+  <!-- IF-API-37 결과가 있을 때만 표시한다. 미연동을 0건 성공으로 표현하지 않는다. -->
+  <aside class="guidance guidance-warning" id="imbalance-banner" role="alert" hidden>
+    <span class="material-symbols-rounded guidance-icon" aria-hidden="true">error</span>
+    <p class="guidance-copy" id="imbalance-text"></p>
+  </aside>
+  <aside class="guidance guidance-neutral" id="balance-banner" role="status" aria-live="polite" hidden>
+    <span class="material-symbols-rounded guidance-icon" aria-hidden="true">info</span>
+    <p class="guidance-copy" data-balance-message></p>
+  </aside>
 
-  <!-- 고정 문구 -->
-  <div class="fgc-banner fgc-banner--warn" style="margin-top:10px">
-    <span class="material-symbols-outlined" style="font-size:18px">edit_off</span>
-    <span><strong>수정·삭제는 없습니다. 잘못됐으면 역분개로 고칩니다.</strong>
-      잘못된 분개를 지우면 "그때 무슨 일이 있었는지"가 사라지기 때문입니다.</span>
-  </div>
+  <!-- 확정 분개를 직접 고치지 않는 업무 제약도 오용 방지를 위해 유지한다. -->
+  <aside class="guidance guidance-warning">
+    <span class="material-symbols-rounded guidance-icon" aria-hidden="true">edit_off</span>
+    <div>
+      <strong class="guidance-title">수정·삭제는 없습니다. 잘못됐으면 역분개로 고칩니다.</strong>
+      <p class="guidance-copy">잘못된 분개를 지우면 그때 무슨 일이 있었는지 확인할 수 없기 때문입니다.</p>
+    </div>
+  </aside>
 
-  <!-- ① 검색 -->
-  <section class="fgc-card" style="margin-top:16px">
-    <form class="fgc-card__body fgc-toolbar" id="ledger-filter-form" method="get" th:action="@{/journals}">
-      <div class="fgc-field" style="min-width:130px">
-        <label class="fgc-label" for="f-from">분개일 (시작)</label>
-        <input class="fgc-input" id="f-from" name="from" type="date"
+  <!-- IF-API-34 검색은 이 폼을 명시적으로 제출할 때만 실행한다. -->
+  <form class="filter-bar ledger-filter-bar" id="ledger-filter-form" method="get" th:action="@{/journals}"
+        aria-label="검증원장 검색 조건">
+    <div class="filter-fields ledger-filter-fields">
+      <div class="filter-field ledger-filter-date">
+        <label class="filter-field-label" for="f-from">분개일 (시작)</label>
+        <input class="field-control" id="f-from" name="from" type="date"
                th:value="${fromFilter ?: month + '-01'}" value="2026-07-01">
       </div>
-      <div class="fgc-field" style="min-width:130px">
-        <label class="fgc-label" for="f-to">분개일 (끝)</label>
-        <input class="fgc-input" id="f-to" name="to" type="date"
+      <div class="filter-field ledger-filter-date">
+        <label class="filter-field-label" for="f-to">분개일 (끝)</label>
+        <input class="field-control" id="f-to" name="to" type="date"
                th:value="${toFilter ?: T(java.time.YearMonth).parse(month).atEndOfMonth()}" value="2026-07-31">
       </div>
-      <div class="fgc-field" style="min-width:220px">
-        <label class="fgc-label" for="f-type">분개 유형</label>
-        <select class="fgc-select" id="f-type" name="type">
+      <div class="filter-field ledger-filter-type">
+        <label class="filter-field-label" for="f-type">분개 유형</label>
+        <select class="select-control" id="f-type" name="type">
           <option value="" th:selected="${typeFilter == null}">전체</option>
           <option th:each="type : ${journalTypes}" th:value="${type.name()}" th:text="${type.label()}"
                   th:selected="${type.name() == typeFilter}"></option>
         </select>
       </div>
-      <div class="fgc-field" style="min-width:150px">
-        <label class="fgc-label" for="f-account">계정과목</label>
-        <input class="fgc-input" id="f-account" name="account" type="text" placeholder="계정코드"
+      <div class="filter-field ledger-filter-account">
+        <label class="filter-field-label" for="f-account">계정과목</label>
+        <input class="field-control" id="f-account" name="account" type="text" placeholder="계정코드"
                th:value="${accountFilter}">
       </div>
-      <div class="fgc-field" style="min-width:120px">
-        <label class="fgc-label" for="f-contract">계약 ID</label>
-        <input class="fgc-input" id="f-contract" name="contract" type="number" min="1" inputmode="numeric"
+      <div class="filter-field ledger-filter-contract">
+        <label class="filter-field-label" for="f-contract">계약 ID</label>
+        <input class="field-control" id="f-contract" name="contract" type="number" min="1" inputmode="numeric"
                th:value="${contractFilter}">
       </div>
-      <div class="fgc-field" style="min-width:120px">
-        <label class="fgc-label" for="f-status">상태</label>
-        <select class="fgc-select" id="f-status" name="status">
+      <div class="filter-field ledger-filter-status">
+        <label class="filter-field-label" for="f-status">상태</label>
+        <select class="select-control" id="f-status" name="status">
           <option value="" th:selected="${statusFilter == null}">전체</option>
           <option th:each="status : ${journalStatuses}" th:value="${status.name()}" th:text="${status.label()}"
                   th:selected="${status.name() == statusFilter}"></option>
         </select>
       </div>
-      <button class="fgc-btn fgc-btn--primary" id="f-search" name="searched" value="true" type="submit">
-        <span class="material-symbols-outlined" style="font-size:18px">search</span> 조회
-      </button>
-      <a class="fgc-btn fgc-btn--ghost" id="f-reset" th:href="@{/journals}">
-        <span class="material-symbols-outlined" style="font-size:18px">restart_alt</span> 초기화
+    </div>
+    <div class="filter-actions ledger-filter-actions">
+      <a class="button button-secondary" id="f-reset" th:href="@{/journals}">
+        <span class="material-symbols-rounded" aria-hidden="true">restart_alt</span>초기화
       </a>
-    </form>
-  </section>
+      <button class="button button-primary" id="f-search" name="searched" value="true" type="submit">
+        <span class="material-symbols-rounded" aria-hidden="true">search</span>조회
+      </button>
+    </div>
+  </form>
 
-  <div class="fgc-responsive-split" style="margin-top:16px;display:grid;grid-template-columns:1.35fr 1fr;gap:16px" id="ledger-grid">
-
+  <div class="ledger-work-grid" id="ledger-grid">
     <!-- ③ 분개 목록 -->
-    <section class="fgc-card">
-      <div class="fgc-card__head">
-        <span class="fgc-card__title">분개 목록</span>
-        <span class="fgc-muted" style="font-size:12px"><span id="row-count" th:text="${journals.totalElements}">0</span>건 · 한 화면 20행</span>
-      </div>
-      <div style="overflow-x:auto">
-        <table class="fgc-table">
+    <section class="surface">
+      <header class="surface-header">
+        <h2 class="surface-title">분개 목록</h2>
+        <span class="text-secondary ledger-count-note"><span id="row-count" class="tabular-nums"
+              th:text="${journals.totalElements}">0</span>건 · 한 화면 20행</span>
+      </header>
+      <div class="data-table-viewport ledger-table-viewport" tabindex="0" role="region" aria-label="분개 목록 표">
+        <table class="data-table ledger-table">
+          <caption class="visually-hidden">조회 조건에 해당하는 검증원장 분개 목록</caption>
+          <colgroup>
+            <col class="ledger-col-number">
+            <col class="ledger-col-date">
+            <col class="ledger-col-type">
+            <col class="ledger-col-source">
+            <col class="ledger-col-contract">
+            <col class="ledger-col-amount">
+            <col class="ledger-col-amount">
+            <col class="ledger-col-status">
+            <col class="ledger-col-reversal">
+          </colgroup>
           <thead>
             <tr>
-              <th style="width:126px">분개번호</th>
-              <th style="width:92px">분개일</th>
-              <th style="width:170px">유형</th>
-              <th style="width:170px">원천</th>
-              <th style="width:66px">계약</th>
-              <th class="fgc-th-num" style="width:104px">차변 합계</th>
-              <th class="fgc-th-num" style="width:104px">대변 합계</th>
-              <th style="width:88px">상태</th>
-              <th style="width:126px">역분개 표시</th>
+              <th scope="col">분개번호</th>
+              <th scope="col">분개일</th>
+              <th scope="col">유형</th>
+              <th scope="col">원천</th>
+              <th scope="col">계약</th>
+              <th class="is-number" scope="col">차변 합계</th>
+              <th class="is-number" scope="col">대변 합계</th>
+              <th scope="col">상태</th>
+              <th scope="col">역분개 표시</th>
             </tr>
           </thead>
           <tbody id="list-body">
             <tr th:if="${!searched}">
-              <td colspan="9"><div class="fgc-empty">조회 조건을 설정하고 조회 버튼을 눌러 주세요.</div></td>
+              <td colspan="9"><p class="empty-state">조회 조건을 설정하고 조회 버튼을 눌러 주세요.</p></td>
             </tr>
             <tr th:if="${searched and journals.content.empty}">
-              <td colspan="9"><div class="fgc-empty">조건에 맞는 자료가 없습니다.</div></td>
+              <td colspan="9"><p class="empty-state">조건에 맞는 자료가 없습니다.</p></td>
             </tr>
-            <tr th:each="journal : ${journals.content}" tabindex="0"
+            <tr class="ledger-row" th:each="journal : ${journals.content}" tabindex="0" aria-selected="false"
                 th:data-journal-id="${journal.journalHeaderId}">
-              <td class="fgc-mono" th:text="${journal.journalNo}">JRN-001</td>
-              <td th:text="${journal.journalDate}">2026-07-31</td>
+              <td class="ledger-disclosure-cell">
+                <div class="table-cell-disclosure">
+                  <span class="table-cell-preview is-single-line tabular-nums" th:text="${journal.journalNo}">JRN-001</span>
+                  <details class="table-cell-details" hidden>
+                    <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span>
+                      <span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                    <p class="table-cell-full tabular-nums" th:text="${journal.journalNo}">JRN-001</p>
+                  </details>
+                </div>
+              </td>
+              <td class="tabular-nums" th:text="${journal.journalDate}">2026-07-31</td>
               <td th:text="${journal.journalTypeLabel}">실제 지급</td>
-              <td class="fgc-mono"
-                  th:text="${journal.sourceEntityType + ' #' + journal.sourceEntityId}">COMMISSION_TRANSACTION #1</td>
-              <td class="fgc-mono" th:text="${journal.contractNo ?: journal.contractId}">C-001</td>
-              <td class="fgc-td-num"
-                  th:classappend="${journal.debitTotal.compareTo(journal.creditTotal) != 0} ? ' fgc-error'"
-                  th:text="${#numbers.formatDecimal(journal.debitTotal, 1, 'COMMA', 0, 'POINT') + '원'}">0원</td>
-              <td class="fgc-td-num"
-                  th:classappend="${journal.debitTotal.compareTo(journal.creditTotal) != 0} ? ' fgc-error'"
-                  th:text="${#numbers.formatDecimal(journal.creditTotal, 1, 'COMMA', 0, 'POINT') + '원'}">0원</td>
-              <td><span class="fgc-badge" th:text="${journal.statusLabel}">기표</span></td>
-              <td>
-                <span class="fgc-badge fgc-badge--review" th:if="${journal.reversalOfJournalNo != null}"
-                      th:text="${'원분개 ' + journal.reversalOfJournalNo}">원분개 JRN-001</span>
+              <td class="ledger-disclosure-cell">
+                <div class="table-cell-disclosure">
+                  <span class="table-cell-preview is-single-line tabular-nums"
+                        th:text="${journal.sourceEntityType + ' #' + journal.sourceEntityId}">COMMISSION_TRANSACTION #1</span>
+                  <details class="table-cell-details" hidden>
+                    <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span>
+                      <span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                    <p class="table-cell-full tabular-nums"
+                       th:text="${journal.sourceEntityType + ' #' + journal.sourceEntityId}">COMMISSION_TRANSACTION #1</p>
+                  </details>
+                </div>
+              </td>
+              <td class="tabular-nums" th:text="${journal.contractNo ?: journal.contractId}">C-001</td>
+              <td class="is-number tabular-nums"
+                  th:classappend="${journal.debitTotal.signum() < 0} ? ' is-negative-amount' : (${journal.debitTotal.compareTo(journal.creditTotal) != 0} ? ' ledger-imbalanced-amount' : '')"
+                  th:title="${journal.debitTotal.compareTo(journal.creditTotal) != 0} ? '차변·대변 합계 불일치' : null"
+                  th:text="${journal.debitTotal.signum() < 0 ? '(' + #numbers.formatDecimal(journal.debitTotal.abs(), 1, 'COMMA', 0, 'POINT') + ')원' : #numbers.formatDecimal(journal.debitTotal, 1, 'COMMA', 0, 'POINT') + '원'}">0원</td>
+              <td class="is-number tabular-nums"
+                  th:classappend="${journal.creditTotal.signum() < 0} ? ' is-negative-amount' : (${journal.debitTotal.compareTo(journal.creditTotal) != 0} ? ' ledger-imbalanced-amount' : '')"
+                  th:title="${journal.debitTotal.compareTo(journal.creditTotal) != 0} ? '차변·대변 합계 불일치' : null"
+                  th:text="${journal.creditTotal.signum() < 0 ? '(' + #numbers.formatDecimal(journal.creditTotal.abs(), 1, 'COMMA', 0, 'POINT') + ')원' : #numbers.formatDecimal(journal.creditTotal, 1, 'COMMA', 0, 'POINT') + '원'}">0원</td>
+              <td><span class="status-badge"
+                        th:classappend="${journal.status.name() == 'POSTED'} ? ' status-badge-success' : (${journal.status.name() == 'REVERSED'} ? ' status-badge-review' : ' status-badge-neutral')"
+                        th:text="${journal.statusLabel}">기표됨</span></td>
+              <td class="ledger-disclosure-cell">
+                <div class="table-cell-disclosure" th:if="${journal.reversalOfJournalNo != null}">
+                  <span class="table-cell-preview is-single-line" th:text="${'원분개 ' + journal.reversalOfJournalNo}">원분개 JRN-001</span>
+                  <details class="table-cell-details" hidden>
+                    <summary><span class="table-cell-more">전체 보기</span><span class="table-cell-less">접기</span>
+                      <span class="material-symbols-rounded table-cell-chevron" aria-hidden="true">expand_more</span></summary>
+                    <p class="table-cell-full" th:text="${'원분개 ' + journal.reversalOfJournalNo}">원분개 JRN-001</p>
+                  </details>
+                </div>
                 <span th:unless="${journal.reversalOfJournalNo != null}">—</span>
               </td>
             </tr>
           </tbody>
         </table>
       </div>
-      <footer class="fgc-pagination" id="ledger-pagination" style="padding:10px 16px;display:flex;justify-content:flex-end;gap:8px">
-        <a class="fgc-btn fgc-btn--ghost" id="ledger-prev" th:if="${journals.page > 1}"
-           th:href="@{/journals(from=${fromFilter},to=${toFilter},type=${typeFilter},account=${accountFilter},contract=${contractFilter},status=${statusFilter},searched=true,page=${journals.page - 1})}">이전</a>
-        <span id="ledger-page-info" class="fgc-muted" style="align-self:center"
+      <nav class="pagination-controls ledger-pagination" id="ledger-pagination" aria-label="검증원장 페이지 이동">
+        <a class="pagination-button ledger-pagination-text" id="ledger-prev" th:if="${journals.page > 1}"
+           th:href="@{/journals(from=${fromFilter},to=${toFilter},type=${typeFilter},account=${accountFilter},contract=${contractFilter},status=${statusFilter},selected=${selectedJournalId},searched=true,page=${journals.page - 1})}">이전</a>
+        <span id="ledger-page-info" class="text-secondary tabular-nums"
               th:text="${journals.page + ' / ' + (journals.totalPages > 0 ? journals.totalPages : 1)}">1 / 1</span>
-        <a class="fgc-btn fgc-btn--ghost" id="ledger-next" th:if="${journals.page < journals.totalPages}"
-           th:href="@{/journals(from=${fromFilter},to=${toFilter},type=${typeFilter},account=${accountFilter},contract=${contractFilter},status=${statusFilter},searched=true,page=${journals.page + 1})}">다음</a>
-      </footer>
+        <a class="pagination-button ledger-pagination-text" id="ledger-next" th:if="${journals.page < journals.totalPages}"
+           th:href="@{/journals(from=${fromFilter},to=${toFilter},type=${typeFilter},account=${accountFilter},contract=${contractFilter},status=${statusFilter},selected=${selectedJournalId},searched=true,page=${journals.page + 1})}">다음</a>
+      </nav>
     </section>
 
     <!-- ④ 상세 패널 -->
-    <section class="fgc-card" style="align-self:start">
-      <div class="fgc-card__head">
-        <span class="fgc-card__title">분개 상세</span>
+    <section class="surface ledger-detail-panel" aria-labelledby="ledger-detail-title">
+      <header class="surface-header">
+        <h2 class="surface-title" id="ledger-detail-title">분개 상세</h2>
         <span id="detail-badge"></span>
-      </div>
-      <div class="fgc-card__body" id="detail-body">
-        <p class="fgc-muted" style="font-size:13px;margin:0">왼쪽 목록에서 분개를 고르세요.</p>
+      </header>
+      <div class="surface-body ledger-detail-body" id="detail-body" aria-live="polite">
+        <p class="text-secondary ledger-placeholder">왼쪽 목록에서 분개를 고르세요.</p>
       </div>
     </section>
   </div>
 
+  <!-- 공통 Modal 구조와 data-* 계약은 기존 동작을 위해 그대로 유지한다. -->
   <div class="modal-backdrop" data-modal="journal-reverse" data-close-on-backdrop="true" hidden aria-hidden="true">
-    <section class="modal" role="dialog" aria-modal="true" aria-labelledby="journal-reverse-title" style="width:min(520px,100%)">
+    <section class="modal ledger-reverse-modal" role="dialog" aria-modal="true" aria-labelledby="journal-reverse-title">
       <header class="modal-header"><h2 class="modal-title" id="journal-reverse-title">원분개 역분개</h2></header>
       <div class="modal-body">
-        <p class="fgc-muted" id="journal-reverse-target" style="margin-top:0"></p>
-        <div class="fgc-banner fgc-banner--warn">
-          원분개를 수정하거나 삭제하지 않고 반대 차변·대변의 새 분개를 만듭니다. 처리 후 되돌리려면 별도 정정 절차가 필요합니다.
-        </div>
-        <label class="fgc-label fgc-label--required" for="journal-reverse-reason" style="display:block;margin-top:16px">역분개 사유</label>
-        <textarea class="textarea-control" id="journal-reverse-reason" maxlength="1000" rows="5" required
-                  data-modal-initial-focus placeholder="역분개가 필요한 업무 사유를 입력하세요."></textarea>
-        <p class="fgc-error" id="journal-reverse-reason-error" hidden>역분개 사유를 입력하세요.</p>
-        <label class="fgc-label" for="journal-reverse-evidence" style="display:block;margin-top:16px">증빙 참조</label>
-        <input class="fgc-input" id="journal-reverse-evidence" maxlength="500" type="text" placeholder="문서번호 또는 내부 증빙 경로">
+        <p class="text-secondary ledger-modal-target" id="journal-reverse-target"></p>
+        <aside class="guidance guidance-warning">
+          <span class="material-symbols-rounded guidance-icon" aria-hidden="true">warning</span>
+          <p class="guidance-copy">원분개를 수정하거나 삭제하지 않고 반대 차변·대변의 새 분개를 만듭니다. 처리 후 되돌리려면 별도 정정 절차가 필요합니다.</p>
+        </aside>
+        <label class="field ledger-modal-field" for="journal-reverse-reason">
+          <span class="field-label">역분개 사유 <span class="field-required" aria-hidden="true">*</span></span>
+          <textarea class="textarea-control" id="journal-reverse-reason" maxlength="1000" rows="5" required
+                    aria-describedby="journal-reverse-reason-error" data-modal-initial-focus
+                    placeholder="역분개가 필요한 업무 사유를 입력하세요."></textarea>
+          <span class="field-error" id="journal-reverse-reason-error" role="alert" hidden>역분개 사유를 입력하세요.</span>
+        </label>
+        <label class="field ledger-modal-field" for="journal-reverse-evidence">
+          <span class="field-label">증빙 참조</span>
+          <input class="field-control" id="journal-reverse-evidence" maxlength="500" type="text"
+                 placeholder="문서번호 또는 내부 증빙 경로">
+        </label>
       </div>
       <footer class="modal-footer">
-        <button class="fgc-btn fgc-btn--ghost" type="button" data-modal-close>취소</button>
-        <button class="fgc-btn fgc-btn--primary" id="journal-reverse-submit" type="button">역분개 생성</button>
+        <button class="button button-secondary" type="button" data-modal-close>취소</button>
+        <button class="button button-primary" id="journal-reverse-submit" type="button">역분개 생성</button>
       </footer>
     </section>
   </div>
 
   <div class="modal-backdrop" data-modal="journal-correction-request" data-close-on-backdrop="true" hidden aria-hidden="true">
-    <section class="modal" role="dialog" aria-modal="true" aria-labelledby="journal-correction-title" style="width:min(560px,100%)">
+    <section class="modal ledger-correction-modal" role="dialog" aria-modal="true" aria-labelledby="journal-correction-title">
       <header class="modal-header"><h2 class="modal-title" id="journal-correction-title">역분개 + 재기표 요청</h2></header>
       <div class="modal-body">
-        <p class="fgc-muted" id="journal-correction-target" style="margin-top:0"></p>
-        <div class="fgc-banner fgc-banner--muted">
-          원분개를 바로 바꾸지 않고 원장 정정 예외를 만든 뒤 예외함에서 올바른 신규 분개를 입력합니다.
-        </div>
-        <label class="fgc-label fgc-label--required" for="journal-correction-reason" style="display:block;margin-top:16px">정정 요청 사유</label>
-        <textarea class="textarea-control" id="journal-correction-reason" maxlength="1000" rows="5" required
-                  data-modal-initial-focus placeholder="잘못된 내용과 필요한 정정을 입력하세요."></textarea>
-        <p class="fgc-error" id="journal-correction-reason-error" hidden>정정 요청 사유를 입력하세요.</p>
-        <label class="fgc-label" for="journal-correction-evidence" style="display:block;margin-top:16px">증빙 참조</label>
-        <input class="fgc-input" id="journal-correction-evidence" maxlength="500" type="text" placeholder="문서번호 또는 내부 증빙 경로">
+        <p class="text-secondary ledger-modal-target" id="journal-correction-target"></p>
+        <aside class="guidance guidance-neutral">
+          <span class="material-symbols-rounded guidance-icon" aria-hidden="true">info</span>
+          <p class="guidance-copy">원분개를 바로 바꾸지 않고 원장 정정 예외를 만든 뒤 예외함에서 올바른 신규 분개를 입력합니다.</p>
+        </aside>
+        <label class="field ledger-modal-field" for="journal-correction-reason">
+          <span class="field-label">정정 요청 사유 <span class="field-required" aria-hidden="true">*</span></span>
+          <textarea class="textarea-control" id="journal-correction-reason" maxlength="1000" rows="5" required
+                    aria-describedby="journal-correction-reason-error" data-modal-initial-focus
+                    placeholder="잘못된 내용과 필요한 정정을 입력하세요."></textarea>
+          <span class="field-error" id="journal-correction-reason-error" role="alert" hidden>정정 요청 사유를 입력하세요.</span>
+        </label>
+        <label class="field ledger-modal-field" for="journal-correction-evidence">
+          <span class="field-label">증빙 참조</span>
+          <input class="field-control" id="journal-correction-evidence" maxlength="500" type="text"
+                 placeholder="문서번호 또는 내부 증빙 경로">
+        </label>
       </div>
       <footer class="modal-footer">
-        <button class="fgc-btn fgc-btn--ghost" type="button" data-modal-close>취소</button>
-        <button class="fgc-btn fgc-btn--primary" id="journal-correction-submit" type="button">예외함에서 정정 계속</button>
+        <button class="button button-secondary" type="button" data-modal-close>취소</button>
+        <button class="button button-primary" id="journal-correction-submit" type="button">예외함에서 정정 계속</button>
       </footer>
     </section>
   </div>
-
-<!-- 스크립트는 main 안에 둔다 - 셸의 page()는 ~{::main}만 삽입하므로 main 밖 스크립트는 렌더링에서 사라진다 -->
-<script>
-/* 화면 폭이 좁으면 목록·상세 2단 그리드를 세로로 표시한다. */
-(function () {
-  "use strict";
-  function reflow() {
-    document.getElementById("ledger-grid").style.gridTemplateColumns =
-      window.innerWidth < 1150 ? "1fr" : "1.35fr 1fr";
-  }
-  reflow();
-  window.addEventListener("resize", reflow);
-})();
-</script>
 </main>
 </body>
 </html>

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -42,7 +42,6 @@ class PublishingTemplateStructureTest {
             "templates/transaction/list.html",
             "templates/transaction/form.html",
             "templates/schedule/detail.html",
-            "templates/ledger/list.html",
             "templates/exception/list.html",
             "templates/vrun/list.html",
             "templates/vrun/detail.html"
@@ -61,6 +60,7 @@ class PublishingTemplateStructureTest {
             "templates/audit/list.html",
             "templates/contract/form.html",
             "templates/schedule/list.html",
+            "templates/ledger/list.html",
             "templates/arbitrage/list.html",
             "templates/error/403.html",
             "templates/error/404.html",
@@ -223,6 +223,70 @@ class PublishingTemplateStructureTest {
                 .doesNotContain("form.addEventListener(\"submit\"")
                 .doesNotContain("function loadList(")
                 .doesNotContain("function query(");
+    }
+
+    @Test
+    void ledgerUsesCommonPageShellFormattingAndAccessibleAjaxStates() throws IOException {
+        String template = resource("templates/ledger/list.html");
+
+        // 페이지 셸 전환 (#287) — 기능 훅은 유지하고 레거시 클래스·인라인 표현은 다시 들어오지 못하게 한다.
+        assertThat(template)
+                .contains("class=\"page-content ledger-page\"")
+                .contains("class=\"page-header\"")
+                .contains("class=\"page-title\"")
+                .contains("class=\"guidance guidance-neutral\" aria-labelledby=\"notice-ledger\"")
+                .contains("id=\"imbalance-banner\" role=\"alert\"")
+                .contains("id=\"balance-banner\" role=\"status\" aria-live=\"polite\"")
+                .contains("class=\"filter-bar ledger-filter-bar\"")
+                .contains("class=\"filter-fields ledger-filter-fields\"")
+                .contains("class=\"surface\"")
+                .contains("class=\"data-table-viewport ledger-table-viewport\"")
+                .contains("class=\"data-table ledger-table\"")
+                .contains("<caption class=\"visually-hidden\">")
+                .contains("<th scope=\"col\">")
+                .contains("class=\"table-cell-disclosure\"")
+                .contains("class=\"pagination-controls ledger-pagination\"")
+                .contains("aria-label=\"검증원장 페이지 이동\"")
+                .contains("aria-selected=\"false\"")
+                // Modal 은 이미 공통 구조를 쓰고 있으므로 data-* 계약까지 함께 고정한다.
+                .contains("data-modal=\"journal-reverse\" data-close-on-backdrop=\"true\"")
+                .contains("data-modal-initial-focus")
+                .contains("data-modal-close")
+                .doesNotContain("class=\"fgc-")
+                .doesNotContain("publishing-page")
+                .doesNotContain("style=\"")
+                .doesNotContainPattern("(?i)<style[\\s>]")
+                .doesNotContainPattern("(?i)<script[\\s>]");
+
+        assertThat(resource("static/css/features/ledger.css"))
+                .contains(".ledger-work-grid")
+                .contains("grid-template-columns: minmax(0, 1.35fr) minmax(20rem, 1fr)")
+                .contains("@media (max-width: 63.9375rem)")
+                .contains("@media (max-width: 47.9375rem)")
+                .contains(".ledger-page :is(a, button, input, select, textarea, summary, [tabindex]):focus-visible")
+                .contains("var(--space-")
+                .contains("var(--color-")
+                .doesNotContainPattern("#[0-9a-fA-F]{3,8}\\b")
+                // 공통 컴포넌트의 구현을 화면 CSS 에 복제하지 않는다.
+                .doesNotContain("overscroll-behavior-inline");
+
+        assertThat(resource("static/js/features/ledger/ledger.js"))
+                .contains("document.querySelector(\".ledger-page\")")
+                .contains("format.won(value)")
+                .contains("format.isNegative(value)")
+                .contains("format.errorText(error, fallback)")
+                .contains("function syncTableCellDisclosures()")
+                .contains("preview.scrollHeight > preview.clientHeight")
+                .contains("document.fonts.ready")
+                .contains("row.setAttribute(\"aria-selected\", String(selected))")
+                .contains("event.target.closest(\"a, button, details, input, select, textarea\")")
+                .contains("detailBody.setAttribute(\"aria-busy\", \"true\")")
+                .contains("window.FgcUi.toast(message, \"error\")")
+                .contains("sessionStorage.setItem(SUCCESS_TOAST_KEY")
+                .contains("window.FgcUi.toast(successMessage, \"success\")")
+                .doesNotContain("toLocaleString")
+                .doesNotContain("wrapper.style")
+                .doesNotContain("className = \"fgc-");
     }
 
     @Test


### PR DESCRIPTION
## 📖 1. 변경 사항 요약

- LEDG-W01 검증원장 화면의 레거시 `fgc-*` 페이지 골격을 공통 UI 컴포넌트로 전환했습니다.
- 목록 서버 렌더링과 상세·역분개·불균형 Ajax 계약은 유지했습니다.
- 인라인 스타일과 반응형 스크립트를 제거하고 화면 전용 `ledger.css`로 이관했습니다.
- 표시 형식, 오류 안내, 접근성 및 반응형 동작을 공통 화면 기준에 맞췄습니다.

## 🔗 2. 관련 이슈

- Closes #287

## 🛠 3. 구현 내용

### 페이지 골격 및 공통 컴포넌트

- `publishing-page` 기반 페이지 셸을 `page-content ledger-page`로 전환했습니다.
- 검색 영역을 `filter-bar`, `filter-fields`, `filter-actions` 구조로 변경했습니다.
- 목록·상세 카드를 `surface`, `surface-header`, `surface-body` 구조로 변경했습니다.
- 목록 표를 `data-table-viewport`, `data-table` 구조로 변경했습니다.
- 버튼, 입력 필드, 상태 배지, 빈 상태 및 페이지네이션을 공통 컴포넌트로 치환했습니다.
- `ledger/list.html`의 인라인 스타일과 인라인 `<script>`를 모두 제거했습니다.

### Guidance 정리

- 화면 설명 문구는 제거했습니다.
- 아래 업무상 필수 안내는 공통 Guidance로 유지했습니다.
  - 검증원장이 정식 회계장부가 아니라는 고정 문구
  - 분개 수정·삭제가 불가능하다는 업무 제약
  - 역분개 모달의 되돌리기 어려운 작업 경고
- 불균형 조회 결과는 로딩·성공·오류 상태를 구분해 표시하도록 변경했습니다.

### 목록 및 상세 표시

- 분개 상태 배지를 다음과 같이 구분했습니다.
  - `POSTED` → 성공
  - `DRAFT` → 중립
  - `REVERSED` → 검토
- 분개번호, 원천, 역분개 관계, 계정과목, 적요 등 긴 값에 전체 보기/접기를 적용했습니다.
- 목록과 상세 금액 표시에 `js/common/format.js`를 사용하도록 통일했습니다.
- 음수 금액은 빨간색과 괄호 표기를 함께 적용했습니다.
- 차변·대변 불일치 금액은 색상, 굵기, 밑줄 및 설명 문구로 구분했습니다.
- 상세행에 기존 응답의 적요 값을 함께 표시하도록 보완했습니다.

### Ajax 및 Toast

- 상세 조회와 불균형 조회에 로딩·빈 상태·오류 상태를 구분했습니다.
- Ajax 처리 중 `aria-busy`를 적용했습니다.
- 상세 조회, 불균형 조회, 역분개 및 정정 요청 실패 메시지에 오류코드와 요청 ID를 표시합니다.
- 역분개 성공 후 서버 렌더링으로 목록이 갱신되어도 성공 Toast가 유지되도록 보완했습니다.

### 접근성 및 반응형

- 표에 숨김 caption과 `scope="col"`을 적용했습니다.
- 목록 및 상세 표 스크롤 영역에 `role="region"`과 접근 가능한 이름을 추가했습니다.
- 분개 행에 `aria-selected`와 Enter/Space 키 선택을 적용했습니다.
- 행 내부의 링크·버튼·상세 보기 등은 행 선택 이벤트에서 제외했습니다.
- 권한 없는 사용자에게 역분개 버튼 비활성 사유를 `aria-describedby`로 제공합니다.
- Guidance 아이콘에 `aria-hidden="true"`를 적용했습니다.
- 화면 전용 `:focus-visible` 규칙을 추가했습니다.
- 1023px 이하에서는 목록과 상세를 단일 열로 전환하고, 767px 이하에서는 검색 조건을 단일 열로 표시합니다.

## 🔒 4. 기존 계약 보존

- 목록은 기존과 동일하게 조회 버튼을 제출해야만 서버에서 검색합니다.
- 다음 식별자와 동작 계약을 유지했습니다.
  - `data-can-reverse`
  - `data-selected-journal-id`
  - `id="ledger-filter-form"`
  - `id="notice-ledger"`
  - `id="imbalance-banner"`
  - `id="balance-banner"`
  - `id="detail-badge"`
  - `id="detail-body"`
  - `data-modal="journal-reverse"`
  - `data-modal="journal-correction-request"`
- 검색 및 페이지 이동 시 기존 쿼리 파라미터를 유지합니다.
- 공통 Modal 구조와 필수 사유 검증을 유지했습니다.
- Controller, Service, DTO, Mapper, DB, Flyway 및 문서는 변경하지 않았습니다.

## 🧪 5. 테스트

- [x] `node --check src/main/resources/static/js/features/ledger/ledger.js`
- [x] `./gradlew test --tests com.susukkang.fgc.ui.PublishingTemplateStructureTest`
- [x] `./gradlew test --tests com.susukkang.fgc.journal.controller.JournalViewControllerTest`
- [x] 레거시 `fgc-*` 클래스 잔존 여부 확인
- [x] 인라인 `style`, `<style>`, `<script>` 잔존 여부 확인
- [x] 화면 전용 CSS/JS 하드코딩 색상 잔존 여부 확인
- [x] `git diff --check`

전체 테스트도 실행했으나 현재 실행 환경에서 Docker/Testcontainers를 찾지 못해 PostgreSQL 통합 테스트가 실행되지 않았습니다.

- 전체 1,151건 중 282건이 동일한 Docker 미탐지 원인으로 실패
- 이번 변경과 관련된 구조 테스트와 Web MVC 테스트는 별도로 실행하여 성공 확인

## 🖥️ 6. 브라우저 QA

시드 데모 계정으로 별도 로컬 포트에서 확인했습니다.

- [x] `settle01` 로그인 및 LEDG-W01 접근
- [x] 조회 버튼을 누르기 전 자동 조회되지 않음
- [x] 조회 후 검색 조건 유지
- [x] 1440px 레이아웃
- [x] 900px 단일 열 레이아웃
- [x] 720px 모바일 검색 조건 레이아웃
- [x] 본문 전체 가로 넘침 없음
- [x] 표 영역에서만 가로 스크롤 발생
- [x] Ajax 오류 메시지와 Toast에 오류코드·요청 ID 표시
- [x] 브라우저 Console 오류 없음
- [x] `audit01`에서 `data-can-reverse=false` 확인

현재 로컬 DB에 분개 데이터가 없어 실제 행 선택, 역분개 버튼 및 모달 실행은 브라우저에서 재현하지 못했습니다. 해당 경로는 구조 테스트와 기존 Controller/API 테스트로 확인했습니다.

## 📋 7. 리뷰 요구사항

- 기존 MPA 목록 조회와 Ajax 상세 조회의 경계가 유지되는지
- 공통 컴포넌트 치환 후 기존 `id`, `name`, `th:*`, `data-*` 계약이 보존되는지
- 금액 포맷과 상태 배지가 서버 렌더링·JS 렌더링에서 동일한지
- 긴 값 전체 보기 동작과 HTML escape 처리
- 권한 없는 사용자의 역분개 버튼 비활성 안내
- 1023px/767px 반응형 전환과 표 영역 스크롤 범위
- 오류코드·요청 ID가 실패 Toast에 표시되는지

## 💬 8. 참고 사항

- 상세 응답에는 역분개 사유 필드가 제공되지 않아 기존 역분개 사유를 상세 패널에 표시하는 기능은 구현하지 않았습니다.
- 역분개 사유 조회가 필요하면 `JournalDetailResponse` 또는 별도의 정정 이력 조회 계약이 먼저 정의되어야 합니다.
- 실제 역분개 생성은 데이터를 변경하므로 이번 브라우저 QA에서는 수행하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 원장 화면을 공통 페이지 구성과 컴포넌트 기반 UI로 개편했습니다.
  - 검색 필터, 목록·상세 패널, 페이지네이션을 개선했습니다.
  - 금액·일자·상태 표시와 불균형 내역을 더 명확하게 표시합니다.
  - 행 선택, 상세 내용 공개, 로딩·오류 상태를 지원합니다.
  - 역분개 및 정정 요청 기능과 사유 입력 검증을 개선했습니다.
  - 화면 크기에 맞춰 목록, 상세 패널, 필터, 모달이 반응형으로 배치됩니다.
  - 키보드 탐색과 접근 가능한 상태 안내를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->