### PR TITLE
[Refactor] TRAN-W01·W02 공통 UI 컴포넌트 전환 (#284)

### DIFF
--- a/src/main/resources/static/css/common/components.css
+++ b/src/main/resources/static/css/common/components.css
@@ -658,34 +658,11 @@ a.kpi-card:active {
   gap: var(--space-1);
 }
 
-/*
- * 목록형 Ajax 페이지네이션: 페이지 번호 버튼이 세로로 쌓이지 않도록 한 줄로 유지한다.
- *
- * TODO(#138): 아래 세 선택자는 TRAN·SCHE 화면 전용이라 공통 파일에 있을 자리가 아니다.
- *   [data-transaction-page-numbers] → features/transaction.css 의 .transaction-page-numbers
- *   [data-transaction-pagination]   → features/transaction.css 의 .transaction-pagination
- *   [data-schedule-page-numbers]    → features/schedule.css 의 .schedule-page-numbers
- * data-* 훅은 JS 가 참조하므로 그대로 두고 스타일만 옮긴다.
- * 두 도메인이 같은 블록을 동시에 건드리지 않도록 TRAN 이슈가 먼저 옮기고 SCHE 가 뒤따른다.
- */
-[data-transaction-page-numbers],
+/* SCHE 목록형 Ajax 페이지네이션. SCHE 전용 CSS 이관 전까지 훅을 유지한다. */
 [data-schedule-page-numbers] {
   display: flex;
   align-items: center;
   gap: var(--space-1);
-}
-
-[data-transaction-pagination] {
-  display: flex;
-  min-height: 2.5rem;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 1rem;
-  padding: 0.5rem 1rem;
-  border-top: 1px solid var(--color-border-subtle);
-  color: var(--color-text-secondary);
-  font-size: 0.75rem;
-  line-height: 1.125rem;
 }
 
 .pagination-button {

--- a/src/main/resources/static/css/features/transaction.css
+++ b/src/main/resources/static/css/features/transaction.css
@@ -247,7 +247,6 @@
 .transaction-confirm-blockers { display: grid; gap: var(--space-3); }
 .transaction-confirm-summary { padding: var(--space-3); border-radius: var(--radius-8); background: var(--color-bg-subtle); }
 .transaction-confirm-blockers { padding: var(--space-3); border: 1px solid var(--color-status-error-border); border-radius: var(--radius-8); color: var(--color-status-error-text); background: var(--color-status-error-bg); }
-.transaction-confirm-links { display: flex; flex-wrap: wrap; gap: var(--space-2); }
 
 .transaction-page :is(a, button, input, select, textarea, summary):focus-visible {
   outline: 2px solid var(--color-border-focus);
@@ -276,6 +275,5 @@
   .transaction-form-grid { width: 100%; }
   .transaction-form-grid { grid-template-columns: 1fr; }
   .transaction-filter-checkbox { padding-block: var(--space-2); }
-  .transaction-add-attribution,
-  .transaction-confirm-links .button { width: 100%; }
+  .transaction-add-attribution { width: 100%; }
 }

--- a/src/main/resources/static/css/features/transaction.css
+++ b/src/main/resources/static/css/features/transaction.css
@@ -1,15 +1,281 @@
-/*
- * TRAN-W01·W02 화면 전용 스타일 (#138).
- *
- * 지금은 루트 레이아웃만 둔다. 컬럼 폭·화면 전용 Grid·반응형은 TRAN 담당 이슈에서 채운다.
- * 공통 컴포넌트(components.css)의 디자인을 여기에 다시 복사하지 않는다.
- *
- * 이관 예정: templates/transaction/form.html 의 <style> 블록, 두 템플릿의 인라인 style,
- *           components.css 의 [data-transaction-page-numbers]·[data-transaction-pagination].
- */
-
+/* TRAN-W01·W02 화면 전용 레이아웃과 상태 표현. */
 .transaction-page {
   display: grid;
   min-width: 0;
   gap: var(--space-4);
+}
+
+.transaction-page-header,
+.transaction-surface-header { min-width: 0; }
+
+.transaction-filter-bar { align-items: flex-end; }
+.transaction-filter-fields { flex: 1 1 auto; }
+.transaction-filter-month,
+.transaction-filter-stage,
+.transaction-filter-status-field { width: 8.5rem; }
+.transaction-filter-insurer,
+.transaction-filter-source,
+.transaction-filter-agent,
+.transaction-filter-item { width: 10rem; }
+.transaction-filter-contract { width: 9.5rem; }
+
+.transaction-filter-checkbox {
+  display: inline-flex;
+  min-height: var(--control-height-sm);
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.transaction-filter-checkbox input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--color-action-primary);
+}
+
+.transaction-filter-status { margin: calc(-1 * var(--space-2)) var(--space-3) 0; }
+
+.transaction-result-count,
+.transaction-panel-meta,
+.transaction-panel-placeholder {
+  color: var(--color-text-tertiary);
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+}
+
+.transaction-list-panel,
+.transaction-form-panel,
+.transaction-attribution-panel,
+.transaction-gate-panel,
+.transaction-cap-panel,
+.transaction-action-panel {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.transaction-list-table { min-width: 71.25rem; }
+.transaction-col-stage { width: 6.5rem; }
+.transaction-col-source { width: 7rem; }
+.transaction-col-business-key { width: 10.5rem; }
+.transaction-col-month { width: 5.5rem; }
+.transaction-col-agent { width: 9rem; }
+.transaction-col-item { width: 8.5rem; }
+.transaction-col-amount { width: 7rem; }
+.transaction-col-cashflow { width: 5rem; }
+.transaction-col-status { width: 5.5rem; }
+.transaction-col-attribution { width: 6.5rem; }
+.transaction-col-action { width: 5rem; }
+
+.transaction-state-row td {
+  height: 8rem;
+  white-space: normal;
+}
+
+.transaction-state {
+  display: grid;
+  justify-items: center;
+  gap: var(--space-2);
+  padding: var(--space-5);
+  text-align: center;
+}
+
+.transaction-state-title { color: var(--color-text-primary); font-weight: 700; }
+.transaction-state-copy { max-width: 36rem; color: var(--color-text-secondary); }
+.transaction-state-error .transaction-state-title,
+.transaction-state-error .transaction-state-icon { color: var(--color-status-error-text); }
+.transaction-state-icon { color: var(--color-icon-secondary); font-size: 1.5rem; }
+
+.transaction-pagination {
+  display: flex;
+  min-height: 2.5rem;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  border-top: 1px solid var(--color-border-subtle);
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+}
+
+.transaction-page-numbers { display: flex; align-items: center; gap: var(--space-1); }
+
+.transaction-form-layout {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(0, 1.55fr) minmax(20rem, 1fr);
+  gap: var(--space-4);
+}
+
+.transaction-form-column {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.transaction-form-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.transaction-mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+.transaction-number,
+.transaction-attribution-table input[type="number"] { text-align: right; font-variant-numeric: tabular-nums; }
+
+.transaction-screen-state {
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--color-status-info-border);
+  border-radius: var(--radius-8);
+  color: var(--color-status-info-text);
+  background: var(--color-status-info-bg);
+  font-size: 0.8125rem;
+}
+
+.transaction-screen-state.is-error {
+  border-color: var(--color-status-error-border);
+  color: var(--color-status-error-text);
+  background: var(--color-status-error-bg);
+}
+
+.transaction-attribution-table { min-width: 85rem; }
+
+.transaction-attribution-table input,
+.transaction-attribution-table select {
+  width: 100%;
+  height: var(--control-height-sm);
+  padding: 0 var(--space-2);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-6);
+  color: var(--color-text-primary);
+  background: var(--color-bg-surface);
+  font-size: 0.75rem;
+}
+
+.transaction-attribution-table input:focus,
+.transaction-attribution-table select:focus {
+  border-color: var(--color-border-focus);
+  outline: 0;
+  box-shadow: var(--shadow-focus);
+}
+
+.transaction-attr-col-index { width: 2.5rem; }
+.transaction-attr-col-scope { width: 6rem; }
+.transaction-attr-col-contract { width: 11rem; }
+.transaction-attr-col-agent { width: 9rem; }
+.transaction-attr-col-date { width: 8rem; }
+.transaction-attr-col-month { width: 8rem; }
+.transaction-attr-col-amount { width: 8rem; }
+.transaction-attr-col-decision { width: 9rem; }
+.transaction-attr-col-method { width: 10rem; }
+.transaction-attr-col-policy { width: 9rem; }
+.transaction-attr-col-evidence { width: 13rem; }
+.transaction-attr-col-action { width: 3.5rem; }
+.transaction-add-attribution { min-width: auto; }
+.transaction-attribution-error { margin: var(--space-3) var(--space-4); }
+
+.transaction-gate-list { padding-block: var(--space-2); }
+
+.transaction-gate-step {
+  display: grid;
+  grid-template-columns: 1.5rem minmax(0, 1fr);
+  gap: var(--space-3);
+  align-items: start;
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+.transaction-gate-step:last-child { border-bottom: 0; }
+
+.transaction-gate-icon {
+  display: grid;
+  width: 1.5rem;
+  height: 1.5rem;
+  place-items: center;
+  border-radius: var(--radius-full);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-subtle);
+  font-size: 0.875rem;
+}
+
+.transaction-gate-label { color: var(--color-text-primary); font-size: 0.8125rem; font-weight: 600; }
+.transaction-gate-detail { margin-top: var(--space-1); color: var(--color-text-tertiary); font-size: 0.75rem; line-height: 1.125rem; overflow-wrap: anywhere; }
+.transaction-gate-pass .transaction-gate-icon { color: var(--color-text-inverse); background: var(--color-status-success-solid); }
+.transaction-gate-fail .transaction-gate-icon { color: var(--color-text-inverse); background: var(--color-status-error-solid); }
+
+.transaction-cap-body { display: grid; gap: var(--space-3); }
+.transaction-cap-card {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--color-border-default);
+  border-top: 3px solid var(--color-action-primary);
+  border-radius: var(--radius-8);
+}
+
+.transaction-cap-heading,
+.transaction-cap-usage,
+.transaction-cap-amount-line { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); }
+.transaction-cap-heading,
+.transaction-cap-amount-line.is-emphasized { font-weight: 700; }
+.transaction-cap-progress {
+  width: 100%;
+  height: 0.625rem;
+  overflow: hidden;
+  border: 0;
+  border-radius: var(--radius-full);
+  color: var(--color-status-review-solid);
+  background: var(--color-bg-subtle);
+}
+.transaction-cap-progress::-webkit-progress-bar { background: var(--color-bg-subtle); }
+.transaction-cap-progress::-webkit-progress-value { background: currentColor; }
+.transaction-cap-progress::-moz-progress-bar { background: currentColor; }
+.transaction-cap-progress.is-normal { color: var(--color-status-success-solid); }
+.transaction-cap-progress.is-warning { color: var(--color-status-warning-solid); }
+.transaction-cap-progress.is-violation { color: var(--color-status-error-solid); }
+.transaction-cap-usage,
+.transaction-cap-amount-line { font-size: 0.75rem; }
+.transaction-cap-amount-line { padding-bottom: var(--space-2); border-bottom: 1px solid var(--color-border-default); }
+.is-negative-amount { color: var(--color-status-error-text); }
+
+.transaction-action-list { display: flex; flex-direction: column; gap: var(--space-2); }
+.transaction-confirm-body,
+.transaction-confirm-summary,
+.transaction-confirm-blockers { display: grid; gap: var(--space-3); }
+.transaction-confirm-summary { padding: var(--space-3); border-radius: var(--radius-8); background: var(--color-bg-subtle); }
+.transaction-confirm-blockers { padding: var(--space-3); border: 1px solid var(--color-status-error-border); border-radius: var(--radius-8); color: var(--color-status-error-text); background: var(--color-status-error-bg); }
+.transaction-confirm-links { display: flex; flex-wrap: wrap; gap: var(--space-2); }
+
+.transaction-page :is(a, button, input, select, textarea, summary):focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+}
+
+@media (max-width: 63.9375rem) {
+  .transaction-form-layout { grid-template-columns: 1fr; }
+  .transaction-form-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 47.9375rem) {
+  .transaction-page-header,
+  .transaction-surface-header,
+  .transaction-pagination { align-items: stretch; flex-direction: column; }
+  .transaction-filter-month,
+  .transaction-filter-stage,
+  .transaction-filter-status-field,
+  .transaction-filter-insurer,
+  .transaction-filter-source,
+  .transaction-filter-agent,
+  .transaction-filter-item,
+  .transaction-filter-contract,
+  .transaction-filter-checkbox,
+  .transaction-filter-actions,
+  .transaction-form-grid { width: 100%; }
+  .transaction-form-grid { grid-template-columns: 1fr; }
+  .transaction-filter-checkbox { padding-block: var(--space-2); }
+  .transaction-add-attribution,
+  .transaction-confirm-links .button { width: 100%; }
 }

--- a/src/main/resources/static/js/features/transaction/transaction-form.js
+++ b/src/main/resources/static/js/features/transaction/transaction-form.js
@@ -2,8 +2,10 @@
   "use strict";
 
   var apiClient = window.FgcUi && window.FgcUi.apiClient;
+  var format = window.FgcUi && window.FgcUi.format;
+  var modal = window.FgcUi && window.FgcUi.modal;
   var main = document.querySelector("[data-transaction-form]");
-  if (!apiClient || !main) return;
+  if (!apiClient || !format || !modal || !main) return;
 
   var AGENTS = [];
   var MANUAL_PAYMENT_SOURCE_TYPE = "GA_MANUAL_PAYMENT";
@@ -11,7 +13,17 @@
   var contracts = [];
   var attributionSequence = 0;
   var saving = false;
+  var initializationError = false;
   var paymentId = new URLSearchParams(window.location.search).get("id");
+  var lastPrecheckResult = null;
+  var GATES = [
+    { label: "귀속행 존재", keys: ["ATTRIBUTION_REQUIRED", "NO_ATTRIBUTION", "ATTRIBUTION_EMPTY"] },
+    { label: "귀속금액 합계 일치", keys: ["ATTRIBUTION_AMOUNT", "ATTRIBUTION_BALANCE", "MISMATCH"] },
+    { label: "검토필요 귀속 해소", keys: ["REVIEW_REQUIRED"] },
+    { label: "1,200% 한도", keys: ["CAP", "1200", "VIOLATION"] },
+    { label: "차익거래 검증", keys: ["ARBITRAGE"] },
+    { label: "증빙·업무키 검증", keys: ["EVIDENCE", "DUPLICATE", "BUSINESS_KEY"] }
+  ];
 
   var stage = document.getElementById("stage");
   var sourceType = document.getElementById("sourceType");
@@ -28,6 +40,15 @@
   var precheckButton = document.getElementById("btn-precheck");
   var confirmButton = document.getElementById("btn-confirm");
   var recipientField = document.getElementById("recipient-field");
+  var formStatus = document.getElementById("transaction-form-status");
+  var lockNotice = document.getElementById("draft-lock-notice");
+  var confirmSubmitButton = document.getElementById("btn-confirm-submit");
+  var confirmSummary = document.getElementById("transaction-confirm-summary");
+  var confirmBlockers = document.getElementById("transaction-confirm-blockers");
+  var confirmLinks = document.getElementById("transaction-confirm-links");
+  var capLink = document.getElementById("transaction-cap-link");
+  var exceptionLink = document.getElementById("transaction-exception-link");
+  var canProcess = !saveButton.disabled;
   var previousPaymentStage = stage.value;
 
   initializeSettlementMonth();
@@ -39,7 +60,8 @@
   addButton.addEventListener("click", addAttributionRow);
   saveButton.addEventListener("click", save);
   precheckButton.addEventListener("click", precheck);
-  confirmButton.addEventListener("click", confirmPayment);
+  confirmButton.addEventListener("click", openConfirmation);
+  confirmSubmitButton.addEventListener("click", confirmPayment);
   amount.addEventListener("input", updateAttributionSummary);
   settlementMonth.addEventListener("change", function () {
     loadAgents();
@@ -53,13 +75,28 @@
   item.addEventListener("change", syncAttributionModeForSelectedItem);
   recipient.addEventListener("change", handleRecipientChange);
 
+  renderGates([], null);
+  if (canProcess) {
+    precheckButton.disabled = !paymentId;
+    confirmButton.disabled = true;
+  }
+
   loadContracts()
     .then(function () {
       if (paymentId) return loadDraft(paymentId);
       return Promise.all([loadAgents(), loadCommissionItems()])
         .then(function () { syncPaymentStageUi(); addAttributionRow(); });
     })
-    .catch(function (error) { showError(error, "지급 건 화면을 초기화하지 못했습니다."); });
+    .then(function () {
+      main.setAttribute("aria-busy", "false");
+      if (!initializationError) formStatus.hidden = true;
+    })
+    .catch(function (error) {
+      main.setAttribute("aria-busy", "false");
+      formStatus.classList.add("is-error");
+      formStatus.textContent = format.errorText(error, "지급 건 화면을 초기화하지 못했습니다. 화면을 새로고침하세요.");
+      showError(error, "지급 건 화면을 초기화하지 못했습니다. 화면을 새로고침하세요.");
+    });
 
   function loadAgents() {
     var asOf = monthFirstDay();
@@ -89,6 +126,7 @@
       })
       .catch(function (error) {
         fillOptions(recipient, [], "설계사를 불러오지 못했습니다.");
+        markReferenceError(error, "설계사 목록을 불러오지 못했습니다. 정산월을 확인한 뒤 다시 시도하세요.");
         showError(error, "설계사 목록을 불러오지 못했습니다.");
       });
   }
@@ -102,7 +140,10 @@
           : [];
         refreshContractSelects();
       })
-      .catch(function (error) { showError(error, "계약 목록을 불러오지 못했습니다."); });
+      .catch(function (error) {
+        markReferenceError(error, "계약 목록을 불러오지 못했습니다. 잠시 후 다시 시도하세요.");
+        showError(error, "계약 목록을 불러오지 못했습니다.");
+      });
   }
 
   function loadCommissionItems() {
@@ -114,7 +155,10 @@
         item.dataset.items = JSON.stringify(items);
         filterCommissionItemsByCashflow();
       })
-      .catch(function (error) { showError(error, "수수료 항목을 불러오지 못했습니다."); });
+      .catch(function (error) {
+        markReferenceError(error, "수수료 항목을 불러오지 못했습니다. 정산월을 확인한 뒤 다시 시도하세요.");
+        showError(error, "수수료 항목을 불러오지 못했습니다.");
+      });
   }
 
   function filterCommissionItemsByCashflow() {
@@ -169,8 +213,8 @@
             applyAttributionMode(row);
           });
           if (!attrBody.querySelector("[data-attr-row]")) addAttributionRow();
-          document.getElementById("tx-status").textContent = "작성중 · #" + id;
-          saveButton.textContent = "수정 저장";
+          setTransactionStatus("작성중 · #" + id, "status-badge-neutral");
+          setButtonLabel(saveButton, "수정 저장");
           syncPaymentStageUi();
           previousPaymentStage = stage.value;
           updateAttributionAgentLabels();
@@ -180,7 +224,7 @@
   }
 
   function addAttributionRow() {
-    if (attrBody.querySelector(".fgc-empty")) clear(attrBody);
+    if (attrBody.querySelector(".empty-state")) clear(attrBody);
     attributionSequence += 1;
     var row = document.createElement("tr");
     row.dataset.attrRow = "";
@@ -201,8 +245,9 @@
     var removeCell = document.createElement("td");
     var removeButton = document.createElement("button");
     removeButton.type = "button";
-    removeButton.className = "fgc-btn fgc-btn--ghost";
-    removeButton.textContent = "×";
+    removeButton.className = "button button-ghost";
+    removeButton.textContent = "삭제";
+    removeButton.setAttribute("aria-label", attributionSequence + "번 귀속행 삭제");
     removeButton.addEventListener("click", function () {
       row.remove();
       renumberRows();
@@ -349,7 +394,7 @@
     if (!noContract) {
       noContract = document.createElement("span");
       noContract.dataset.noContract = "";
-      noContract.className = "fgc-muted";
+      noContract.className = "transaction-panel-meta";
       noContract.textContent = "-";
       noContract.hidden = true;
       contractCell.appendChild(noContract);
@@ -357,7 +402,7 @@
     if (!automaticMethod) {
       automaticMethod = document.createElement("span");
       automaticMethod.dataset.automaticMethod = "";
-      automaticMethod.className = "fgc-muted";
+      automaticMethod.className = "transaction-panel-meta";
       automaticMethod.textContent = "-";
       automaticMethod.hidden = true;
       methodCell.appendChild(automaticMethod);
@@ -438,16 +483,19 @@
   function save() {
     if (saving) return;
     var payload;
-    try { payload = buildPayload(); } catch (error) { showError(error, error.message); return; }
+    clearFieldErrors();
+    try { payload = buildPayload(); } catch (error) { showValidationError(error); return; }
 
     saving = true;
     saveButton.disabled = true;
+    main.setAttribute("aria-busy", "true");
+    setBusy(saveButton, true, "저장 중");
     var editing = Boolean(paymentId);
     var path = editing ? "/api/v1/transactions/" + encodeURIComponent(paymentId) : "/api/v1/transactions";
     apiClient.request(path, { method: editing ? "PUT" : "POST", body: payload })
       .then(function (envelope) {
         paymentId = envelope.data && envelope.data.commissionTransactionId;
-        document.getElementById("tx-status").textContent = "작성중 · #" + paymentId;
+        setTransactionStatus("작성중 · #" + paymentId, "status-badge-neutral");
         lockDraftInputs();
         precheckButton.disabled = false;
         confirmButton.disabled = true;
@@ -456,7 +504,9 @@
       .catch(function (error) { showError(error, "수수료 지급 건을 저장하지 못했습니다."); })
       .finally(function () {
         saving = false;
-        if (!paymentId) saveButton.disabled = false;
+        main.setAttribute("aria-busy", "false");
+        setBusy(saveButton, false, "임시저장 (검증 없음)");
+        if (!paymentId && canProcess) saveButton.disabled = false;
       });
   }
 
@@ -464,14 +514,17 @@
     if (!paymentId) return;
     precheckButton.disabled = true;
     confirmButton.disabled = true;
-    renderCapMessage("1,200% 한도를 계산하는 중입니다.");
+    setBusy(precheckButton, true, "검증 중");
+    renderCapMessage("loading", "1,200% 한도를 계산하는 중입니다.");
 
     apiClient.request("/api/v1/transactions/" + encodeURIComponent(paymentId) + "/precheck", {
       method: "POST"
     }).then(function (envelope) {
       var result = envelope.data;
+      lastPrecheckResult = result;
       renderPrecheck(result);
-      confirmButton.disabled = !result.confirmable;
+      confirmButton.disabled = !canProcess;
+      confirmButton.dataset.confirmable = String(result.confirmable === true);
       toast(
         result.confirmable
           ? "사전검증을 통과했습니다. 이제 확정할 수 있습니다."
@@ -481,48 +534,50 @@
       );
     }).catch(function (error) {
       showError(error, "1,200% 사전검증을 수행하지 못했습니다.");
-      renderCapMessage("사전검증 중 오류가 발생했습니다.");
+      renderCapMessage("error", format.errorText(error, "사전검증 중 오류가 발생했습니다. 다시 시도하세요."));
     }).finally(function () {
-      precheckButton.disabled = false;
+      setBusy(precheckButton, false, "사전검증");
+      precheckButton.disabled = !canProcess;
     });
   }
 
   function renderPrecheck(result) {
     var capBody = document.getElementById("cap-body");
     clear(capBody);
+    capBody.setAttribute("aria-busy", "false");
     (result.capPreview || []).forEach(function (preview) {
       capBody.appendChild(capPreviewCard(preview));
     });
     if (!result.capPreview || result.capPreview.length === 0) {
-      renderCapMessage("표시할 1,200% 검증 결과가 없습니다.");
+      renderCapMessage("empty", "표시할 1,200% 검증 결과가 없습니다.");
     }
     renderGates(result.blockers || [], result.confirmable);
   }
 
   function capPreviewCard(preview) {
     var card = document.createElement("div");
-    card.style.cssText = "border:1px solid #d8e0e8;border-top:3px solid #173b57;border-radius:10px;padding:16px;margin-bottom:12px";
+    card.className = "transaction-cap-card";
 
     var heading = document.createElement("div");
-    heading.style.cssText = "display:flex;justify-content:space-between;gap:12px;font-weight:700";
+    heading.className = "transaction-cap-heading";
     heading.appendChild(textElement("span", (preview.paymentStageLabel || preview.paymentStage) + " · " + preview.contractNo));
     var badge = textElement("span", preview.resultStatusLabel + statusSuffix(preview.resultStatus));
-    badge.style.cssText = statusStyle(preview.resultStatus);
+    badge.className = "status-badge " + capStatusBadge(preview.resultStatus);
     heading.appendChild(badge);
     card.appendChild(heading);
 
     var usage = Math.max(0, number(preview.usagePct));
-    var track = document.createElement("div");
-    track.style.cssText = "height:10px;background:#e5e7eb;border-radius:999px;margin:14px 0 6px;overflow:hidden";
-    var bar = document.createElement("div");
-    bar.style.cssText = "height:100%;width:" + Math.min(usage, 100) + "%;background:" + statusColor(preview.resultStatus);
-    track.appendChild(bar);
-    card.appendChild(track);
+    var progress = document.createElement("progress");
+    progress.className = "transaction-cap-progress " + capBarClass(preview.resultStatus);
+    progress.max = 100;
+    progress.value = Math.min(usage, 100);
+    progress.setAttribute("aria-label", "한도 사용률 " + format.usageRate(preview.usagePct) + "%");
+    card.appendChild(progress);
 
     var usageLine = document.createElement("div");
-    usageLine.style.cssText = "display:flex;justify-content:space-between;font-size:12px;margin-bottom:12px";
-    usageLine.appendChild(textElement("span", "사용률 " + preview.usagePct + "%"));
-    usageLine.appendChild(textElement("span", "한도 " + money(preview.limitAmount)));
+    usageLine.className = "transaction-cap-usage";
+    usageLine.appendChild(textElement("span", "사용률 " + format.usageRate(preview.usagePct) + "%"));
+    usageLine.appendChild(textElement("span", "한도 " + format.won(preview.limitAmount)));
     card.appendChild(usageLine);
 
     card.appendChild(amountLine("이번 건 전 산입 누계", preview.existingIncludedAmount));
@@ -534,11 +589,10 @@
 
   function amountLine(label, value, emphasize) {
     var line = document.createElement("div");
-    line.style.cssText = "display:flex;justify-content:space-between;padding:8px 0;border-bottom:1px solid #e5e7eb;font-size:13px";
-    if (emphasize) line.style.fontWeight = "700";
+    line.className = "transaction-cap-amount-line" + (emphasize ? " is-emphasized" : "");
     line.appendChild(textElement("span", label));
-    var amountText = textElement("span", money(value));
-    if (number(value) < 0) amountText.style.color = "#ef4444";
+    var amountText = textElement("span", format.won(value));
+    if (format.isNegative(value)) amountText.className = "is-negative-amount";
     line.appendChild(amountText);
     return line;
   }
@@ -546,39 +600,102 @@
   function renderGates(blockers, confirmable) {
     var gateList = document.getElementById("gate-list");
     clear(gateList);
-    if (confirmable) {
-      var success = textElement("div", "✓ 확정 게이트를 모두 통과했습니다.");
-      success.style.cssText = "color:#15803d;font-weight:700;padding:10px 0";
-      gateList.appendChild(success);
-      return;
-    }
-    blockers.forEach(function (blocker, index) {
+    var matched = GATES.map(function () { return []; });
+    (blockers || []).forEach(function (blocker) {
+      var haystack = String((blocker && blocker.code) || "") + " " + String((blocker && blocker.message) || "");
+      haystack = haystack.toUpperCase();
+      var index = GATES.findIndex(function (gate) {
+        return gate.keys.some(function (key) { return haystack.indexOf(key) !== -1; });
+      });
+      matched[index < 0 ? GATES.length - 1 : index].push(blocker);
+    });
+
+    GATES.forEach(function (gate, index) {
+      var failures = matched[index];
+      var state = confirmable === true ? "pass" : failures.length ? "fail" : "todo";
       var row = document.createElement("div");
-      row.className = "gate-step gate--fail";
-      var no = textElement("span", index + 1);
-      no.className = "gate-no";
-      row.appendChild(no);
-      row.appendChild(textElement("span", blocker.message || blocker.code));
+      row.className = "transaction-gate-step transaction-gate-" + state;
+      var icon = textElement("span", state === "pass" ? "check" : state === "fail" ? "close" : "more_horiz");
+      icon.className = "material-symbols-rounded transaction-gate-icon";
+      icon.setAttribute("aria-hidden", "true");
+      row.appendChild(icon);
+      var copy = document.createElement("div");
+      var label = textElement("div", (index + 1) + ". " + gate.label + " · " + (state === "pass" ? "통과" : state === "fail" ? "차단" : "미확인"));
+      label.className = "transaction-gate-label";
+      copy.appendChild(label);
+      var detail = textElement("div", failures.length
+        ? failures.map(function (blocker) { return blocker.message || blocker.code; }).join(" / ")
+        : state === "pass" ? "서버 사전검증 결과 통과했습니다." : "사전검증 후 서버 판정이 표시됩니다.");
+      detail.className = "transaction-gate-detail";
+      copy.appendChild(detail);
+      row.appendChild(copy);
       gateList.appendChild(row);
     });
-    if (blockers.length === 0) {
-      gateList.appendChild(textElement("div", "확정할 수 없습니다. 입력값과 검증 결과를 확인하세요."));
-    }
+  }
+
+  function openConfirmation() {
+    if (!paymentId || confirmButton.disabled || !lastPrecheckResult) return;
+    prepareConfirmation(lastPrecheckResult);
+    modal.open("transaction-confirm");
+  }
+
+  function prepareConfirmation(result) {
+    clear(confirmSummary);
+    confirmSummary.appendChild(summaryLine("업무키", bizKey.value || "-"));
+    confirmSummary.appendChild(summaryLine("지급액", format.won(amount.value)));
+    confirmSummary.appendChild(summaryLine("흐름", cashflow.options[cashflow.selectedIndex].textContent));
+    confirmSummary.appendChild(summaryLine("서버 판정", result.confirmable ? "확정 가능" : "확정 차단"));
+
+    clear(confirmBlockers);
+    var blockers = result.blockers || [];
+    blockers.forEach(function (blocker) {
+      confirmBlockers.appendChild(textElement("p", (blocker.code ? blocker.code + " · " : "") + (blocker.message || "확정 차단 사유를 확인하세요.")));
+    });
+    confirmBlockers.hidden = blockers.length === 0;
+    confirmSubmitButton.hidden = result.confirmable !== true;
+    confirmSubmitButton.disabled = result.confirmable !== true;
+    configureResultLinks(result);
+  }
+
+  function configureResultLinks(result) {
+    var preview = (result.capPreview || []).find(function (entry) { return entry.capCheckId != null; });
+    var capCheckId = result.capCheckId || (preview && preview.capCheckId);
+    var exceptionCaseId = result.exceptionCaseId || result.exceptionId;
+    capLink.hidden = capCheckId == null;
+    exceptionLink.hidden = exceptionCaseId == null;
+    if (capCheckId != null) capLink.href = "/cap-checks?capCheckId=" + encodeURIComponent(capCheckId);
+    if (exceptionCaseId != null) exceptionLink.href = "/exceptions?exceptionCaseId=" + encodeURIComponent(exceptionCaseId);
+    confirmLinks.hidden = capLink.hidden && exceptionLink.hidden;
   }
 
   function confirmPayment() {
-    if (!paymentId || confirmButton.disabled) return;
+    if (!paymentId || !lastPrecheckResult || lastPrecheckResult.confirmable !== true) return;
+    confirmSubmitButton.disabled = true;
     confirmButton.disabled = true;
+    main.setAttribute("aria-busy", "true");
+    setBusy(confirmSubmitButton, true, "확정 중");
     apiClient.request("/api/v1/transactions/" + encodeURIComponent(paymentId) + "/confirm", {
       method: "POST",
       idempotencyKey: "TRAN-CONFIRM-" + paymentId
-    }).then(function () {
-      document.getElementById("tx-status").textContent = "확정 · #" + paymentId;
+    }).then(function (envelope) {
+      setTransactionStatus("확정 · #" + paymentId, "status-badge-success");
       toast("수수료 지급 건을 확정했습니다.", "success", 3000);
+      modal.close("transaction-confirm");
       window.setTimeout(function () { window.location.assign("/transactions"); }, 900);
     }).catch(function (error) {
       showError(error, "수수료 지급 건을 확정하지 못했습니다.");
-      precheckButton.disabled = false;
+      var failedResult = {
+        confirmable: false,
+        blockers: [{ code: error.code, message: format.errorText(error, "수수료 지급 건을 확정하지 못했습니다. 입력값과 예외함을 확인하세요.") }],
+        capCheckId: error.params && error.params.capCheckId,
+        exceptionCaseId: error.params && error.params.exceptionCaseId,
+        capPreview: []
+      };
+      prepareConfirmation(failedResult);
+      precheckButton.disabled = !canProcess;
+    }).finally(function () {
+      main.setAttribute("aria-busy", "false");
+      setBusy(confirmSubmitButton, false, "확정 실행");
     });
   }
 
@@ -587,19 +704,22 @@
     attrBody.querySelectorAll("button").forEach(function (button) { button.disabled = true; });
     addButton.disabled = true;
     saveButton.disabled = true;
+    lockNotice.hidden = false;
   }
 
-  function renderCapMessage(message) {
+  function renderCapMessage(kind, message) {
     var capBody = document.getElementById("cap-body");
     clear(capBody);
     var text = textElement("p", message);
-    text.className = "fgc-muted";
+    text.className = "transaction-panel-placeholder transaction-cap-state transaction-cap-state-" + kind;
+    text.setAttribute("role", kind === "error" ? "alert" : "status");
     capBody.appendChild(text);
+    capBody.setAttribute("aria-busy", String(kind === "loading"));
   }
 
   function statusSuffix(status) { return status === "VIOLATION" ? "(100% 초과)" : ""; }
-  function statusColor(status) { return { NORMAL: "#22c55e", WARNING: "#f59e0b", VIOLATION: "#ef4444", REVIEW_REQUIRED: "#64748b" }[status] || "#64748b"; }
-  function statusStyle(status) { return "font-size:12px;padding:3px 7px;border-radius:4px;color:" + statusColor(status) + ";border:1px solid " + statusColor(status); }
+  function capStatusBadge(status) { return { NORMAL: "status-badge-success", WARNING: "status-badge-warning", VIOLATION: "status-badge-error", REVIEW_REQUIRED: "status-badge-review" }[status] || "status-badge-neutral"; }
+  function capBarClass(status) { return { NORMAL: "is-normal", WARNING: "is-warning", VIOLATION: "is-violation" }[status] || "is-review"; }
   function textElement(tag, text) { var element = document.createElement(tag); element.textContent = text; return element; }
   function toast(message, tone, duration) { if (window.FgcUi && typeof window.FgcUi.toast === "function") window.FgcUi.toast(message, tone, duration); }
 
@@ -609,7 +729,7 @@
     if (!isInsurerToGa()) requireValue(recipient, "수령 설계사");
     requireValue(item, "수수료 항목"); requireValue(amount, "금액");
     var attributions = Array.from(attrBody.querySelectorAll("[data-attr-row]")).map(attributionPayload);
-    if (attributions.length === 0) throw new Error("귀속행을 하나 이상 추가하세요.");
+    if (attributions.length === 0) throw validationError("귀속행을 하나 이상 추가하세요.", null, "err-attributions");
     return {
       sourceType: sourceType.value,
       sourceBusinessKey: bizKey.value.trim(),
@@ -640,10 +760,10 @@
     var attributionMethod = row.querySelector("[data-attr-method]").value;
     var allocationBasis = blankToNull(row.querySelector("[data-allocation-basis]").value);
     if ((decision.inclusionStatus === "EXCLUDED" || newcomerSupport) && !rowEvidence) {
-      throw new Error("제외 귀속행은 제외유형과 증빙을 입력해야 합니다.");
+      throw validationError("제외 귀속행은 제외유형과 증빙을 입력해야 합니다.", row.querySelector("[data-attr-evidence]"), "err-attributions");
     }
     if (attributionMethod === "APPROVED_ALLOCATION" && !allocationBasis) {
-      throw new Error("승인 배부에는 배부정책을 입력해야 합니다.");
+      throw validationError("승인 배부에는 배부정책을 입력해야 합니다.", row.querySelector("[data-allocation-basis]"), "err-attributions");
     }
     return {
       contractId: newcomerSupport ? null : Number(contract.value), attributionDate: date.value,
@@ -658,10 +778,10 @@
     var sum = Array.from(attrBody.querySelectorAll("[data-attr-amount]"))
       .reduce(function (total, input) { return total + number(input.value); }, 0);
     var difference = number(amount.value) - sum;
-    document.getElementById("attr-sum").textContent = money(sum);
+    document.getElementById("attr-sum").textContent = format.won(sum);
     var diff = document.getElementById("attr-diff");
-    diff.textContent = difference === 0 ? "지급액과 일치" : "차액 " + money(difference);
-    diff.style.color = difference === 0 ? "#15803d" : "#d92d20";
+    diff.textContent = difference === 0 ? "일치" : "불일치 · 차액 " + format.won(difference);
+    diff.className = "status-badge " + (difference === 0 ? "status-badge-success" : "status-badge-error");
   }
 
   function suggestedAmount() {
@@ -714,8 +834,7 @@
       settlementMonth.value = globalMonth;
       return;
     }
-    var today = new Date();
-    settlementMonth.value = String(today.getFullYear()) + "-" + String(today.getMonth() + 1).padStart(2, "0");
+    settlementMonth.value = format.today().slice(0, 7);
   }
   function decisionReason(decision) {
     var labels = {
@@ -740,6 +859,88 @@
       + String(now.getMilliseconds()).padStart(3, "0");
   }
 
+  function summaryLine(label, value) {
+    var line = document.createElement("div");
+    line.className = "transaction-cap-amount-line";
+    line.appendChild(textElement("span", label));
+    line.appendChild(textElement("strong", value));
+    return line;
+  }
+
+  function setTransactionStatus(label, tone) {
+    var status = document.getElementById("tx-status");
+    status.textContent = label;
+    status.className = "status-badge " + tone;
+  }
+
+  function setBusy(button, busy, label) {
+    button.classList.toggle("is-loading", busy);
+    button.setAttribute("aria-busy", String(busy));
+    setButtonLabel(button, label);
+  }
+
+  function setButtonLabel(button, label) {
+    var slot = button.querySelector("[data-button-label]");
+    if (slot) slot.textContent = label;
+  }
+
+  function validationError(message, control, slotId) {
+    var error = new Error(message);
+    error.control = control;
+    error.slotId = slotId;
+    return error;
+  }
+
+  function clearFieldErrors() {
+    main.querySelectorAll("[id^='err-']").forEach(function (slot) {
+      slot.hidden = true;
+      slot.textContent = "";
+    });
+    main.querySelectorAll("[aria-invalid='true']").forEach(function (control) {
+      control.removeAttribute("aria-invalid");
+      var field = control.closest(".field");
+      if (field) field.classList.remove("is-error");
+    });
+  }
+
+  function showValidationError(error) {
+    var slot = document.getElementById(error.slotId || "err-attributions");
+    if (slot) {
+      slot.textContent = error.message;
+      slot.hidden = false;
+    }
+    if (error.control) {
+      error.control.setAttribute("aria-invalid", "true");
+      var field = error.control.closest(".field");
+      if (field) field.classList.add("is-error");
+      error.control.focus();
+    } else if (slot) {
+      slot.scrollIntoView({ block: "nearest" });
+    }
+  }
+
+  function showServerFieldError(fieldName, message) {
+    var controls = {
+      sourceType: sourceType,
+      sourceBusinessKey: bizKey,
+      settlementMonth: settlementMonth,
+      agentId: recipient,
+      commissionItemId: item,
+      amount: amount,
+      evidenceRef: evidence
+    };
+    var control = controls[fieldName];
+    if (!control) return;
+    showValidationError(validationError(message, control, "err-" + control.id));
+  }
+
+  function markReferenceError(error, fallback) {
+    initializationError = true;
+    formStatus.hidden = false;
+    formStatus.classList.add("is-error");
+    formStatus.textContent = format.errorText(error, fallback);
+  }
+
   function fillOptions(select, entries, placeholder) {
     clear(select);
     if (placeholder) addOption(select, "", placeholder);
@@ -751,15 +952,18 @@
   function controlCell(control) { var cell = document.createElement("td"); cell.appendChild(control); return cell; }
   function appendTextCell(row, value) { var cell = document.createElement("td"); cell.textContent = value; row.appendChild(cell); return cell; }
   function renumberRows() { attrBody.querySelectorAll("[data-attr-row]").forEach(function (row, index) { row.firstElementChild.textContent = index + 1; }); }
-  function renderEmptyAttributions() { var row = document.createElement("tr"); var cell = document.createElement("td"); var empty = document.createElement("div"); cell.colSpan = 12; empty.className = "fgc-empty"; empty.textContent = "귀속행을 추가하세요."; cell.appendChild(empty); row.appendChild(cell); attrBody.appendChild(row); }
-  function requireValue(control, label) { if (!control.value || (control.type === "number" && number(control.value) < 0)) { control.focus(); throw new Error(label + "을(를) 확인하세요."); } }
+  function renderEmptyAttributions() { var row = document.createElement("tr"); var cell = document.createElement("td"); var empty = document.createElement("div"); cell.colSpan = 12; empty.className = "empty-state"; empty.textContent = "귀속행을 추가하세요."; cell.appendChild(empty); row.appendChild(cell); attrBody.appendChild(row); }
+  function requireValue(control, label) {
+    if (!control.value || (control.type === "number" && number(control.value) < 0)) {
+      throw validationError("필수값을 확인하세요: " + label, control, control.closest("[data-attr-row]") ? "err-attributions" : "err-" + control.id);
+    }
+  }
   function showError(error, fallback) {
-    var message = error && (error.detail || error.message) ? (error.detail || error.message) : fallback;
-    if (error && error.field && !error.detail) message += " (" + error.field + ")";
+    var message = format.errorText(error, fallback);
+    if (error && error.field) showServerFieldError(error.field, message);
     toast(message, "error", 8000);
   }
   function blankToNull(value) { var trimmed = String(value || "").trim(); return trimmed || null; }
   function number(value) { var parsed = Number(value); return Number.isFinite(parsed) ? parsed : 0; }
-  function money(value) { return new Intl.NumberFormat("ko-KR", { maximumFractionDigits: 0 }).format(number(value)) + "원"; }
   function clear(element) { while (element.firstChild) element.removeChild(element.firstChild); }
 })();

--- a/src/main/resources/static/js/features/transaction/transaction-form.js
+++ b/src/main/resources/static/js/features/transaction/transaction-form.js
@@ -16,13 +16,28 @@
   var initializationError = false;
   var paymentId = new URLSearchParams(window.location.search).get("id");
   var lastPrecheckResult = null;
+  /*
+   * 확정 게이트 6단계 — 화면정의서 :710-718 · 운영정책서 제31조의 순서를 그대로 옮긴다.
+   * 게이트를 임의로 늘리거나 줄이지 않는다. 이전 구현은 차익거래·업무키 게이트를 만들어 넣었는데
+   * 두 문서 어디에도 없고(화면정의서 :795 "검증 시 생성: cap_check, exception_case",
+   * 제31조 게이트 목록) precheck 가 해당 코드를 발행하지도 않아 영구히 판정되지 않는 칸이었다.
+   *
+   * codes 는 IF-API-24 blockers[] 의 오류 카탈로그 코드다. Blocker.code 는 FgcErrorCode.getCode()
+   * ("FGC-TRAN-002" 형태), message 는 부록 A 한글 표준 문구이므로
+   * (TransactionPrecheckResponse.Blocker) 영문 키워드 부분일치로는 분류할 수 없다 —
+   * 이전 구현에서 "FGC-CAP-*" 가 전부 "CAP" 키에 걸려 한도 게이트로 몰리고
+   * 나머지는 마지막 게이트로 떨어지던 원인이다.
+   *
+   * 6단계는 검사가 아니라 "앞 단계를 전부 통과하면 확정" 이라는 결과다 —
+   * 앞의 어느 게이트에도 속하지 않는 차단 사유(증빙 누락·정책버전 없음 등)를 여기서 받는다.
+   */
   var GATES = [
-    { label: "귀속행 존재", keys: ["ATTRIBUTION_REQUIRED", "NO_ATTRIBUTION", "ATTRIBUTION_EMPTY"] },
-    { label: "귀속금액 합계 일치", keys: ["ATTRIBUTION_AMOUNT", "ATTRIBUTION_BALANCE", "MISMATCH"] },
-    { label: "검토필요 귀속 해소", keys: ["REVIEW_REQUIRED"] },
-    { label: "1,200% 한도", keys: ["CAP", "1200", "VIOLATION"] },
-    { label: "차익거래 검증", keys: ["ARBITRAGE"] },
-    { label: "증빙·업무키 검증", keys: ["EVIDENCE", "DUPLICATE", "BUSINESS_KEY"] }
+    { label: "작성중(DRAFT) 저장", codes: ["FGC-TRAN-005"] },
+    { label: "귀속행 입력", codes: ["FGC-TRAN-002"] },
+    { label: "귀속합계 = 지급액", codes: ["FGC-TRAN-003"] },
+    { label: "검토필요 귀속 해소", codes: ["FGC-CAP-002"] },
+    { label: "1,200% 사전검증", codes: ["FGC-CAP-001", "FGC-CAP-003", "FGC-CAP-004"] },
+    { label: "전부 통과 → 확정", codes: [] }
   ];
 
   var stage = document.getElementById("stage");
@@ -45,9 +60,6 @@
   var confirmSubmitButton = document.getElementById("btn-confirm-submit");
   var confirmSummary = document.getElementById("transaction-confirm-summary");
   var confirmBlockers = document.getElementById("transaction-confirm-blockers");
-  var confirmLinks = document.getElementById("transaction-confirm-links");
-  var capLink = document.getElementById("transaction-cap-link");
-  var exceptionLink = document.getElementById("transaction-exception-link");
   var canProcess = !saveButton.disabled;
   var previousPaymentStage = stage.value;
 
@@ -602,17 +614,32 @@
     clear(gateList);
     var matched = GATES.map(function () { return []; });
     (blockers || []).forEach(function (blocker) {
-      var haystack = String((blocker && blocker.code) || "") + " " + String((blocker && blocker.message) || "");
-      haystack = haystack.toUpperCase();
+      var code = String((blocker && blocker.code) || "");
       var index = GATES.findIndex(function (gate) {
-        return gate.keys.some(function (key) { return haystack.indexOf(key) !== -1; });
+        return gate.codes.indexOf(code) !== -1;
       });
+      /* 어느 게이트에도 없는 코드는 마지막 "전부 통과 → 확정" 이 받는다. */
       matched[index < 0 ? GATES.length - 1 : index].push(blocker);
     });
 
+    /*
+     * 제31조는 "반드시 다음 순서로 처리한다" 이고 precheck 도 앞 단계가 막히면 뒤 단계 계산에
+     * 도달하지 못한다(예: 귀속행이 없으면 한도 계산 루프 자체를 돌지 않는다).
+     * 그래서 앞 게이트가 차단이면 뒤 게이트는 "통과" 가 아니라 "미확인" 으로 둔다 —
+     * 판정되지 않은 것을 통과로 보이게 하지 않는다.
+     */
+    var blockedBefore = false;
+    /* 사전검증 전에는 confirmable 이 null 이다 — 아직 아무것도 판정되지 않았다. */
+    var evaluated = confirmable != null;
+
     GATES.forEach(function (gate, index) {
       var failures = matched[index];
-      var state = confirmable === true ? "pass" : failures.length ? "fail" : "todo";
+      var state;
+      if (!evaluated) state = "todo";
+      else if (confirmable === true) state = "pass";
+      else if (failures.length) state = "fail";
+      else state = blockedBefore ? "todo" : "pass";
+      if (failures.length) blockedBefore = true;
       var row = document.createElement("div");
       row.className = "transaction-gate-step transaction-gate-" + state;
       var icon = textElement("span", state === "pass" ? "check" : state === "fail" ? "close" : "more_horiz");
@@ -625,7 +652,9 @@
       copy.appendChild(label);
       var detail = textElement("div", failures.length
         ? failures.map(function (blocker) { return blocker.message || blocker.code; }).join(" / ")
-        : state === "pass" ? "서버 사전검증 결과 통과했습니다." : "사전검증 후 서버 판정이 표시됩니다.");
+        : state === "pass" ? "서버 사전검증 결과 통과했습니다."
+          : evaluated ? "앞 단계가 막혀 아직 판정하지 않았습니다."
+            : "사전검증 후 서버 판정이 표시됩니다.");
       detail.className = "transaction-gate-detail";
       copy.appendChild(detail);
       row.appendChild(copy);
@@ -654,19 +683,17 @@
     confirmBlockers.hidden = blockers.length === 0;
     confirmSubmitButton.hidden = result.confirmable !== true;
     confirmSubmitButton.disabled = result.confirmable !== true;
-    configureResultLinks(result);
   }
 
-  function configureResultLinks(result) {
-    var preview = (result.capPreview || []).find(function (entry) { return entry.capCheckId != null; });
-    var capCheckId = result.capCheckId || (preview && preview.capCheckId);
-    var exceptionCaseId = result.exceptionCaseId || result.exceptionId;
-    capLink.hidden = capCheckId == null;
-    exceptionLink.hidden = exceptionCaseId == null;
-    if (capCheckId != null) capLink.href = "/cap-checks?capCheckId=" + encodeURIComponent(capCheckId);
-    if (exceptionCaseId != null) exceptionLink.href = "/exceptions?exceptionCaseId=" + encodeURIComponent(exceptionCaseId);
-    confirmLinks.hidden = capLink.hidden && exceptionLink.hidden;
-  }
+  /*
+   * 계산근거·예외함 링크는 두지 않는다 — 내려줄 ID 가 없다.
+   * IF-API-24 는 아무것도 저장하지 않는 미리보기라 CapPreviewItem.capCheckId 는 항상 null 이고
+   * (TransactionPrecheckResponse 주석), 응답에 exceptionCaseId 자체가 없다.
+   * 확정 실패 응답의 params 도 문구 치환값(a·b·c)만 담아 링크용 ID 가 오지 않는다.
+   * 세 경로 모두 막혀 있어 버튼은 영구히 hidden 이었다 —
+   * "API 없는 기능을 동작하는 것처럼 만들지 않는다"(이슈 #283).
+   * 확정 경로에서 cap_check·exception_case ID 를 내려주게 되면 그때 별도 이슈로 되살린다.
+   */
 
   function confirmPayment() {
     if (!paymentId || !lastPrecheckResult || lastPrecheckResult.confirmable !== true) return;

--- a/src/main/resources/static/js/features/transaction/transaction-list.js
+++ b/src/main/resources/static/js/features/transaction/transaction-list.js
@@ -29,6 +29,7 @@ if (typeof module !== "undefined" && module.exports) {
   if (typeof window === "undefined" || typeof document === "undefined") return;
 
   var apiClient = window.FgcUi && window.FgcUi.apiClient;
+  var format = window.FgcUi && window.FgcUi.format;
   var form = document.querySelector("[data-transaction-filter-form]");
   var body = document.getElementById("list-body");
   var pagination = document.querySelector("[data-transaction-pagination]");
@@ -37,8 +38,9 @@ if (typeof module !== "undefined" && module.exports) {
   var currentPageText = document.querySelector("[data-transaction-current-page]");
   var totalPagesText = document.querySelector("[data-transaction-total-pages]");
   var pageNumbers = document.querySelector("[data-transaction-page-numbers]");
+  var filterStatus = document.getElementById("transaction-filter-status");
 
-  if (!apiClient || !form || !body || !pagination || !previousButton || !nextButton) return;
+  if (!apiClient || !format || !form || !body || !pagination || !previousButton || !nextButton) return;
 
   var fields = {
     month: document.getElementById("f-month"),
@@ -83,6 +85,8 @@ if (typeof module !== "undefined" && module.exports) {
   });
   previousButton.addEventListener("click", function () { changePage(pageGroupStart(state.page) - 1); });
   nextButton.addEventListener("click", function () { changePage(pageGroupStart(state.page) + 5); });
+  window.addEventListener("resize", syncTableCellDisclosures);
+  if (document.fonts && document.fonts.ready) document.fonts.ready.then(syncTableCellDisclosures);
 
   load();
 
@@ -121,7 +125,8 @@ if (typeof module !== "undefined" && module.exports) {
     var sequence = ++requestSequence;
     if (activeRequest) activeRequest.abort();
     activeRequest = new AbortController();
-    renderMessage("수수료 지급 건을 불러오는 중입니다.", false);
+    body.setAttribute("aria-busy", "true");
+    renderState("loading", "불러오는 중", "수수료 지급 건을 불러오는 중입니다.");
     pagination.hidden = true;
 
     apiClient.request(apiPath(), { signal: activeRequest.signal })
@@ -135,11 +140,14 @@ if (typeof module !== "undefined" && module.exports) {
       .catch(function (error) {
         if (error && error.name === "AbortError") return;
         if (sequence !== requestSequence) return;
-        var message = error && error.message ? error.message : "수수료 지급 건을 불러오지 못했습니다.";
-        if (error && error.requestId) message += " 요청번호 " + error.requestId;
-        renderMessage(message, true);
+        var message = format.errorText(error, "수수료 지급 건을 불러오지 못했습니다. 잠시 후 다시 시도하세요.");
+        renderState("error", "목록을 불러오지 못했습니다", message, load);
+        toast(message, "error");
         setText("row-count", 0);
-        setText("sum-amount", formatMoney(0));
+        setText("sum-amount", format.won(0));
+      })
+      .finally(function () {
+        if (sequence === requestSequence) body.setAttribute("aria-busy", "false");
       });
   }
 
@@ -155,21 +163,21 @@ if (typeof module !== "undefined" && module.exports) {
   function renderRows(rows) {
     clear(body);
     var sum = 0;
-    if (rows.length === 0) renderMessage("조건에 맞는 자료가 없습니다.", false);
+    if (rows.length === 0) renderState("empty", "조회 결과가 없습니다", "검색 조건을 바꾸어 다시 조회하세요.");
 
     rows.forEach(function (item) {
       rememberFilterOptions(item);
       sum += number(item.amount);
       var row = document.createElement("tr");
       appendCell(row, item.paymentStageLabel || item.paymentStage);
-      appendCell(row, item.sourceTypeLabel || item.sourceType);
-      appendCell(row, item.sourceBusinessKey, "fgc-mono");
-      appendCell(row, formatMonth(item.settlementMonth));
-      appendCell(row, item.recipientAgentName || "—");
-      appendCell(row, item.commissionItemName || item.commissionItemCode);
-      appendCell(row, formatMoney(item.amount), "fgc-td-num");
-      appendCell(row, item.cashflowTypeLabel || item.cashflowType);
-      appendCell(row, item.statusLabel || item.status);
+      appendDisclosureCell(row, item.sourceTypeLabel || item.sourceType);
+      appendDisclosureCell(row, item.sourceBusinessKey, "transaction-mono");
+      appendCell(row, format.month(item.settlementMonth));
+      appendDisclosureCell(row, item.recipientAgentName || "-");
+      appendDisclosureCell(row, item.commissionItemName || item.commissionItemCode);
+      appendCell(row, format.won(item.amount), "is-number tabular-nums");
+      appendBadgeCell(row, item.cashflowTypeLabel || item.cashflowType, cashflowBadge(item.cashflowType));
+      appendBadgeCell(row, item.statusLabel || item.status, statusBadge(item.status));
       appendAttributionCell(row, item.attributionCount, item.differenceAmount);
       appendActionCell(row, item);
       body.appendChild(row);
@@ -177,17 +185,18 @@ if (typeof module !== "undefined" && module.exports) {
 
     refreshDynamicOptions();
     setText("row-count", rows.length);
-    setText("sum-amount", formatMoney(sum));
+      setText("sum-amount", format.won(sum));
+    syncTableCellDisclosures();
   }
 
   function appendAttributionCell(row, count, difference) {
     var cell = document.createElement("td");
     var value = number(count);
-    cell.textContent = value + "건";
-    if (value === 0 || number(difference) !== 0) {
-      cell.style.color = "#d92d20";
-      cell.style.fontWeight = "700";
-    }
+    var imbalanced = value === 0 || number(difference) !== 0;
+    var badge = document.createElement("span");
+    badge.className = "status-badge " + (imbalanced ? "status-badge-error" : "status-badge-success");
+    badge.textContent = imbalanced ? value + "건 · 확인필요" : value + "건 · 일치";
+    cell.appendChild(badge);
     row.appendChild(cell);
   }
 
@@ -195,12 +204,13 @@ if (typeof module !== "undefined" && module.exports) {
     var cell = document.createElement("td");
     if (item.status === "DRAFT") {
       var link = document.createElement("a");
-      link.className = "fgc-btn fgc-btn--ghost";
+      link.className = "button button-ghost";
       link.href = "/transactions/new?id=" + encodeURIComponent(item.commissionTransactionId);
       link.textContent = "수정";
+      link.setAttribute("aria-label", (item.sourceBusinessKey || "선택한 지급 건") + " 수정");
       cell.appendChild(link);
     } else {
-      cell.textContent = "—";
+      cell.textContent = "-";
     }
     row.appendChild(cell);
   }
@@ -214,6 +224,8 @@ if (typeof module !== "undefined" && module.exports) {
     renderPageNumbers(page, totalPages);
     previousButton.disabled = pageGroupStart(page) === 1;
     nextButton.disabled = pageGroupStart(page) + 5 > totalPages;
+    previousButton.setAttribute("aria-disabled", String(previousButton.disabled));
+    nextButton.setAttribute("aria-disabled", String(nextButton.disabled));
     pagination.hidden = number(pageData.totalElements) === 0;
   }
 
@@ -265,9 +277,15 @@ if (typeof module !== "undefined" && module.exports) {
           addOption(fields.insurer, row.insurerId, row.insurerCode + " · " + row.insurerName);
         });
         fields.insurer.value = state.insurerId;
+        fields.insurer.removeAttribute("aria-invalid");
+        filterStatus.hidden = true;
       })
-      .catch(function () {
-        fields.insurer.title = "보험회사 목록을 불러오지 못했습니다.";
+      .catch(function (error) {
+        var message = format.errorText(error, "보험회사 목록을 불러오지 못했습니다. 잠시 후 화면을 새로고침하세요.");
+        fields.insurer.setAttribute("aria-invalid", "true");
+        filterStatus.textContent = message;
+        filterStatus.hidden = false;
+        toast(message, "error");
       })
       .finally(function () { fields.insurer.disabled = false; });
   }
@@ -304,29 +322,98 @@ if (typeof module !== "undefined" && module.exports) {
     select.appendChild(option);
   }
 
-  function renderMessage(message, error) {
+  function renderState(kind, title, message, retry) {
     clear(body);
     var row = document.createElement("tr");
+    row.className = "transaction-state-row";
     var cell = document.createElement("td");
     var content = document.createElement("div");
     cell.colSpan = 11;
-    content.className = "fgc-empty";
-    content.textContent = message;
-    if (error) content.style.color = "#d92d20";
+    content.className = "transaction-state transaction-state-" + kind;
+    content.setAttribute("role", kind === "error" ? "alert" : "status");
+    var icon = textElement("span", kind === "loading" ? "progress_activity" : kind === "error" ? "error" : "inbox");
+    icon.className = "material-symbols-rounded transaction-state-icon";
+    icon.setAttribute("aria-hidden", "true");
+    content.appendChild(icon);
+    var heading = textElement("strong", title);
+    heading.className = "transaction-state-title";
+    content.appendChild(heading);
+    var copy = textElement("span", message);
+    copy.className = "transaction-state-copy";
+    content.appendChild(copy);
+    if (retry) {
+      var retryButton = textElement("button", "다시 시도");
+      retryButton.type = "button";
+      retryButton.className = "button button-secondary";
+      retryButton.addEventListener("click", retry);
+      content.appendChild(retryButton);
+    }
     cell.appendChild(content);
     row.appendChild(cell);
     body.appendChild(row);
   }
 
-  function appendCell(row, content, className) {
+  function appendBadgeCell(row, label, tone) {
     var cell = document.createElement("td");
-    if (className) cell.className = className;
-    cell.textContent = content == null || content === "" ? "—" : String(content);
+    var badge = textElement("span", label || "-");
+    badge.className = "status-badge " + tone;
+    cell.appendChild(badge);
     row.appendChild(cell);
   }
 
-  function formatMonth(value) { return value ? String(value).slice(0, 7) : "—"; }
-  function formatMoney(value) { return new Intl.NumberFormat("ko-KR", { maximumFractionDigits: 0 }).format(number(value)) + "원"; }
+  function cashflowBadge(value) { return value === "DEDUCTION" ? "status-badge-warning" : "status-badge-info"; }
+  function statusBadge(value) {
+    return { DRAFT: "status-badge-neutral", CONFIRMED: "status-badge-success", CANCELLED: "status-badge-error" }[value]
+      || "status-badge-neutral";
+  }
+
+  function appendDisclosureCell(row, content, className) {
+    var cell = document.createElement("td");
+    cell.className = "table-cell-disclosure" + (className ? " " + className : "");
+    var value = content == null || content === "" ? "-" : String(content);
+    var preview = textElement("span", value);
+    preview.className = "table-cell-preview is-single-line";
+    var details = document.createElement("details");
+    details.className = "table-cell-details";
+    details.hidden = true;
+    var summary = document.createElement("summary");
+    summary.appendChild(textElement("span", "전체 보기"));
+    summary.firstChild.className = "table-cell-more";
+    var less = textElement("span", "접기");
+    less.className = "table-cell-less";
+    summary.appendChild(less);
+    var chevron = textElement("span", "expand_more");
+    chevron.className = "material-symbols-rounded table-cell-chevron";
+    chevron.setAttribute("aria-hidden", "true");
+    summary.appendChild(chevron);
+    var full = textElement("div", value);
+    full.className = "table-cell-full";
+    details.appendChild(summary);
+    details.appendChild(full);
+    cell.appendChild(preview);
+    cell.appendChild(details);
+    row.appendChild(cell);
+  }
+
+  function syncTableCellDisclosures() {
+    window.requestAnimationFrame(function () {
+      body.querySelectorAll(".table-cell-disclosure").forEach(function (cell) {
+        var preview = cell.querySelector(".table-cell-preview");
+        var details = cell.querySelector(".table-cell-details");
+        details.hidden = preview.scrollWidth <= preview.clientWidth && preview.scrollHeight <= preview.clientHeight;
+      });
+    });
+  }
+
+  function appendCell(row, content, className) {
+    var cell = document.createElement("td");
+    if (className) cell.className = className;
+    cell.textContent = content == null || content === "" ? "-" : String(content);
+    row.appendChild(cell);
+  }
+
+  function textElement(tag, value) { var element = document.createElement(tag); element.textContent = value; return element; }
+  function toast(message, tone) { if (window.FgcUi && typeof window.FgcUi.toast === "function") window.FgcUi.toast(message, tone); }
   function number(value) { var parsed = Number(value); return Number.isFinite(parsed) ? parsed : 0; }
   function positivePage(value) { var parsed = Number.parseInt(value, 10); return Number.isInteger(parsed) && parsed > 0 ? parsed : 1; }
   function setText(id, value) { var element = document.getElementById(id); if (element) element.textContent = value; }

--- a/src/main/resources/templates/transaction/form.html
+++ b/src/main/resources/templates/transaction/form.html
@@ -1,266 +1,148 @@
 <!DOCTYPE html>
-<!--
-  FGC-UI-TRAN-W02 지급 건 등록·귀속·확정  ★ 이 프로젝트의 핵심 화면
-  요구사항 FUN-065 · FUN-031 · FUN-033 · FUN-034 / REG-08 · 09 · 11 · 20 · 21
-  데이터  쓰기 commission_transaction, transaction_attribution
-          검증 시 생성 cap_check(check_kind='PRE_CONFIRM'), cap_check_detail, exception_case
-  API     POST /api/v1/transactions              (저장 — 검증 없음)
-          POST /api/v1/transactions/{id}/precheck (사전검증 — 저장 없이 계산만)
-          POST /api/v1/transactions/{id}/confirm  (확정 — 6단계 게이트 전부 통과해야 함)
-  라우트  GET /transactions/new → transaction/form.html
-
-  [★ 저장 API와 확정 API를 반드시 분리합니다]
-    하나로 합치면 임시저장을 할 수 없고, 검증 실패 시 입력한 내용이 날아갑니다.
-
-  [막을 것]
-   · 귀속 없이 확정 · 귀속합계 ≠ 지급액 · 검토필요 귀속이 남은 채 확정
-   · 한도를 넘은 채 확정 → 거부하고 예외를 자동 생성합니다
-   · 근거(증빙) 없는 "제외" 선택
-   · 확정된 건의 금액 수정 → 취소 후 다시 만듭니다
-   · 초년도 지급을 13회차로 미뤄 적기 → 귀속일 기준으로 판정하므로 통하지 않습니다
-   · ★ "관리자 강제 통과" 버튼은 만들지 않습니다. 규제 위반은 승인으로 넘길 수 없습니다.
-
-  [정적 부착 단계] 목업(30_산출물/화면_MVP/FGC-UI-TRAN-W02)의 정적 골격만 옮겼다.
-  저장·사전검증·확정 동작은 IF-API-22~25 연동 시 붙인다. 폼 필드는 정적 값 그대로다.
--->
+<!-- FGC-UI-TRAN-W02 지급 건 등록·귀속·확정 · FUN-065 · FUN-031 · FUN-033 · FUN-034 -->
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-TRAN-W02', '지급 건 등록·귀속·확정', '수수료 지급 건', '/transactions')}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main id="main-content" class="fgc-main publishing-page publishing-page-form publishing-page-transaction-form"
-      data-transaction-form>
-
-  <!-- 목업 head 의 화면 전용 스타일 — 셸 조각은 main 만 가져가므로 여기로 옮겼다 -->
-  <style>
-    .form-grid { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: 14px; }
-    @media (max-width: 1000px) { .form-grid { grid-template-columns: repeat(2, minmax(0,1fr)); } }
-    @media (max-width: 680px)  { .form-grid { grid-template-columns: 1fr; } }
-    .gate-step { display:flex; gap:10px; align-items:flex-start; padding:8px 0; border-bottom:1px solid #e8edf2; }
-    .gate-step:last-child { border-bottom:0; }
-    .gate-no { flex:none; width:22px; height:22px; border-radius:9999px; display:flex; align-items:center;
-               justify-content:center; font-size:11px; font-weight:700; background:#eaeef2; color:#43474d; }
-    .gate--pass .gate-no { background:#22C55E; color:#fff; }
-    .gate--fail .gate-no { background:#EF4444; color:#fff; }
-    .gate--todo .gate-no { background:#eaeef2; color:#43474d; }
-    .attr-table input, .attr-table select { width: 100%; font-size: 12px; padding: 4px 6px; }
-  </style>
-
-  <div class="publishing-page-head" style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
-    <div>
-      <h1 class="fgc-page-title">지급 건 등록 · 귀속 · 확정</h1>
-      <p class="fgc-page-desc">
-        "누구에게 · 어떤 계약 몫으로 · 어떤 명목으로 · 얼마를" 주는지 한 건 적습니다.
-        <strong>확정</strong>을 누르면 규제 검사를 통과해야만 상태가 바뀝니다.
-      </p>
+<main id="main-content" class="page-content publishing-page transaction-page transaction-form-page"
+      data-transaction-form aria-busy="true">
+  <header class="page-header transaction-page-header">
+    <div class="page-header-copy"><h1 class="page-title">지급 건 등록 · 귀속 · 확정</h1></div>
+    <div class="page-header-actions">
+      <a class="button button-secondary" th:href="@{/transactions}">
+        <span class="material-symbols-rounded" aria-hidden="true">arrow_back</span> 목록으로
+      </a>
     </div>
-    <a class="fgc-btn fgc-btn--ghost" th:href="@{/transactions}" style="text-decoration:none">
-      <span class="material-symbols-outlined" style="font-size:18px">arrow_back</span> 목록으로
-    </a>
+  </header>
+
+  <aside class="guidance guidance-info transaction-boundary-guidance" aria-labelledby="transaction-boundary-title">
+    <span class="material-symbols-rounded guidance-icon" aria-hidden="true">event</span>
+    <div>
+      <h2 class="guidance-title" id="transaction-boundary-title">초년도 구간은 [계약일, 1주년일)입니다</h2>
+      <p class="guidance-copy">계약일이 2026-07-18이면 귀속일 2027-07-17까지 초년도이고, 2027-07-18부터는 아닙니다. 회차 번호가 아닌 귀속일로 판단하므로 초년도 지급을 13회차로 미뤄도 한도를 피할 수 없습니다.</p>
+    </div>
+  </aside>
+
+  <div id="transaction-form-status" class="transaction-screen-state" role="status" aria-live="polite">기준정보를 불러오는 중입니다.</div>
+  <div id="draft-lock-notice" class="guidance guidance-neutral transaction-lock-notice" role="status" hidden>
+    <span class="material-symbols-rounded guidance-icon" aria-hidden="true">lock</span>
+    <div><strong class="guidance-title">저장된 초안을 검증하는 동안 입력이 잠겼습니다</strong><p class="guidance-copy">내용을 다시 편집하려면 목록에서 이 초안을 다시 여세요.</p></div>
   </div>
 
-  <!-- 초년도 경계 안내 -->
-  <div class="fgc-banner fgc-banner--info" style="margin-top:14px">
-    <span class="material-symbols-outlined" style="font-size:18px">event</span>
-    <span>
-      <strong>초년도 구간은 [계약일, 1주년일) 입니다.</strong>
-      계약일이 2026-07-18이면 귀속일 2027-07-17까지는 초년도, 2027-07-18부터는 초년도가 아닙니다.
-      회차 번호가 아니라 <strong>귀속일</strong>로 판단하므로, 초년도 지급을 13회차로 미뤄 적어도 한도를 피할 수 없습니다.
-    </span>
-  </div>
-
-  <div class="fgc-responsive-split" style="margin-top:16px;display:grid;grid-template-columns:1.55fr 1fr;gap:16px" id="main-grid">
-
-    <div style="display:flex;flex-direction:column;gap:16px">
-
-      <!-- ① 지급 건 입력 — 제출 동작은 IF-API-22(저장)·IF-API-25(확정) 연동 시 붙인다 -->
-      <section class="fgc-card">
-        <div class="fgc-card__head">
-          <span class="fgc-card__title">① 지급 건</span>
-          <span id="tx-status">—</span>
-        </div>
-        <div class="fgc-card__body form-grid">
-
-          <div class="fgc-field">
-            <label class="fgc-label fgc-label--required" for="stage">지급단계</label>
-            <select class="fgc-select" id="stage">
-              <option value="GA_TO_FC">GA→설계사</option>
-              <option value="INSURER_TO_GA">원수사→GA</option>
-            </select>
+  <div class="transaction-form-layout" id="main-grid">
+    <div class="transaction-form-column">
+      <section class="surface transaction-form-panel" aria-labelledby="transaction-input-title">
+        <header class="surface-header transaction-surface-header">
+          <h2 class="surface-title" id="transaction-input-title">① 지급 건</h2>
+          <span id="tx-status" class="status-badge status-badge-neutral">미저장</span>
+        </header>
+        <div class="surface-body transaction-form-grid">
+          <div class="field">
+            <label class="field-label" for="stage">지급단계 <span class="field-required" aria-hidden="true">*</span></label>
+            <select class="select-control" id="stage"><option value="GA_TO_FC">GA→설계사</option><option value="INSURER_TO_GA">원수사→GA</option></select>
+            <span class="field-error" id="err-stage" hidden></span>
           </div>
-
-          <div class="fgc-field">
-            <label class="fgc-label fgc-label--required" for="sourceType">원천유형</label>
-            <select class="fgc-select" id="sourceType"></select>
+          <div class="field">
+            <label class="field-label" for="sourceType">원천유형 <span class="field-required" aria-hidden="true">*</span></label>
+            <select class="select-control" id="sourceType"></select><span class="field-error" id="err-sourceType" hidden></span>
           </div>
-
-          <div class="fgc-field">
-            <label class="fgc-label fgc-label--required" for="bizKey">업무키</label>
-            <input class="fgc-input fgc-mono" id="bizKey" type="text" maxlength="160" placeholder="자동 생성됩니다">
-            <span class="fgc-help">같은 원천유형 안에서 중복될 수 없습니다.</span>
-            <span class="fgc-error" id="err-bizKey" hidden></span>
+          <div class="field">
+            <label class="field-label" for="bizKey">업무키 <span class="field-required" aria-hidden="true">*</span></label>
+            <input class="field-control transaction-mono" id="bizKey" type="text" maxlength="160" placeholder="자동 생성됩니다" aria-describedby="help-bizKey err-bizKey">
+            <span class="field-helper" id="help-bizKey">같은 원천유형 안에서 중복될 수 없습니다.</span><span class="field-error" id="err-bizKey" hidden></span>
           </div>
-
-          <div class="fgc-field">
-            <label class="fgc-label fgc-label--required" for="settlementMonth">정산월</label>
-            <input class="fgc-input" id="settlementMonth" type="month" th:value="${month}" value="">
-            <span class="fgc-help">DB에는 항상 그 달 1일로 저장됩니다.</span>
+          <div class="field">
+            <label class="field-label" for="settlementMonth">정산월 <span class="field-required" aria-hidden="true">*</span></label>
+            <input class="field-control" id="settlementMonth" type="month" th:value="${month}" value="" aria-describedby="help-settlementMonth err-settlementMonth">
+            <span class="field-helper" id="help-settlementMonth">DB에는 항상 그 달 1일로 저장됩니다.</span><span class="field-error" id="err-settlementMonth" hidden></span>
           </div>
-
-          <div class="fgc-field" id="recipient-field">
-            <label class="fgc-label fgc-label--required" for="recipient">수령 설계사</label>
-            <!-- 설계사 선택지는 IF-API-22 연동 시 채운다 -->
-            <select class="fgc-select" id="recipient"></select>
-            <span class="fgc-help">GA→설계사 단계에서는 반드시 있어야 합니다.</span>
+          <div class="field" id="recipient-field">
+            <label class="field-label" for="recipient">수령 설계사 <span class="field-required" aria-hidden="true">*</span></label>
+            <select class="select-control" id="recipient" aria-describedby="help-recipient err-recipient"></select>
+            <span class="field-helper" id="help-recipient">GA→설계사 단계에서는 반드시 있어야 합니다.</span><span class="field-error" id="err-recipient" hidden></span>
           </div>
-
-          <div class="fgc-field">
-            <label class="fgc-label fgc-label--required" for="item">수수료 항목</label>
-            <!-- 수수료 항목 선택지는 IF-API-22 연동 시 채운다 -->
-            <select class="fgc-select" id="item"></select>
+          <div class="field">
+            <label class="field-label" for="item">수수료 항목 <span class="field-required" aria-hidden="true">*</span></label>
+            <select class="select-control" id="item"></select><span class="field-error" id="err-item" hidden></span>
           </div>
-
-          <div class="fgc-field">
-            <label class="fgc-label fgc-label--required" for="amount">금액 (원)</label>
-            <input class="fgc-input fgc-num" id="amount" type="number" min="0" step="1" value="250000">
-            <span class="fgc-help">
-              항상 0 이상입니다. 주는 돈인지 빼는 돈인지는 아래 <strong>흐름</strong>으로 구분합니다. 음수를 저장하지 않습니다.
-            </span>
+          <div class="field">
+            <label class="field-label" for="amount">금액 (원) <span class="field-required" aria-hidden="true">*</span></label>
+            <input class="field-control transaction-number" id="amount" type="number" min="0" step="1" value="250000" aria-describedby="help-amount err-amount">
+            <span class="field-helper" id="help-amount">금액은 0 이상으로 입력하고 지급·차감은 흐름으로 구분합니다.</span><span class="field-error" id="err-amount" hidden></span>
           </div>
-
-          <div class="fgc-field">
-            <label class="fgc-label fgc-label--required" for="cashflow">흐름</label>
-            <select class="fgc-select" id="cashflow">
-              <option value="PAYMENT">지급</option>
-              <option value="DEDUCTION">차감</option>
-            </select>
+          <div class="field">
+            <label class="field-label" for="cashflow">흐름 <span class="field-required" aria-hidden="true">*</span></label>
+            <select class="select-control" id="cashflow"><option value="PAYMENT">지급</option><option value="DEDUCTION">차감</option></select>
           </div>
-
-          <div class="fgc-field">
-            <label class="fgc-label" for="evidence">증빙</label>
-            <input class="fgc-input" id="evidence" type="text" maxlength="200" placeholder="문서번호 · 링크">
-            <span class="fgc-help">귀속행에서 "제외"를 고르면 증빙이 반드시 필요합니다.</span>
+          <div class="field">
+            <label class="field-label" for="evidence">증빙</label>
+            <input class="field-control" id="evidence" type="text" maxlength="200" placeholder="문서번호 · 링크" aria-describedby="help-evidence err-evidence">
+            <span class="field-helper" id="help-evidence">귀속행에서 제외를 고르면 증빙이 반드시 필요합니다.</span><span class="field-error" id="err-evidence" hidden></span>
           </div>
         </div>
       </section>
 
-      <!-- ② 귀속행 -->
-      <section class="fgc-card">
-        <div class="fgc-card__head">
-          <span class="fgc-card__title">② 귀속행 — 이 돈이 어느 계약 몫인가</span>
-          <button class="fgc-btn fgc-btn--ghost" id="btn-add-attr" type="button"
-                  style="padding:4px 10px;font-size:12px">
-            <span class="material-symbols-outlined" style="font-size:16px">add</span> 귀속행 추가
-          </button>
-        </div>
-        <div style="overflow-x:auto">
-          <table class="fgc-table attr-table" style="min-width:1360px">
-            <thead>
-              <tr>
-                <th style="width:36px">#</th>
-                <th style="width:96px">귀속 범위</th>
-                <th style="width:100px">계약번호</th>
-                <th style="width:150px">설계사</th>
-                <th style="width:120px">귀속일</th>
-                <th style="width:132px">귀속월</th>
-                <th style="width:120px" class="fgc-th-num">귀속금액</th>
-                <th style="width:118px">산입 판정</th>
-                <th style="width:150px">귀속 방법</th>
-                <th style="width:110px">배부정책</th>
-                <th style="width:300px">증빙</th>
-                <th style="width:40px"></th>
-              </tr>
-            </thead>
-            <tbody id="attr-body">
-              <tr><td colspan="12"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
-            </tbody>
-            <tfoot>
-              <tr>
-                <td colspan="6">귀속금액 합계</td>
-                <td class="fgc-td-num"><span class="fgc-amount" id="attr-sum">0</span></td>
-                <td colspan="5" id="attr-diff" class="fgc-muted"></td>
-              </tr>
-            </tfoot>
+      <section class="surface transaction-attribution-panel" aria-labelledby="transaction-attribution-title">
+        <header class="surface-header transaction-surface-header">
+          <h2 class="surface-title" id="transaction-attribution-title">② 귀속행 — 이 돈이 어느 계약 몫인가</h2>
+          <button class="button button-secondary transaction-add-attribution" id="btn-add-attr" type="button"><span class="material-symbols-rounded" aria-hidden="true">add</span> 귀속행 추가</button>
+        </header>
+        <div class="data-table-viewport transaction-attribution-viewport">
+          <table class="data-table transaction-attribution-table">
+            <caption class="visually-hidden">지급 건에 연결할 계약별 귀속행</caption>
+            <colgroup>
+              <col class="transaction-attr-col-index"><col class="transaction-attr-col-scope"><col class="transaction-attr-col-contract"><col class="transaction-attr-col-agent">
+              <col class="transaction-attr-col-date"><col class="transaction-attr-col-month"><col class="transaction-attr-col-amount"><col class="transaction-attr-col-decision">
+              <col class="transaction-attr-col-method"><col class="transaction-attr-col-policy"><col class="transaction-attr-col-evidence"><col class="transaction-attr-col-action">
+            </colgroup>
+            <thead><tr>
+              <th scope="col">#</th><th scope="col">귀속 범위</th><th scope="col">계약번호</th><th scope="col">설계사</th><th scope="col">귀속일</th><th scope="col">귀속월</th>
+              <th scope="col" class="is-number">귀속금액</th><th scope="col">산입 판정</th><th scope="col">귀속 방법</th><th scope="col">배부정책</th><th scope="col">증빙</th><th scope="col" aria-label="행 삭제"></th>
+            </tr></thead>
+            <tbody id="attr-body" aria-live="polite"><tr><td colspan="12"><div class="empty-state" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr></tbody>
+            <tfoot><tr><td colspan="6">귀속금액 합계</td><td class="is-number"><span class="tabular-nums" id="attr-sum">0원</span></td><td colspan="5"><span id="attr-diff" class="status-badge status-badge-neutral">미확인</span></td></tr></tfoot>
           </table>
         </div>
-        <div class="fgc-card__body" style="padding-top:12px">
-          <div class="fgc-banner fgc-banner--muted">
-            <span class="material-symbols-outlined" style="font-size:18px">help</span>
-            <span>
-              <strong>귀속(歸屬)</strong>이란 "이 돈이 어느 계약 때문에 나갔는지 연결하는 것"입니다.
-              시책처럼 여러 계약에 걸친 돈은 계약별로 나눠 적고,
-              <strong>나눈 금액의 합이 실제 지급액과 반드시 같아야</strong> 합니다.
-              나누는 기준을 모르면 임의로 나누지 말고 <strong>검토필요</strong>로 두세요(REG-20 · REG-06C).
-            </span>
-          </div>
-        </div>
+        <p class="field-error transaction-attribution-error" id="err-attributions" role="alert" hidden></p>
       </section>
     </div>
 
-    <!-- ③ 검증 결과 패널 -->
-    <div style="display:flex;flex-direction:column;gap:16px">
-
-      <section class="fgc-card">
-        <div class="fgc-card__head">
-          <span class="fgc-card__title">③ 확정 게이트 6단계</span>
-          <span class="fgc-muted" style="font-size:11px">운영정책서 제31조</span>
-        </div>
-        <!-- 게이트 6단계 표시는 IF-API-25 확정 응답(blockers[])으로 채운다 -->
-        <div class="fgc-card__body" style="padding:8px 16px" id="gate-list"></div>
+    <div class="transaction-form-column">
+      <section class="surface transaction-gate-panel" aria-labelledby="transaction-gate-title">
+        <header class="surface-header transaction-surface-header"><h2 class="surface-title" id="transaction-gate-title">③ 확정 게이트 6단계</h2><span class="transaction-panel-meta">운영정책서 제31조</span></header>
+        <div class="surface-body transaction-gate-list" id="gate-list" aria-live="polite"></div>
       </section>
-
-      <section class="fgc-card" id="cap-panel">
-        <div class="fgc-card__head">
-          <span class="fgc-card__title">1,200% 사전검증</span>
-          <span class="fgc-muted" style="font-size:11px">저장하지 않고 계산만</span>
-        </div>
-        <!-- 사전검증 결과(계약별 게이지)는 IF-API-24 Ajax 응답으로 채운다 -->
-        <div class="fgc-card__body" id="cap-body">
-          <p class="fgc-muted" style="font-size:13px;margin:0">
-            [사전검증] 버튼을 누르면 이 지급 건을 더했을 때 한도를 넘는지 미리 계산합니다.
-            아무것도 저장하지 않습니다.
-          </p>
-        </div>
+      <section class="surface transaction-cap-panel" id="cap-panel" aria-labelledby="transaction-cap-title">
+        <header class="surface-header transaction-surface-header"><h2 class="surface-title" id="transaction-cap-title">1,200% 사전검증</h2><span class="transaction-panel-meta">저장하지 않고 계산만</span></header>
+        <div class="surface-body transaction-cap-body" id="cap-body" role="status" aria-live="polite" aria-busy="false"><p class="transaction-panel-placeholder">[사전검증]을 누르면 한도 초과 여부를 미리 계산하며 아무것도 저장하지 않습니다.</p></div>
       </section>
-
-      <!-- ④ 버튼 — 동작은 IF-API-22(저장)·24(사전검증)·25(확정) 연동 시 붙인다 -->
-      <section class="fgc-card">
-        <div class="fgc-card__body" style="display:flex;flex-direction:column;gap:8px">
-          <button type="button" class="fgc-btn fgc-btn--ghost" id="btn-save" data-fgc-action="save" th:disabled="${!canProcess}">
-            <span class="material-symbols-outlined" style="font-size:18px">save</span> 임시저장 (검증 없음)
-          </button>
-          <button type="button" class="fgc-btn fgc-btn--ghost" id="btn-precheck" data-fgc-action="precheck" th:disabled="${!canProcess}">
-            <span class="material-symbols-outlined" style="font-size:18px">calculate</span> 사전검증
-          </button>
-          <button type="button" class="fgc-btn fgc-btn--primary" id="btn-confirm" data-fgc-action="confirm" th:disabled="${!canProcess}">
-            <span class="material-symbols-outlined" style="font-size:18px">verified</span> 확정
-          </button>
-          <p class="fgc-help" style="margin:4px 0 0">
-            확정은 6단계를 <strong>전부</strong> 통과해야 합니다.
-            한 단계라도 걸리면 상태가 바뀌지 않습니다.
-          </p>
-          <!--
-            [의도적으로 만들지 않은 것]
-            "관리자 승인으로 강제 통과" 버튼이 여기 없습니다.
-            규제 위반은 승인으로 넘길 수 없기 때문입니다.
-            대신 예외함에서 정정 · 감액 · 취소 중 하나를 고릅니다.
-          -->
+      <section class="surface transaction-action-panel" aria-labelledby="transaction-actions-title">
+        <h2 class="visually-hidden" id="transaction-actions-title">지급 건 작업</h2>
+        <div class="surface-body transaction-action-list">
+          <button type="button" class="button button-secondary" id="btn-save" data-fgc-action="save" th:disabled="${!canProcess}" aria-describedby="transaction-action-help transaction-permission-help"><span class="material-symbols-rounded" aria-hidden="true">save</span><span data-button-label>임시저장 (검증 없음)</span></button>
+          <button type="button" class="button button-secondary" id="btn-precheck" data-fgc-action="precheck" th:disabled="${!canProcess}" aria-describedby="transaction-action-help transaction-permission-help"><span class="material-symbols-rounded" aria-hidden="true">calculate</span><span data-button-label>사전검증</span></button>
+          <button type="button" class="button button-primary" id="btn-confirm" data-fgc-action="confirm" th:disabled="${!canProcess}" aria-describedby="transaction-action-help transaction-permission-help"><span class="material-symbols-rounded" aria-hidden="true">verified</span><span data-button-label>확정</span></button>
+          <p class="field-helper" id="transaction-action-help">확정은 서버가 판정한 6단계를 모두 통과해야 합니다.</p>
+          <p class="field-error" id="transaction-permission-help" th:if="${!canProcess}">현재 계정은 조회만 가능하며 저장·사전검증·확정을 실행할 수 없습니다.</p>
         </div>
       </section>
     </div>
   </div>
 
-<!-- 스크립트는 main 안에 둔다 - 셸의 page()는 ~{::main}만 삽입하므로 main 밖 스크립트는 렌더링에서 사라진다 -->
-<script>
-/* 화면 폭이 좁으면 좌우 2단을 세로로 — 데이터·검증 동작은 IF-API-22~25 연동 시 추가 */
-(function () {
-  "use strict";
-  function reflow() {
-    document.getElementById("main-grid").style.gridTemplateColumns =
-      window.innerWidth < 1150 ? "1fr" : "1.55fr 1fr";
-  }
-  reflow();
-  window.addEventListener("resize", reflow);
-})();
-</script>
+  <div class="modal-backdrop" data-modal="transaction-confirm" data-close-on-backdrop="true" hidden aria-hidden="true">
+    <section class="modal transaction-confirm-modal" role="dialog" aria-modal="true" aria-labelledby="transaction-confirm-title" aria-describedby="transaction-confirm-description">
+      <header class="modal-header"><h2 class="modal-title" id="transaction-confirm-title">지급 건 확정</h2></header>
+      <div class="modal-body transaction-confirm-body">
+        <div class="guidance guidance-warning"><span class="material-symbols-rounded guidance-icon" aria-hidden="true">warning</span><div><strong class="guidance-title">확정 후에는 이 화면에서 되돌릴 수 없습니다</strong><p class="guidance-copy" id="transaction-confirm-description">취소가 필요하면 별도의 IF-API-26 절차로 처리해야 합니다. 현재 내용을 확인한 뒤 확정하세요.</p></div></div>
+        <div id="transaction-confirm-summary" class="transaction-confirm-summary"></div>
+        <div id="transaction-confirm-blockers" class="transaction-confirm-blockers" role="alert" hidden></div>
+        <div id="transaction-confirm-links" class="transaction-confirm-links" hidden>
+          <a id="transaction-cap-link" class="button button-secondary" href="/cap-checks" hidden>계산근거 보기</a>
+          <a id="transaction-exception-link" class="button button-secondary" href="/exceptions" hidden>예외함으로 이동</a>
+        </div>
+      </div>
+      <footer class="modal-footer"><button class="button button-secondary" type="button" data-modal-close data-modal-initial-focus>취소</button><button class="button button-primary" id="btn-confirm-submit" type="button"><span data-button-label>확정 실행</span></button></footer>
+    </section>
+  </div>
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/transaction/form.html
+++ b/src/main/resources/templates/transaction/form.html
@@ -135,10 +135,6 @@
         <div class="guidance guidance-warning"><span class="material-symbols-rounded guidance-icon" aria-hidden="true">warning</span><div><strong class="guidance-title">확정 후에는 이 화면에서 되돌릴 수 없습니다</strong><p class="guidance-copy" id="transaction-confirm-description">취소가 필요하면 별도의 IF-API-26 절차로 처리해야 합니다. 현재 내용을 확인한 뒤 확정하세요.</p></div></div>
         <div id="transaction-confirm-summary" class="transaction-confirm-summary"></div>
         <div id="transaction-confirm-blockers" class="transaction-confirm-blockers" role="alert" hidden></div>
-        <div id="transaction-confirm-links" class="transaction-confirm-links" hidden>
-          <a id="transaction-cap-link" class="button button-secondary" href="/cap-checks" hidden>계산근거 보기</a>
-          <a id="transaction-exception-link" class="button button-secondary" href="/exceptions" hidden>예외함으로 이동</a>
-        </div>
       </div>
       <footer class="modal-footer"><button class="button button-secondary" type="button" data-modal-close data-modal-initial-focus>취소</button><button class="button button-primary" id="btn-confirm-submit" type="button"><span data-button-label>확정 실행</span></button></footer>
     </section>

--- a/src/main/resources/templates/transaction/list.html
+++ b/src/main/resources/templates/transaction/list.html
@@ -1,149 +1,126 @@
 <!DOCTYPE html>
-<!--
-  FGC-UI-TRAN-W01 수수료 지급 건 목록
-  요구사항 FUN-065 · FUN-031
-  데이터  읽기 commission_transaction, transaction_attribution, vw_transaction_attribution_balance
-  API     GET /api/v1/transactions?settlementMonth=&paymentStage=&insurerId=&contractNo=&agentId=&commissionItemId=&status=&sourceType=&noAttributionOnly=
-  라우트  GET /transactions → transaction/list.html
-
-  [막을 것]
-   · 귀속행이 0건인 지급 건을 확정 상태로 만들기 — DB 트리거가 거부합니다
-   · 같은 업무키를 두 번 등록 — DB UNIQUE(source_type, source_business_key)
-  [주의] amount 는 항상 0 이상입니다. 주는 돈/빼는 돈은 cashflow_type 으로 구분하고
-         음수를 저장하지 않습니다.
-
-  [정적 부착 단계] 목업(30_산출물/화면_MVP/FGC-UI-TRAN-W01)의 정적 골격만 옮겼다.
-  데이터 영역(목록·합계)은 IF-API-20 연동 시 서버 렌더링으로 채운다.
--->
+<!-- FGC-UI-TRAN-W01 수수료 지급 건 목록 · FUN-065 · FUN-031 -->
 <html th:replace="~{layout/default :: page(~{::main}, 'FGC-UI-TRAN-W01', '수수료 지급 건 목록', null, null)}"
       xmlns:th="http://www.thymeleaf.org">
 <body>
-<main id="main-content" class="fgc-main publishing-page publishing-page-list publishing-page-transaction-list">
-
-  <div class="publishing-page-head" style="display:flex;align-items:flex-end;justify-content:space-between;gap:16px;flex-wrap:wrap">
-    <div>
-      <h1 class="fgc-page-title">수수료 지급 건 목록</h1>
-      <p class="fgc-page-desc">
-        실제로 오간 돈 한 건 한 건입니다. <strong>귀속</strong> 칸이 0이면 이 돈이 어느 계약 몫인지
-        아직 안 적었다는 뜻이라 확정할 수 없습니다.
-      </p>
+<main id="main-content" class="page-content publishing-page transaction-page transaction-list-page">
+  <header class="page-header transaction-page-header">
+    <div class="page-header-copy">
+      <h1 class="page-title">수수료 지급 건 목록</h1>
     </div>
-    <!-- 등록은 SETTLEMENT (화면정의서 :673, IF-API-22). a 태그는 disabled 가 없어 숨긴다. -->
-    <a class="fgc-btn fgc-btn--primary" th:href="@{/transactions/new}" th:if="${canProcess}" style="text-decoration:none" data-fgc-action="create">
-      <span class="material-symbols-outlined" style="font-size:18px">add</span> 신규 등록
-    </a>
-  </div>
+    <div class="page-header-actions">
+      <a class="button button-primary" th:href="@{/transactions/new}" th:if="${canProcess}"
+         data-fgc-action="create">
+        <span class="material-symbols-rounded" aria-hidden="true">add</span>
+        신규 등록
+      </a>
+    </div>
+  </header>
 
-  <!-- ① 검색 -->
-  <section class="fgc-card" style="margin-top:16px">
-    <form class="fgc-card__body fgc-toolbar" data-transaction-filter-form>
-      <div class="fgc-field" style="min-width:140px">
-        <label class="fgc-label" for="f-month">정산월</label>
-        <input class="fgc-input" id="f-month" type="month" th:value="${month}" value="2026-07">
+  <form class="filter-bar transaction-filter-bar" data-transaction-filter-form>
+    <div class="filter-fields transaction-filter-fields">
+      <div class="filter-field transaction-filter-month">
+        <label class="filter-field-label" for="f-month">정산월</label>
+        <input class="field-control" id="f-month" type="month" th:value="${month}" value="2026-07">
       </div>
-      <div class="fgc-field" style="min-width:160px">
-        <label class="fgc-label" for="f-stage">지급단계</label>
-        <select class="fgc-select" id="f-stage"><option value="">전체</option>
+      <div class="filter-field transaction-filter-stage">
+        <label class="filter-field-label" for="f-stage">지급단계</label>
+        <select class="select-control" id="f-stage">
+          <option value="">전체</option>
           <option value="GA_TO_FC">GA→설계사</option>
           <option value="INSURER_TO_GA">원수사→GA</option>
         </select>
       </div>
-      <div class="fgc-field" style="min-width:170px">
-        <label class="fgc-label" for="f-insurer">보험회사</label>
-        <select class="fgc-select" id="f-insurer"><option value="">전체</option></select>
+      <div class="filter-field transaction-filter-insurer">
+        <label class="filter-field-label" for="f-insurer">보험회사</label>
+        <select class="select-control" id="f-insurer" aria-describedby="transaction-filter-status">
+          <option value="">전체</option>
+        </select>
       </div>
-      <div class="fgc-field" style="min-width:160px">
-        <label class="fgc-label" for="f-contract-no">계약번호</label>
-        <input class="fgc-input" id="f-contract-no" type="search" placeholder="계약번호 입력" autocomplete="off">
+      <div class="filter-field transaction-filter-contract">
+        <label class="filter-field-label" for="f-contract-no">계약번호</label>
+        <input class="field-control" id="f-contract-no" type="search" placeholder="계약번호 입력" autocomplete="off">
       </div>
-      <div class="fgc-field" style="min-width:170px">
-        <label class="fgc-label" for="f-source">원천유형</label>
-        <!-- 원천유형 선택지는 IF-API-20 연동 시 코드 테이블로 채운다 -->
-        <select class="fgc-select" id="f-source"><option value="">전체</option></select>
+      <div class="filter-field transaction-filter-source">
+        <label class="filter-field-label" for="f-source">원천유형</label>
+        <select class="select-control" id="f-source"><option value="">전체</option></select>
       </div>
-      <div class="fgc-field" style="min-width:130px">
-        <label class="fgc-label" for="f-agent">수령 설계사</label>
-        <!-- 설계사 선택지는 IF-API-20 연동 시 채운다 -->
-        <select class="fgc-select" id="f-agent"><option value="">전체</option></select>
+      <div class="filter-field transaction-filter-agent">
+        <label class="filter-field-label" for="f-agent">수령 설계사</label>
+        <select class="select-control" id="f-agent"><option value="">전체</option></select>
       </div>
-      <div class="fgc-field" style="min-width:130px">
-        <label class="fgc-label" for="f-item">수수료 항목</label>
-        <!-- 수수료 항목 선택지는 IF-API-20 연동 시 채운다 -->
-        <select class="fgc-select" id="f-item"><option value="">전체</option></select>
+      <div class="filter-field transaction-filter-item">
+        <label class="filter-field-label" for="f-item">수수료 항목</label>
+        <select class="select-control" id="f-item"><option value="">전체</option></select>
       </div>
-      <div class="fgc-field" style="min-width:120px">
-        <label class="fgc-label" for="f-status">상태</label>
-        <!-- 상태 선택지는 IF-API-20 연동 시 코드 테이블로 채운다 -->
-        <select class="fgc-select" id="f-status"><option value="">전체</option></select>
+      <div class="filter-field transaction-filter-status-field">
+        <label class="filter-field-label" for="f-status">상태</label>
+        <select class="select-control" id="f-status"><option value="">전체</option></select>
       </div>
-      <label style="display:flex;gap:5px;align-items:center;font-size:12px;padding-bottom:6px">
-        <input type="checkbox" id="f-noattr"> 귀속 0건만
+      <label class="transaction-filter-checkbox" for="f-noattr">
+        <input type="checkbox" id="f-noattr">
+        <span>귀속 0건만</span>
       </label>
-      <button type="button" class="fgc-btn fgc-btn--ghost" id="f-reset">
-        <span class="material-symbols-outlined" style="font-size:18px">restart_alt</span> 초기화
-      </button>
-      <button class="fgc-btn fgc-btn--primary" type="submit">
-        <span class="material-symbols-outlined" style="font-size:18px">search</span> 조회
-      </button>
-    </form>
-  </section>
-
-  <!-- ② 목록 -->
-  <section class="fgc-card" style="margin-top:16px">
-    <div class="fgc-card__head">
-      <span class="fgc-card__title">지급 건</span>
-      <span class="fgc-muted" style="font-size:12px"><span id="row-count">0</span>건 · 한 화면 20행</span>
     </div>
-    <div style="overflow-x:auto">
-      <table class="fgc-table" style="min-width:1140px">
+    <div class="filter-actions transaction-filter-actions">
+      <button type="button" class="button button-secondary" id="f-reset">
+        <span class="material-symbols-rounded" aria-hidden="true">restart_alt</span>
+        초기화
+      </button>
+      <button class="button button-primary" type="submit">
+        <span class="material-symbols-rounded" aria-hidden="true">search</span>
+        조회
+      </button>
+    </div>
+  </form>
+  <p id="transaction-filter-status" class="transaction-filter-status field-error" role="status" aria-live="polite" hidden></p>
+
+  <section class="surface transaction-list-panel" aria-labelledby="transaction-list-title">
+    <header class="surface-header transaction-surface-header">
+      <h2 class="surface-title" id="transaction-list-title">지급 건</h2>
+      <span class="transaction-result-count"><span class="tabular-nums" id="row-count">0</span>건 · 한 화면 20행</span>
+    </header>
+    <div class="data-table-viewport transaction-table-viewport">
+      <table class="data-table transaction-list-table">
+        <caption class="visually-hidden">검색 조건에 해당하는 수수료 지급 건</caption>
+        <colgroup>
+          <col class="transaction-col-stage"><col class="transaction-col-source">
+          <col class="transaction-col-business-key"><col class="transaction-col-month">
+          <col class="transaction-col-agent"><col class="transaction-col-item">
+          <col class="transaction-col-amount"><col class="transaction-col-cashflow">
+          <col class="transaction-col-status"><col class="transaction-col-attribution">
+          <col class="transaction-col-action">
+        </colgroup>
         <thead>
           <tr>
-            <th style="width:104px">지급단계</th>
-            <th style="width:112px">원천유형</th>
-            <th style="width:150px">업무키</th>
-            <th style="width:80px">정산월</th>
-            <th style="width:140px">수령 설계사</th>
-            <th style="width:130px">수수료 항목</th>
-            <th class="fgc-th-num" style="width:100px">금액</th>
-            <th style="width:64px">흐름</th>
-            <th style="width:84px">상태</th>
-            <th style="width:96px">귀속</th>
-            <th style="width:70px"></th>
+            <th scope="col">지급단계</th><th scope="col">원천유형</th><th scope="col">업무키</th>
+            <th scope="col">정산월</th><th scope="col">수령 설계사</th><th scope="col">수수료 항목</th>
+            <th scope="col" class="is-number">금액</th><th scope="col">흐름</th><th scope="col">상태</th>
+            <th scope="col">귀속</th><th scope="col" aria-label="행 작업"></th>
           </tr>
         </thead>
-        <tbody id="list-body">
-          <tr><td colspan="11"><div class="fgc-empty" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
+        <tbody id="list-body" aria-live="polite" aria-busy="false">
+          <tr class="transaction-state-row"><td colspan="11"><div class="empty-state" th:text="#{info.common.empty}">조건에 맞는 자료가 없습니다.</div></td></tr>
         </tbody>
         <tfoot>
-          <!-- PAYMENT/DEDUCTION 분리 합계는 IF-API-20 연동 시 서버 렌더링으로 제공 -->
-          <tr>
-            <td colspan="6">금액 절대값 합계</td>
-            <td class="fgc-td-num"><span class="fgc-amount" id="sum-amount">0</span></td>
-            <td colspan="4"></td>
-          </tr>
+          <!-- PAYMENT/DEDUCTION 분리 합계는 백엔드 응답 계약이 마련되면 제공한다. -->
+          <tr><td colspan="6">금액 절대값 합계</td><td class="is-number"><span class="tabular-nums" id="sum-amount">0원</span></td><td colspan="4"></td></tr>
         </tfoot>
       </table>
     </div>
-    <div class="fgc-card__body">
-      <p class="fgc-help">
-        <strong>귀속</strong> 칸은 이 지급 건이 몇 개 계약에 연결됐는지입니다.
-        0이면 빨간색으로 나오고, 그 상태로는 확정할 수 없습니다.
-      </p>
-    </div>
-    <nav class="schedule-pagination" aria-label="수수료 지급 건 목록 페이지" data-transaction-pagination hidden>
+    <nav class="transaction-pagination" aria-label="수수료 지급 건 목록 페이지" data-transaction-pagination hidden>
       <span><span data-transaction-current-page>1</span> / <span data-transaction-total-pages>1</span> 페이지</span>
       <div class="pagination-controls">
         <button class="pagination-button" type="button" aria-label="이전 페이지" data-transaction-page-prev>
           <span class="material-symbols-rounded" aria-hidden="true">chevron_left</span>
         </button>
-        <span data-transaction-page-numbers></span>
+        <span class="transaction-page-numbers" data-transaction-page-numbers></span>
         <button class="pagination-button" type="button" aria-label="다음 페이지" data-transaction-page-next>
           <span class="material-symbols-rounded" aria-hidden="true">chevron_right</span>
         </button>
       </div>
     </nav>
   </section>
-
 </main>
 </body>
 </html>

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -39,8 +39,6 @@ class PublishingTemplateStructureTest {
      * — 그래야 화면 하나를 전환할 때 다른 화면 담당자의 테스트가 함께 깨지지 않는다 (#138).
      */
     private static final List<String> BRIDGE_SCOPED_TEMPLATES = List.of(
-            "templates/transaction/list.html",
-            "templates/transaction/form.html",
             "templates/schedule/detail.html",
             "templates/ledger/list.html",
             "templates/exception/list.html",
@@ -60,6 +58,8 @@ class PublishingTemplateStructureTest {
             "templates/reco/list.html",
             "templates/audit/list.html",
             "templates/contract/form.html",
+            "templates/transaction/list.html",
+            "templates/transaction/form.html",
             "templates/schedule/list.html",
             "templates/arbitrage/list.html",
             "templates/error/403.html",
@@ -288,6 +288,84 @@ class PublishingTemplateStructureTest {
                 .contains("function usageRate(")
                 .contains("truncateDecimal(value, 4)")
                 .contains("truncateDecimal(value, 6)");
+    }
+
+    // FGC-UI-TRAN-W01·W02: 지급 목록·등록 화면은 공통 컴포넌트와 TRAN 전용 자산만 사용한다.
+    @Test
+    void transactionScreensUseCommonComponentsAndPreserveCriticalContracts() throws IOException {
+        assertThat(resource("templates/transaction/list.html"))
+                .contains("class=\"page-content publishing-page transaction-page transaction-list-page\"")
+                .contains("class=\"page-header transaction-page-header\"")
+                .contains("class=\"filter-bar transaction-filter-bar\"")
+                .contains("class=\"surface transaction-list-panel\"")
+                .contains("class=\"data-table transaction-list-table\"")
+                .contains("class=\"transaction-pagination\"")
+                .contains("data-transaction-filter-form")
+                .contains("data-transaction-page-numbers")
+                .contains("<caption class=\"visually-hidden\"")
+                .contains("scope=\"col\"")
+                .doesNotContain("schedule-")
+                .doesNotContain("page-description")
+                .doesNotContain("fgc-page-desc")
+                .doesNotContain("style=")
+                .doesNotContainPattern("(?i)<style[\\s>]")
+                .doesNotContainPattern("(?i)<script[\\s>]");
+
+        assertThat(resource("templates/transaction/form.html"))
+                .contains("class=\"page-content publishing-page transaction-page transaction-form-page\"")
+                .contains("data-transaction-form aria-busy=\"true\"")
+                .contains("class=\"surface transaction-form-panel\"")
+                .contains("class=\"data-table transaction-attribution-table\"")
+                .contains("data-modal=\"transaction-confirm\"")
+                .contains("확정 후에는 이 화면에서 되돌릴 수 없습니다")
+                .contains("초년도 구간은 [계약일, 1주년일)입니다")
+                .contains("id=\"transaction-permission-help\"")
+                .contains("id=\"err-bizKey\"")
+                .contains("id=\"err-attributions\"")
+                .doesNotContain("page-description")
+                .doesNotContain("fgc-page-desc")
+                .doesNotContain("style=")
+                .doesNotContainPattern("(?i)<style[\\s>]")
+                .doesNotContainPattern("(?i)<script[\\s>]");
+
+        assertThat(resource("static/css/features/transaction.css"))
+                .contains(".transaction-form-layout")
+                .contains(".transaction-pagination")
+                .contains(".transaction-gate-step")
+                .contains("@media (max-width: 63.9375rem)")
+                .contains("@media (max-width: 47.9375rem)")
+                .contains("var(--color-status-error-solid)")
+                .doesNotContainPattern("#[0-9a-fA-F]{3,8}\\b");
+
+        assertThat(resource("static/css/common/components.css"))
+                .doesNotContain("[data-transaction-page-numbers]")
+                .doesNotContain("[data-transaction-pagination]");
+
+        assertThat(resource("static/js/features/transaction/transaction-list.js"))
+                .contains("buildTransactionFilterState(fields, page, attributionImbalanceOnly)")
+                .contains("attributionImbalanceOnly: attributionImbalanceOnly === true")
+                .contains("format.won(")
+                .contains("status-badge ")
+                .contains("aria-disabled")
+                .contains("다시 시도")
+                .doesNotContain("new Intl.NumberFormat")
+                .doesNotContain("style.")
+                .doesNotContain("fetch(");
+
+        assertThat(resource("static/js/features/transaction/transaction-form.js"))
+                .contains("modal.open(\"transaction-confirm\")")
+                .contains("modal.close(\"transaction-confirm\")")
+                .contains("idempotencyKey: \"TRAN-CONFIRM-\" + paymentId")
+                .contains("var GATES = [")
+                .contains("renderGates([], null)")
+                .contains("format.today().slice(0, 7)")
+                .contains("format.won(")
+                .contains("showValidationError")
+                .doesNotContain("new Intl.NumberFormat")
+                .doesNotContain("statusStyle(")
+                .doesNotContain("statusColor(")
+                .doesNotContain("style.")
+                .doesNotContain("fetch(");
     }
 
     /*

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -322,6 +322,12 @@ class PublishingTemplateStructureTest {
                 .contains("id=\"transaction-permission-help\"")
                 .contains("id=\"err-bizKey\"")
                 .contains("id=\"err-attributions\"")
+                // 게이트 패널 제목은 화면정의서 :718 "위 6단계" 와 제31조를 그대로 인용한다.
+                .contains("확정 게이트 6단계")
+                // 내려줄 ID 가 없어 영구히 hidden 이던 링크는 두지 않는다.
+                .doesNotContain("transaction-confirm-links")
+                .doesNotContain("계산근거 보기")
+                .doesNotContain("예외함으로 이동")
                 .doesNotContain("page-description")
                 .doesNotContain("fgc-page-desc")
                 .doesNotContain("style=")
@@ -358,6 +364,31 @@ class PublishingTemplateStructureTest {
                 .contains("idempotencyKey: \"TRAN-CONFIRM-\" + paymentId")
                 .contains("var GATES = [")
                 .contains("renderGates([], null)")
+                /*
+                 * 확정 게이트는 화면정의서 :710-718 · 운영정책서 제31조의 6단계 그대로다.
+                 * 문서에 없는 게이트(차익거래·업무키)를 만들어 넣지 않는다 —
+                 * precheck 가 그런 코드를 발행하지 않아 영구히 판정되지 않는 칸이 된다.
+                 */
+                .contains("{ label: \"작성중(DRAFT) 저장\", codes: [\"FGC-TRAN-005\"] }")
+                .contains("{ label: \"귀속행 입력\", codes: [\"FGC-TRAN-002\"] }")
+                .contains("{ label: \"귀속합계 = 지급액\", codes: [\"FGC-TRAN-003\"] }")
+                .contains("{ label: \"검토필요 귀속 해소\", codes: [\"FGC-CAP-002\"] }")
+                .contains("{ label: \"1,200% 사전검증\", codes: [\"FGC-CAP-001\", \"FGC-CAP-003\", \"FGC-CAP-004\"] }")
+                .doesNotContain("차익거래 검증")
+                .doesNotContain("증빙·업무키 검증")
+                /*
+                 * blocker 분류는 오류 카탈로그 코드로 한다. Blocker.message 는 부록 A 한글 문구라
+                 * 영문 키워드 부분일치는 "FGC-CAP-*" 가 전부 "CAP" 에 걸리는 오분류를 낳았다.
+                 */
+                .doesNotContain("ATTRIBUTION_REQUIRED")
+                .doesNotContain("haystack")
+                /*
+                 * 계산근거·예외함 링크는 내려줄 ID 가 없어 제거했다 (capCheckId 는 IF-API-24 에서 항상 null).
+                 * 동작하지 않는 버튼을 되살리지 않는다.
+                 */
+                .doesNotContain("configureResultLinks")
+                .doesNotContain("transaction-cap-link")
+                .doesNotContain("transaction-exception-link")
                 .contains("format.today().slice(0, 7)")
                 .contains("format.won(")
                 .contains("showValidationError")


### PR DESCRIPTION
## 📖 1. 변경 사항 요약

- TRAN-W01 수수료 지급 건 목록과 TRAN-W02 지급 건 등록·귀속·확정 화면을 공통 UI 컴포넌트로 전환했습니다.
- 레거시 `fgc-*` 클래스와 템플릿·JavaScript의 인라인 스타일을 제거했습니다.
- 확정 확인 모달, 6단계 게이트, 상태 배지, 로딩·빈 결과·오류 상태와 접근성 처리를 추가했습니다.
- 공통 표시 형식과 필드별 오류 UI를 적용했습니다.

## 🔗 2. 관련 이슈

- Closes #284
- Related to #138

## 🛠 3. 구현 내용

### TRAN-W01 수수료 지급 건 목록

- `page-header`, `filter-bar`, `surface`, `data-table`, `button` 등 공통 컴포넌트를 적용했습니다.
- 지급 흐름, 처리 상태, 귀속 상태를 글자와 색상을 함께 사용하는 `status-badge`로 표시합니다.
- 업무키, 원천유형, 수령 설계사, 수수료 항목이 잘린 경우에만 `[전체 보기]`를 제공합니다.
- 조회 상태를 로딩·빈 결과·오류로 구분하고 `aria-busy`, `role="status"`, `role="alert"`를 적용했습니다.
- 조회 실패 시 오류코드·요청 ID와 재시도 버튼을 표시하고 Toast를 함께 제공합니다.
- 보험회사 기준정보 조회 실패도 화면 내 오류와 Toast로 안내합니다.
- 페이지 이동 버튼에 `aria-disabled`를 적용하고 행 수정 링크에 지급 건 문맥을 포함한 `aria-label`을 추가했습니다.
- `attributionImbalanceOnly` 딥링크 상태는 조회 시 유지하고 초기화할 때만 제거합니다.

### TRAN-W02 지급 건 등록·귀속·확정

- 지급 입력, 귀속행, 확정 게이트, 사전검증, 작업 버튼 영역을 공통 컴포넌트로 전환했습니다.
- 기존 인라인 `<style>`과 화면 크기별 JavaScript 리사이즈 처리를 `transaction.css` 반응형 규칙으로 대체했습니다.
- 초년도 구간 `[계약일, 1주년일)` 안내를 유지했습니다.
- 화면 진입 시 기준정보 로딩·오류 상태를 표시합니다.
- 필수값 검증 오류를 Toast 대신 해당 필드 옆에 표시하고 `aria-invalid`와 포커스를 적용했습니다.
- 임시저장 이후 입력이 잠기는 이유와 다시 편집하는 방법을 화면에 안내합니다.
- 서버의 `confirmable`, `blockers[]` 판정만 사용해 확정 게이트 6단계를 통과·차단·미확인 상태로 표시합니다.
- 확정 전 `data-modal="transaction-confirm"` 확인 모달을 표시하고 되돌릴 수 없는 작업임을 안내합니다.
- 차단 시 서버 오류코드와 표준 문구를 표시하며, API가 ID를 제공하는 경우에만 계산근거·예외함 링크를 노출합니다.
- 모달 Esc 닫기, 포커스 트랩, 닫은 후 확정 버튼으로 포커스 복귀를 확인했습니다.
- 기존 `TRAN-CONFIRM-{paymentId}` Idempotency-Key를 유지했습니다.
- 관리자 강제 통과 기능은 추가하지 않았습니다.

### 스타일 및 구조

- TRAN 전용 화면 스타일을 `static/css/features/transaction.css`로 이동했습니다.
- 공통 `components.css`에 있던 `[data-transaction-*]` 페이지네이션 스타일을 TRAN 전용 CSS로 이관했습니다.
- 하드코딩 HEX 색상을 제거하고 공통 디자인 토큰을 사용했습니다.
- 표 컬럼 폭을 `<colgroup>`과 화면 전용 클래스로 관리합니다.
- 63.9375rem, 47.9375rem 공통 브레이크포인트를 적용했습니다.
- 표 내부 가로 스크롤만 허용하고 페이지 본문의 가로 넘침을 제거했습니다.

## 🧪 4. 테스트 결과

### 자동 테스트

- [x] JavaScript 구문 검사 통과
- [x] `transaction-list.test.cjs` 2건 통과
- [x] `PublishingTemplateStructureTest` 23건 통과
- [x] 레거시 클래스·인라인 스타일·하드코딩 HEX 탐지 결과 0건
- [x] `git diff --check` 통과

```bash
node --check src/main/resources/static/js/features/transaction/transaction-list.js
node --check src/main/resources/static/js/features/transaction/transaction-form.js
node --test src/test/js/transaction-list.test.cjs

./gradlew test --tests com.susukkang.fgc.ui.PublishingTemplateStructureTest
```

전체 테스트는 1,151건 중 869건이 통과했습니다. 나머지 282건은 실행 환경에서 Docker/Testcontainers를 찾지 못해 PostgreSQL 테스트 컨텍스트가 시작되지 않아 실패했습니다.

### 브라우저 QA

- [x] 1440px / 900px / 720px 반응형 확인
- [x] 두 화면 모두 페이지 본문 가로 넘침 없음
- [x] 넓은 표는 `data-table-viewport` 내부에서만 가로 스크롤
- [x] TRAN-W01 필터 조회·초기화 확인
- [x] `attributionImbalanceOnly=true` 조회 시 유지 및 초기화 시 제거 확인
- [x] 흐름·상태·귀속 배지 확인
- [x] 긴 업무키 전체 보기 확인
- [x] TRAN-W02 필드 오류 인라인 표시 및 포커스 확인
- [x] 확정 게이트 6단계 상시 표시 확인
- [x] 사전검증 차단 응답 및 표준 오류 문구 확인
- [x] 확정 모달 Esc 닫기와 포커스 복귀 확인
- [x] 콘솔 오류 0건

## 🔐 5. 권한 확인

- `SETTLEMENT` 계정에서 목록 조회, 신규 등록 화면, 사전검증과 확정 모달을 확인했습니다.
- `COMPLIANCE` 계정은 TRAN-W01 조회가 가능하며 신규 등록 버튼이 노출되지 않습니다.
- TRAN-W02 직접 접근은 기존 서버 `@PreAuthorize` 정책에 따라 403으로 차단됩니다.
- 백엔드 권한 정책은 이번 PR에서 변경하지 않았습니다.

## 🗄️ 6. DB / Flyway 변경

- DB 변경 없음
- Flyway 마이그레이션 추가 없음
- 시드 데이터 변경 없음
- 백엔드 API 계약 변경 없음

## 📋 7. 리뷰 요구사항

- TRAN-W01의 흐름·상태·귀속 배지 매핑
- `attributionImbalanceOnly` 딥링크 상태 유지
- 로딩·빈 결과·오류·재시도 UI와 접근성 처리
- TRAN-W02 확정 모달의 비가역 작업 안내
- 서버 `confirmable`, `blockers[]` 기반 6단계 게이트 표시
- 필드 오류의 인라인 표시와 포커스 처리
- 900px·720px 환경의 본문 가로 넘침 방지
- 기존 Idempotency-Key 유지 여부

## ✅ 8. 체크리스트

- [x] 공통 UI 컴포넌트를 사용했습니다.
- [x] 레거시 `fgc-*` 화면 클래스를 제거했습니다.
- [x] 템플릿 인라인 스타일과 스크립트를 제거했습니다.
- [x] JavaScript 인라인 스타일과 하드코딩 색상을 제거했습니다.
- [x] 기존 `id`, `data-*`, Thymeleaf 권한 조건을 유지했습니다.
- [x] 기존 쿼리 파라미터와 딥링크 계약을 유지했습니다.
- [x] Idempotency-Key를 유지했습니다.
- [x] 관리자 강제 통과 기능을 추가하지 않았습니다.
- [x] 백엔드·DB·Flyway·문서를 변경하지 않았습니다.
- [x] 자동 테스트와 브라우저 QA를 수행했습니다.

## 💬 9. 참고 사항

다음 항목은 백엔드 또는 API 계약이 필요한 후속 작업으로 이번 PR에서 제외했습니다.

- IF-API-26 지급 취소 호출부
- 설계사·수수료 항목 필터 전체 선택지 API
- 업무키 서버 생성
- PAYMENT / DEDUCTION 분리 합계
- `COMPLIANCE` 사용자의 TRAN-W02 조회 전용 진입 정책