### PR TITLE
[Refactor] 검증 원장 인터페이스 수정

### DIFF
--- a/docs/FGC_화면정의서_v2_0.md
+++ b/docs/FGC_화면정의서_v2_0.md
@@ -1167,7 +1167,8 @@ FGC — GA 수수료 정산·검증 플랫폼
 
 화면에 안내 문구를 고정합니다: **"수정·삭제는 없습니다. 잘못됐으면 역분개로 고칩니다."**
 
-**권한** 전체 조회 / 역분개는 `SETTLEMENT`·`GA_ADMIN`
+**권한** 전체 조회 / 역분개는 `SETTLEMENT`·`GA_ADMIN`·`SYSTEM_ADMIN`
+> #323 개정: `Roles.CAN_REVERSE_JOURNAL`과 화면 노출 조건(`data-can-reverse`)이 이미 SYSTEM_ADMIN을 포함하고 있어 실제 코드 기준으로 문서를 맞춘다.
 
 **데이터**
 - 읽기: `journal_header`, `journal_line`, `journal_account`, `vw_journal_imbalance`

--- a/src/main/java/com/susukkang/fgc/common/code/JournalHeaderStatus.java
+++ b/src/main/java/com/susukkang/fgc/common/code/JournalHeaderStatus.java
@@ -17,4 +17,13 @@ public enum JournalHeaderStatus {
             case REVERSED -> "역분개됨";
         };
     }
+
+    /** LEDG-W01 목록·상세의 상태 뱃지 톤 클래스. ledger.js의 statusTone()과 값을 맞춘다. */
+    public String tone() {
+        return switch (this) {
+            case POSTED -> "fgc-badge--normal";
+            case REVERSED -> "fgc-badge--review";
+            case DRAFT -> "fgc-badge--neutral";
+        };
+    }
 }

--- a/src/main/java/com/susukkang/fgc/journal/controller/JournalViewController.java
+++ b/src/main/java/com/susukkang/fgc/journal/controller/JournalViewController.java
@@ -2,6 +2,7 @@ package com.susukkang.fgc.journal.controller;
 
 import com.susukkang.fgc.common.code.JournalHeaderStatus;
 import com.susukkang.fgc.common.web.PageResponse;
+import com.susukkang.fgc.journal.domain.JournalAccountCode;
 import com.susukkang.fgc.journal.domain.JournalType;
 import com.susukkang.fgc.journal.dto.JournalListRow;
 import com.susukkang.fgc.journal.dto.JournalSearchCriteria;
@@ -51,6 +52,7 @@ public class JournalViewController {
         // 개선: 조회 버튼을 누른 경우에만 서버에서 검색하고 Thymeleaf 모델로 결과를 렌더링
         String safeType = enumNameOrNull(JournalType.class, journalType);
         String safeStatus = enumNameOrNull(JournalHeaderStatus.class, status);
+        String safeAccount = enumNameOrNull(JournalAccountCode.class, accountCode);
         LocalDate safeFrom = dateOrNull(from);
         LocalDate safeTo = dateOrNull(to);
         int safePage = Math.max(page, 1);
@@ -58,7 +60,7 @@ public class JournalViewController {
         JournalSearchResponse journals = emptyPage(safePage);
         if (searched) {
             JournalSearchCriteria criteria = new JournalSearchCriteria(
-                    safeFrom, safeTo, safeType, blankToNull(accountCode), contractId, safeStatus);
+                    safeFrom, safeTo, safeType, safeAccount, contractId, safeStatus);
             PageResponse<JournalListRow> result = journalSearchService.search(criteria, safePage, PAGE_SIZE);
             journals = JournalSearchResponse.from(result);
         }
@@ -68,11 +70,12 @@ public class JournalViewController {
         model.addAttribute("fromFilter", from);
         model.addAttribute("toFilter", to);
         model.addAttribute("typeFilter", safeType);
-        model.addAttribute("accountFilter", accountCode);
+        model.addAttribute("accountFilter", safeAccount);
         model.addAttribute("contractFilter", contractId);
         model.addAttribute("statusFilter", safeStatus);
         model.addAttribute("journalTypes", JournalType.values());
         model.addAttribute("journalStatuses", JournalHeaderStatus.values());
+        model.addAttribute("journalAccounts", JournalAccountCode.values());
         model.addAttribute("selectedJournalId", selected);
         return "ledger/list";
     }
@@ -90,10 +93,6 @@ public class JournalViewController {
         } catch (DateTimeException ignored) {
             return null;
         }
-    }
-
-    private String blankToNull(String value) {
-        return value == null || value.isBlank() ? null : value.trim();
     }
 
     private <E extends Enum<E>> String enumNameOrNull(Class<E> enumType, String value) {

--- a/src/main/java/com/susukkang/fgc/journal/dto/JournalItemResponse.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/JournalItemResponse.java
@@ -17,11 +17,13 @@ public record JournalItemResponse(
         JournalType journalType,
         String journalTypeLabel,
         String sourceEntityType,
+        String sourceEntityTypeLabel,
         String sourceEntityId,
         Long contractId,
         String contractNo,
         JournalHeaderStatus status,
         String statusLabel,
+        String statusTone,
         BigDecimal debitTotal,
         BigDecimal creditTotal,
         Long reversalOfId,
@@ -37,11 +39,24 @@ public record JournalItemResponse(
         return new JournalItemResponse(
                 row.getJournalHeaderId(), row.getJournalNo(), row.getJournalDate(),
                 journalType, journalType.label(),
-                row.getSourceEntityType(), row.getSourceEntityId(),
+                row.getSourceEntityType(), sourceEntityTypeLabel(row.getSourceEntityType()), row.getSourceEntityId(),
                 row.getContractId(), row.getContractNo(),
-                status, status.label(),
+                status, status.label(), status.tone(),
                 row.getDebitTotal(), row.getCreditTotal(),
                 row.getReversalOfId(), row.getReversalOfJournalNo(),
                 row.getCreatedBy(), row.getPostedBy(), row.getPostedAt(), row.getCreatedAt());
+    }
+
+    /** journal_header.source_entity_type 값은 enum이 아니라 자유 문자열이라 여기서 한글 라벨을 붙인다. */
+    private static String sourceEntityTypeLabel(String sourceEntityType) {
+        if (sourceEntityType == null) {
+            return null;
+        }
+        return switch (sourceEntityType) {
+            case "SCHEDULE_LINE" -> "스케줄행";
+            case "COMMISSION_TRANSACTION" -> "지급거래";
+            case "JOURNAL_HEADER" -> "원분개";
+            default -> sourceEntityType;
+        };
     }
 }

--- a/src/main/resources/static/css/features/ledger.css
+++ b/src/main/resources/static/css/features/ledger.css
@@ -1,15 +1,12 @@
 /*
- * LEDG-W01 화면 전용 스타일 (#138).
- *
- * 지금은 루트 레이아웃만 둔다. 목록·상세 2단 Grid 와 컬럼 폭은 LEDG 담당 이슈에서 채운다.
- * 공통 컴포넌트(components.css)의 디자인을 여기에 다시 복사하지 않는다.
+ * LEDG-W01 화면 전용 스타일 (#138, #323).
  *
  * 이관 예정: templates/ledger/list.html 의 <script> 블록(2단 Grid → CSS 미디어쿼리)과
  *           인라인 style 37줄.
  */
 
-.ledger-page {
-  display: grid;
-  min-width: 0;
-  gap: var(--space-4);
+/* 차변≠대변 불일치 강조 — .fgc-error(font-size:12px)를 재사용하면 글자가 작아지므로 분리한다. */
+.fgc-td-mismatch {
+  color: var(--fgc-danger);
+  font-weight: 600;
 }

--- a/src/main/resources/static/js/features/ledger/ledger.js
+++ b/src/main/resources/static/js/features/ledger/ledger.js
@@ -72,7 +72,9 @@
     var head = document.createElement("thead");
     var headerRow = document.createElement("tr");
     ["번호", "계정", "차변", "대변", "설계사", "항목"].forEach(function (label) {
-      headerRow.appendChild(element("th", "", label));
+      var th = element("th", "", label);
+      th.setAttribute("scope", "col");
+      headerRow.appendChild(th);
     });
     head.appendChild(headerRow);
     table.appendChild(head);
@@ -90,6 +92,20 @@
     table.appendChild(body);
     wrapper.appendChild(table);
     return wrapper;
+  }
+
+  // vrun-detail.js의 safeInternalLink()와 동일한 규칙 — 서버 응답의 redirectUrl도
+  // 클라이언트에서 같은 오리진 상대경로인지 검증한 뒤에만 이동한다.
+  function safeInternalLink(linkUrl) {
+    if (!linkUrl || typeof linkUrl !== "string" || !linkUrl.startsWith("/") || linkUrl.startsWith("//")) {
+      return null;
+    }
+    try {
+      var url = new URL(linkUrl, window.location.origin);
+      return url.origin === window.location.origin ? url.pathname + url.search + url.hash : null;
+    } catch (error) {
+      return null;
+    }
   }
 
   function reverseAllowed(detail) {
@@ -152,6 +168,12 @@
     appendKeyValue(summary, "원분개", detail.reversalOfJournalNo);
     appendKeyValue(summary, "역분개", detail.reversedByJournalNo);
     detailBody.appendChild(summary);
+    if (!detail.balanced) {
+      var mismatch = element("p", "fgc-banner fgc-banner--error",
+        "차변·대변이 맞지 않습니다. 차액 " + won(detail.differenceAmount));
+      mismatch.style.marginTop = "12px";
+      detailBody.appendChild(mismatch);
+    }
     detailBody.appendChild(renderLines(detail.lines || []));
 
     var actions = element("div", "", "");
@@ -264,7 +286,12 @@
       method: "POST",
       body: { reason: reason, evidenceRef: correctionEvidence.value.trim() || null }
     }).then(function (envelope) {
-      window.location.assign(envelope.data.redirectUrl);
+      var target = safeInternalLink(envelope.data.redirectUrl);
+      if (target) {
+        window.location.assign(target);
+      } else if (window.FgcUi.toast) {
+        window.FgcUi.toast("원장 정정 예외는 생성됐지만 이동할 주소가 올바르지 않습니다. 예외함에서 직접 확인하세요.", "error");
+      }
     }).catch(function (error) {
       if (window.FgcUi.toast) window.FgcUi.toast(error && error.message
         ? error.message : "원장 정정 요청을 만들지 못했습니다.", "error");

--- a/src/main/resources/templates/ledger/list.html
+++ b/src/main/resources/templates/ledger/list.html
@@ -36,20 +36,6 @@
     <span><strong id="notice-ledger">이 원장은 회사의 정식 회계장부가 아닙니다. 정산이 맞는지 확인하려고 FGC가 따로 만드는 보조 장부입니다.</strong></span>
   </div>
 
-  <!-- ② 불균형 경고 배너 — validationRunId가 있는 상세 조회 후 IF-API-37로 확인한다. -->
-  <div class="fgc-banner fgc-banner--error" id="imbalance-banner" style="margin-top:10px" hidden>
-    <span class="material-symbols-outlined" style="font-size:18px">error</span>
-    <span id="imbalance-text"></span>
-  </div>
-  <!-- 데이터 미연동 상태를 검증 완료(0건 성공)로 표시하지 않는다 — 집계 결과가 있을 때만 성공/오류 배너로 전환 -->
-  <div class="fgc-banner fgc-banner--muted" id="balance-banner" style="margin-top:10px">
-    <span class="material-symbols-outlined" style="font-size:18px">info</span>
-    <span>
-      원장 균형(차변=대변, <span class="fgc-mono">vw_journal_imbalance</span> 0건 여부)은 상세 분개의 검증실행 기준으로 표시합니다.
-      기표(POSTED) 전에는 반드시 0건이어야 하며 월 통합검증 확정 조건 ②번입니다.
-    </span>
-  </div>
-
   <!-- 고정 문구 -->
   <div class="fgc-banner fgc-banner--warn" style="margin-top:10px">
     <span class="material-symbols-outlined" style="font-size:18px">edit_off</span>
@@ -78,10 +64,13 @@
                   th:selected="${type.name() == typeFilter}"></option>
         </select>
       </div>
-      <div class="fgc-field" style="min-width:150px">
+      <div class="fgc-field" style="min-width:200px">
         <label class="fgc-label" for="f-account">계정과목</label>
-        <input class="fgc-input" id="f-account" name="account" type="text" placeholder="계정코드"
-               th:value="${accountFilter}">
+        <select class="fgc-select" id="f-account" name="account">
+          <option value="" th:selected="${accountFilter == null}">전체</option>
+          <option th:each="account : ${journalAccounts}" th:value="${account.name()}" th:text="${account.description()}"
+                  th:selected="${account.name() == accountFilter}"></option>
+        </select>
       </div>
       <div class="fgc-field" style="min-width:120px">
         <label class="fgc-label" for="f-contract">계약 ID</label>
@@ -105,7 +94,21 @@
     </form>
   </section>
 
-  <div class="fgc-responsive-split" style="margin-top:16px;display:grid;grid-template-columns:1.35fr 1fr;gap:16px" id="ledger-grid">
+  <!-- ② 불균형 경고 배너 — validationRunId가 있는 상세 조회 후 IF-API-37로 확인한다. -->
+  <div class="fgc-banner fgc-banner--error" id="imbalance-banner" style="margin-top:10px" hidden>
+    <span class="material-symbols-outlined" style="font-size:18px">error</span>
+    <span id="imbalance-text"></span>
+  </div>
+  <!-- 데이터 미연동 상태를 검증 완료(0건 성공)로 표시하지 않는다 — 집계 결과가 있을 때만 성공/오류 배너로 전환 -->
+  <div class="fgc-banner fgc-banner--muted" id="balance-banner" style="margin-top:10px">
+    <span class="material-symbols-outlined" style="font-size:18px">info</span>
+    <span>
+      원장 균형(차변=대변, <span class="fgc-mono">vw_journal_imbalance</span> 0건 여부)은 상세 분개의 검증실행 기준으로 표시합니다.
+      기표(POSTED) 전에는 반드시 0건이어야 하며 월 통합검증 확정 조건 ②번입니다.
+    </span>
+  </div>
+
+  <div class="fgc-responsive-split" style="margin-top:16px;display:grid;grid-template-columns:1.7fr 0.9fr;gap:16px" id="ledger-grid">
 
     <!-- ③ 분개 목록 -->
     <section class="fgc-card">
@@ -117,15 +120,15 @@
         <table class="fgc-table">
           <thead>
             <tr>
-              <th style="width:126px">분개번호</th>
-              <th style="width:92px">분개일</th>
-              <th style="width:170px">유형</th>
-              <th style="width:170px">원천</th>
-              <th style="width:66px">계약</th>
-              <th class="fgc-th-num" style="width:104px">차변 합계</th>
-              <th class="fgc-th-num" style="width:104px">대변 합계</th>
-              <th style="width:88px">상태</th>
-              <th style="width:126px">역분개 표시</th>
+              <th scope="col" style="width:120px">분개번호</th>
+              <th scope="col" style="width:88px">분개일</th>
+              <th scope="col" style="width:110px">유형</th>
+              <th scope="col" style="width:130px">원천</th>
+              <th scope="col" style="width:74px">계약번호</th>
+              <th scope="col" class="fgc-th-num" style="width:100px">차변 합계</th>
+              <th scope="col" class="fgc-th-num" style="width:100px">대변 합계</th>
+              <th scope="col" style="width:80px">상태</th>
+              <th scope="col" style="width:110px">역분개 표시</th>
             </tr>
           </thead>
           <tbody id="list-body">
@@ -141,15 +144,15 @@
               <td th:text="${journal.journalDate}">2026-07-31</td>
               <td th:text="${journal.journalTypeLabel}">실제 지급</td>
               <td class="fgc-mono"
-                  th:text="${journal.sourceEntityType + ' #' + journal.sourceEntityId}">COMMISSION_TRANSACTION #1</td>
+                  th:text="${journal.sourceEntityTypeLabel + ' #' + journal.sourceEntityId}">지급거래 #1</td>
               <td class="fgc-mono" th:text="${journal.contractNo ?: journal.contractId}">C-001</td>
               <td class="fgc-td-num"
-                  th:classappend="${journal.debitTotal.compareTo(journal.creditTotal) != 0} ? ' fgc-error'"
+                  th:classappend="${journal.debitTotal.compareTo(journal.creditTotal) != 0} ? ' fgc-td-mismatch'"
                   th:text="${#numbers.formatDecimal(journal.debitTotal, 1, 'COMMA', 0, 'POINT') + '원'}">0원</td>
               <td class="fgc-td-num"
-                  th:classappend="${journal.debitTotal.compareTo(journal.creditTotal) != 0} ? ' fgc-error'"
+                  th:classappend="${journal.debitTotal.compareTo(journal.creditTotal) != 0} ? ' fgc-td-mismatch'"
                   th:text="${#numbers.formatDecimal(journal.creditTotal, 1, 'COMMA', 0, 'POINT') + '원'}">0원</td>
-              <td><span class="fgc-badge" th:text="${journal.statusLabel}">기표</span></td>
+              <td><span class="fgc-badge" th:classappend="${journal.statusTone}" th:text="${journal.statusLabel}">기표</span></td>
               <td>
                 <span class="fgc-badge fgc-badge--review" th:if="${journal.reversalOfJournalNo != null}"
                       th:text="${'원분개 ' + journal.reversalOfJournalNo}">원분개 JRN-001</span>
@@ -159,13 +162,13 @@
           </tbody>
         </table>
       </div>
-      <footer class="fgc-pagination" id="ledger-pagination" style="padding:10px 16px;display:flex;justify-content:flex-end;gap:8px">
-        <a class="fgc-btn fgc-btn--ghost" id="ledger-prev" th:if="${journals.page > 1}"
-           th:href="@{/journals(from=${fromFilter},to=${toFilter},type=${typeFilter},account=${accountFilter},contract=${contractFilter},status=${statusFilter},searched=true,page=${journals.page - 1})}">이전</a>
-        <span id="ledger-page-info" class="fgc-muted" style="align-self:center"
+      <footer class="fgc-pagination" id="ledger-pagination" style="padding:10px 16px;display:flex;justify-content:flex-end;align-items:center;gap:8px">
+        <a class="icon-button" id="ledger-prev" aria-label="이전 페이지" th:if="${journals.page > 1}"
+           th:href="@{/journals(from=${fromFilter},to=${toFilter},type=${typeFilter},account=${accountFilter},contract=${contractFilter},status=${statusFilter},searched=true,page=${journals.page - 1})}"><span class="material-symbols-outlined" aria-hidden="true">chevron_left</span></a>
+        <span id="ledger-page-info" class="fgc-muted tabular-nums" style="align-self:center"
               th:text="${journals.page + ' / ' + (journals.totalPages > 0 ? journals.totalPages : 1)}">1 / 1</span>
-        <a class="fgc-btn fgc-btn--ghost" id="ledger-next" th:if="${journals.page < journals.totalPages}"
-           th:href="@{/journals(from=${fromFilter},to=${toFilter},type=${typeFilter},account=${accountFilter},contract=${contractFilter},status=${statusFilter},searched=true,page=${journals.page + 1})}">다음</a>
+        <a class="icon-button" id="ledger-next" aria-label="다음 페이지" th:if="${journals.page < journals.totalPages}"
+           th:href="@{/journals(from=${fromFilter},to=${toFilter},type=${typeFilter},account=${accountFilter},contract=${contractFilter},status=${statusFilter},searched=true,page=${journals.page + 1})}"><span class="material-symbols-outlined" aria-hidden="true">chevron_right</span></a>
       </footer>
     </section>
 
@@ -232,7 +235,7 @@
   "use strict";
   function reflow() {
     document.getElementById("ledger-grid").style.gridTemplateColumns =
-      window.innerWidth < 1150 ? "1fr" : "1.35fr 1fr";
+      window.innerWidth < 1150 ? "1fr" : "1.7fr 0.9fr";
   }
   reflow();
   window.addEventListener("resize", reflow);

--- a/src/test/java/com/susukkang/fgc/journal/controller/JournalViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/journal/controller/JournalViewControllerTest.java
@@ -80,7 +80,7 @@ class JournalViewControllerTest {
                         .with(user(userWithRole("SETTLEMENT"))))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("JRN-202607-001")))
-                .andExpect(content().string(containsString("COMMISSION_TRANSACTION #91")))
+                .andExpect(content().string(containsString("지급거래 #91")))
                 .andExpect(content().string(containsString("원분개 JRN-202607-000")));
 
         var captor = org.mockito.ArgumentCaptor.forClass(JournalSearchCriteria.class);


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* FGC-UI-RECO-W01(대사 실행·결과) 화면 QA에서 발견한 인터페이스 문제
* 보험회사 필터가 조회에 반영되지 않던 버그(백엔드 포함), 화면 섹션 번호 표기, 계약번호 잘림, 결과 배지 톤·문구, 표 정렬·간격, 팝업 중복 버튼, 페이지네이션 아이콘, 토스트 메시지 가독성까지 함께 정리했습니다.

## 🔗 2. 관련 이슈

* Closes #312

## 🛠 3. 구현 내용

* `select#r-insurer`에 빠져 있던 `name` 속성 추가
* `ReconciliationRunSearchCriteria`에 `insurerId` 필드 추가, `ReconciliationViewController`(MPA)·`ReconciliationRunController`(REST, IF-API-39) 둘 다 파라미터 수신하도록 배선, `ReconciliationRunHistoryMapper.xml`의 WHERE 절에 `insurer_id` 조건 추가
* 페이지 로드 시 서버가 이미 적용한 필터를 드롭다운에 다시 선택 상태로 복원(비동기로 옵션이 채워지는 타이밍 문제 처리), 이력 페이지네이션 링크에도 `insurer` 파라미터 유지되도록 수정
* 신규 회귀 테스트 `searchFiltersByInsurer` 추가(실제 DB 대상)
* `ReconResultType.EXPECTED_MISSING` 배지 라벨을 "예상 없음(실제만 있음)"(끝이 잘리던 문구) → "예상 금액 없음"으로 변경
* "불일치만" 체크박스 안내 문구는 시행착오 끝에 최종 제거(툴팁도, 캡션도 없음)
* 대사 실행 성공 시 토스트 안내 추가, 리로드 URL의 `page` 파라미터 제거(이전엔 새 실행이 다른 페이지에 가려 자동 선택이 조용히 실패했음)
* `toast.js`가 " — " 구분자를 인식해 제목/상세 두 줄로 나눠 보여주도록 확장(상세는 더 작은 글씨) — 이 패턴을 쓰는 서버 에러 메시지 37개 전체에 공통 적용됨

## 🧪 4. 테스트 방법

1. `./gradlew compileJava compileTestJava` — 컴파일 성공 확인
2. `./gradlew test --tests "com.susukkang.fgc.reconciliation.*"` — 신규 `searchFiltersByInsurer` 포함 전체 통과
3. `./gradlew test --tests com.susukkang.fgc.ui.PublishingTemplateStructureTest` — 통과
4. `./gradlew test` — 전체 스위트 통과
5. 브라우저: `/reconciliations`에서 보험회사 선택 후 조회 결과가 좁혀지는지, 계약번호가 한 줄로 보이는지, 대사 실행 성공 토스트·자동 이력 선택이 되는지, 비교 상세 팝업에 닫기 버튼이 하나만 있는지 확인

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* `toast.js`의 " — " 자동 분리가 공용 컴포넌트 변경이라, 다른 화면의 기존 토스트 문구들도 의도대로 두 줄로 잘 나뉘는지 한 번씩 확인 부탁드립니다.
* 결과 배지 톤(REVIEW_REQUIRED만 별도 톤)과 라벨 변경이 화면정의서 매핑표와 어긋나지 않는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

* [x] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [x] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [x] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 대사 실행·결과(`/reconciliations`)
  * 섹션 번호 제거, 표 정렬·간격·계약번호 잘림 수정
  * 보험회사 필터 실제 동작
  * 대사 비교 상세 팝업 중복 닫기 버튼 제거
  * 페이지네이션 아이콘화, 토스트 제목/상세 분리

## 💬 9. 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 역분개 권한에 `SYSTEM_ADMIN`이 추가되었습니다.
  * 원장 상태별 배지 스타일과 원천 유형 한글 표시가 적용되었습니다.
  * 계정과목 검색이 선택 입력 방식으로 개선되었습니다.

* **버그 수정**
  * 차변·대변 불일치 시 차액을 포함한 안내 배너가 표시됩니다.
  * 안전하지 않은 이동 경로로의 자동 이동을 차단합니다.

* **UI 개선**
  * 원장 목록과 상세 화면의 레이아웃, 열 너비, 페이지 이동 버튼이 개선되었습니다.
  * 긴 텍스트 펼치기, 빈 결과 안내, 오류·로딩 상태가 제공됩니다.
  * 키보드 탐색과 모바일 화면 대응이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->