### PR TITLE
fix(contract): CONT-W01·W03 후속 결함 수정 + 유실된 구조 테스트 복구 (#283)

### DIFF
--- a/src/main/resources/static/css/features/contract.css
+++ b/src/main/resources/static/css/features/contract.css
@@ -871,7 +871,8 @@
 .contract-col-insurer { width: 6.5rem; }
 .contract-col-product { width: 11.75rem; }
 .contract-col-date { width: 5.75rem; }
-.contract-col-premium { width: 8.25rem; }
+/* 근거 팝오버 트리거(1.25rem)까지 들어가는 폭 — th 는 overflow:hidden 이라 모자라면 잘린다. */
+.contract-col-premium { width: 10.25rem; }
 .contract-col-agent { width: 8.5rem; }
 .contract-col-status { width: 5.25rem; }
 .contract-col-cap { width: 7rem; }
@@ -922,6 +923,16 @@
   margin: var(--space-10) var(--space-4) 0;
   padding-inline: var(--space-3);
   border-top: 1px solid var(--color-border-default);
+}
+
+/*
+ * 필터 필드 기본 폭. 아래 미디어쿼리가 이 값을 재정의하므로 반드시 앞에 둔다 —
+ * 셀렉터 특정성이 같아 뒤에 두면 좁은 폭 규칙이 진다.
+ */
+.contract-filter-fields > .filter-field {
+  min-width: 11rem;
+  max-width: 16rem;
+  flex: 1 1 11rem;
 }
 
 @media (max-width: 63.9375rem) {
@@ -982,12 +993,6 @@
 
 .contract-filter-fields {
   flex: 1 1 auto;
-}
-
-.contract-filter-fields > .filter-field {
-  min-width: 11rem;
-  max-width: 16rem;
-  flex: 1 1 11rem;
 }
 
 .contract-filter-fields .field-control,

--- a/src/main/resources/static/js/features/contract/contract-form.js
+++ b/src/main/resources/static/js/features/contract/contract-form.js
@@ -460,6 +460,8 @@
     if (event.target === elements.premiumPerCycleAmount) {
       /* 비우면 다시 자동 채움 대상으로 돌아간다. */
       isPremiumPerCycleUserValue = event.target.value !== "";
+      /* 비운 즉시 채워야 안내 문구("비워 두면 … 채웁니다")와 동작이 맞다 — 필수 항목이라 빈 채로 두면 저장이 막힌다. */
+      if (!isPremiumPerCycleUserValue) syncPremiumPerCycleAmount();
     }
     if (event.target === elements.monthlyEquivalentFirstPremium) syncPremiumPerCycleAmount();
     updateSaveState();
@@ -499,8 +501,14 @@
         redirect();
         return;
       }
-      warnIfRefundRateTableIsMissing(savedContractId).then(function (warned) {
-        window.setTimeout(redirect, warned ? 1800 : 0);
+      /*
+       * 이 Promise 를 반환해야 finally 가 이동 전에 돌지 않는다 —
+       * 반환하지 않으면 저장 버튼이 최대 1.8초 동안 다시 눌려 계약이 중복 생성된다.
+       */
+      return warnIfRefundRateTableIsMissing().then(function (warned) {
+        return new Promise(function (resolve) {
+          window.setTimeout(function () { redirect(); resolve(); }, warned ? 1800 : 0);
+        });
       });
     }).catch(function (error) {
       showError(error, "보험계약을 저장하지 못했습니다.");

--- a/src/main/resources/static/js/features/contract/contract-form.js
+++ b/src/main/resources/static/js/features/contract/contract-form.js
@@ -467,6 +467,19 @@
     updateSaveState();
   }
 
+  /*
+   * 이동을 시작할 때까지 프라미스를 붙들어 둔다.
+   *
+   * 반환하지 않으면 .finally() 가 window.location.assign 보다 먼저 돌아 저장 버튼이
+   * 다시 열리고, 두 번째 요청이 실제로 나간다. 등록(POST)·수정(PUT) 두 경로 모두
+   * 같은 문제라 한 곳으로 모았다 — 한쪽만 고치면 다른 쪽에 그대로 남는다 (#325 리뷰).
+   */
+  function redirectAfter(delayMs, go) {
+    return new Promise(function (resolve) {
+      window.setTimeout(function () { go(); resolve(); }, delayMs);
+    });
+  }
+
   function handleSubmit(event) {
     event.preventDefault();
     clearErrors();
@@ -497,18 +510,9 @@
        * IF-API-18·19 가 내려 주는 scheduleHeaderIds 로 "스케줄이 함께 만들어졌다"까지 알린다.
        */
       rememberSaveMessage(saveMessage(saved));
-      if (isEditMode) {
-        redirect();
-        return;
-      }
-      /*
-       * 이 Promise 를 반환해야 finally 가 이동 전에 돌지 않는다 —
-       * 반환하지 않으면 저장 버튼이 최대 1.8초 동안 다시 눌려 계약이 중복 생성된다.
-       */
+      if (isEditMode) return redirectAfter(0, redirect);
       return warnIfRefundRateTableIsMissing().then(function (warned) {
-        return new Promise(function (resolve) {
-          window.setTimeout(function () { redirect(); resolve(); }, warned ? 1800 : 0);
-        });
+        return redirectAfter(warned ? 1800 : 0, redirect);
       });
     }).catch(function (error) {
       showError(error, "보험계약을 저장하지 못했습니다.");

--- a/src/main/resources/static/js/features/contract/contract-list.js
+++ b/src/main/resources/static/js/features/contract/contract-list.js
@@ -191,7 +191,7 @@
         .then(function (response) {
           if (!response.ok) return failedExport(response);
           return response.blob().then(function (blob) {
-            saveBlob(blob, "contracts.csv");
+            saveBlob(blob, exportFilename(response));
             toast("CSV 파일을 내려받았습니다.", "success");
           });
         })
@@ -220,7 +220,24 @@
     document.body.appendChild(anchor);
     anchor.click();
     anchor.remove();
-    URL.revokeObjectURL(url);
+    /* 다운로드를 비동기로 시작하는 브라우저가 있다 — 같은 태스크에서 해제하면 저장이 실패한다. */
+    window.setTimeout(function () { URL.revokeObjectURL(url); }, 0);
+  }
+
+  /*
+   * 서버가 Content-Disposition 으로 "보험계약목록_yyyyMMdd_HHmmss.csv" 를 내려준다.
+   * 헤더가 없거나 읽지 못할 때만 기본 이름을 쓴다.
+   */
+  function exportFilename(response) {
+    var header = response.headers.get("Content-Disposition") || "";
+    var encoded = header.match(/filename\*\s*=\s*UTF-8''([^;]+)/i);
+    if (encoded) {
+      try { return decodeURIComponent(encoded[1].trim()); } catch (error) { /* 아래 기본값으로 */ }
+    }
+    /* 남는 filename= 은 RFC 2047 인코딩워드(=?UTF-8?Q?…?=)일 수 있다 — 그대로 쓰면 파일명이 깨진다. */
+    var plain = header.match(/filename\s*=\s*"?([^";]+)"?/i);
+    if (plain && plain[1].indexOf("=?") === -1) return plain[1].trim();
+    return "contracts.csv";
   }
 
   /*
@@ -239,8 +256,9 @@
       full.className = "table-cell-full";
       Array.from(cell.childNodes).forEach(function (node) {
         preview.appendChild(node.cloneNode(true));
-        full.appendChild(node.cloneNode(true));
       });
+      /* 전체 보기는 값 확인용이다 — 링크까지 복제하면 스크린리더가 같은 목적지를 두 번 읽는다. */
+      full.textContent = cell.textContent.trim();
 
       var details = document.createElement("details");
       details.className = "table-cell-details";
@@ -284,6 +302,8 @@
 
   function scheduleDisclosureSync() {
     window.requestAnimationFrame(syncTableCellDisclosures);
+    /* 폰트가 바뀌면 폭이 달라진다 — policy-list.js·exception-list.js 와 같이 한 번 더 맞춘다. */
+    if (document.fonts && document.fonts.ready) document.fonts.ready.then(syncTableCellDisclosures);
   }
 
   var resizeFrame = null;

--- a/src/main/resources/static/js/features/contract/contract-tabs.js
+++ b/src/main/resources/static/js/features/contract/contract-tabs.js
@@ -276,7 +276,8 @@
 
   function disclosureCell(input) {
     var cell = capDisclosureCell(input, false);
-    cell.className = "contract-disclosure-cell";
+    /* className 을 덮으면 cap-disclosure-cell 의 .table-cell-details 규칙까지 잃는다. */
+    cell.classList.add("contract-disclosure-cell");
     return cell;
   }
 

--- a/src/main/resources/templates/contract/list.html
+++ b/src/main/resources/templates/contract/list.html
@@ -35,7 +35,7 @@
       <table class="data-table contract-table">
         <caption class="visually-hidden">보험계약 검색 결과</caption>
         <colgroup><col class="contract-col-number"><col class="contract-col-insurer"><col class="contract-col-product"><col class="contract-col-date"><col class="contract-col-premium"><col class="contract-col-agent"><col class="contract-col-status"><col class="contract-col-cap"><col class="contract-col-origin"></colgroup>
-        <thead><tr><th scope="col">계약번호</th><th scope="col">보험회사</th><th scope="col">상품명</th><th scope="col">계약일</th><th scope="col" class="is-number" title="주기 보험료를 월 기준으로 환산한 값이며 1,200% 한도 계산 기준으로 사용합니다.">월납환산 초회보험료</th><th scope="col">모집 설계사</th><th scope="col" class="is-center">계약상태</th><th scope="col" class="is-center">1,200% 판정</th><th scope="col" class="is-center">데이터 출처</th></tr></thead>
+        <thead><tr><th scope="col">계약번호</th><th scope="col">보험회사</th><th scope="col">상품명</th><th scope="col">계약일</th><th scope="col" class="is-number">월납환산 초회보험료<span class="evidence" data-evidence><button class="evidence-trigger" type="button" aria-describedby="evidence-monthly-equivalent" aria-label="월납환산 초회보험료 설명 보기"><span class="material-symbols-rounded" aria-hidden="true">help</span></button><div class="evidence-popover" id="evidence-monthly-equivalent" popover><p class="evidence-body">주기 보험료를 월 기준으로 환산한 값입니다. 1,200% 한도 계산 기준으로 사용합니다.</p></div></span></th><th scope="col">모집 설계사</th><th scope="col" class="is-center">계약상태</th><th scope="col" class="is-center">1,200% 판정</th><th scope="col" class="is-center">데이터 출처</th></tr></thead>
         <tbody>
           <!--
             계약상태 배지 색은 화면정의서 4장 규칙 4 (정상=초록·주의=주황·위반=빨강·진행중=파랑) 를 따르고,

--- a/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/web/ScreenViewControllerTest.java
@@ -112,7 +112,11 @@ class ScreenViewControllerTest {
                         "aria-label=\"한도 재검증\"")))
                 // 계약상태 라벨은 서버 enum 이 유일한 출처다 — 화면이 라벨을 새로 만들지 않는다.
                 .andExpect(content().string(org.hamcrest.Matchers.containsString(
-                        "data-code=\"ACTIVE\">정상</span>")))
+                        "data-label-group=\"contractStatus\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        "data-code=\"ACTIVE\"")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString(
+                        ">정상<")))
                 .andExpect(content().string(org.hamcrest.Matchers.not(
                         org.hamcrest.Matchers.containsString("processingJob: \"후속 처리\""))))
                 .andExpect(content().string(org.hamcrest.Matchers.not(

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -12,6 +12,8 @@ class PublishingTemplateStructureTest {
 
     private static final List<String> PUBLISHED_TEMPLATES = List.of(
             "templates/base/index.html",
+            "templates/contract/list.html",
+            "templates/contract/detail.html",
             "templates/contract/form.html",
             "templates/transaction/list.html",
             "templates/transaction/form.html",
@@ -741,12 +743,163 @@ class PublishingTemplateStructureTest {
                 .doesNotContain("fetch(");
     }
 
+    /*
+     * FGC-UI-CONT-W01 보험계약 목록 (#283) — FGC-FUN-018 (화면정의서 :1691).
+     * 자체 필터 카드·표 뷰포트를 공통 컴포넌트로 바꾸고, 계약상태·데이터 출처를 배지로 세웠다.
+     */
+    @Test
+    void contractListUsesCommonFilterTableAndStatusBadges() throws IOException {
+        assertThat(resource("templates/contract/list.html"))
+                .doesNotContain("page-description")
+                .doesNotContain("contract-filter-grid")
+                .doesNotContain("contract-premium-help")
+                .contains("class=\"filter-bar contract-filter-bar\"")
+                .contains("class=\"filter-fields contract-filter-fields\"")
+                .contains("class=\"filter-field\"")
+                .contains("class=\"filter-field-label\"")
+                .contains("class=\"filter-actions contract-filter-actions\"")
+                .contains("class=\"data-table-viewport contract-table-viewport\" tabindex=\"0\" role=\"region\"")
+                // 계약상태는 상태에 따라 색이 갈려야 한다 — 예전에는 전부 neutral 이었다.
+                .contains("status-badge-success")
+                .contains("status-badge-warning")
+                .contains("status-badge-error")
+                .contains("status-badge-info")
+                // 데이터 출처는 CONT-W02 와 같은 배지 표현을 쓴다.
+                .contains("status-badge status-badge-neutral\" th:text=\"${dataOriginLabels[contract.dataOrigin]}\"")
+                .contains("data-disclosure")
+                // 처리 버튼 검증(ContractViewControllerTest·ScreenViewControllerTest)이 의존한다.
+                .contains("data-fgc-action=\"create\"")
+                .doesNotContain("publishing-page")
+                .doesNotContain("style=\"")
+                .doesNotContainPattern("(?i)<style[\\s>]")
+                .doesNotContainPattern("(?i)<script[\\s>]");
+
+        assertThat(resource("static/js/features/contract/contract-list.js"))
+                .contains("format.today()")
+                .contains("table-cell-disclosure")
+                .contains("preview.scrollWidth > preview.clientWidth")
+                .contains("document.fonts.ready")
+                .contains("contract-export-button")
+                .contains("CSV 파일을 내려받았습니다.")
+                .contains("aria-busy");
+
+        assertThat(resource("templates/layout/default.html"))
+                .containsPattern("(?s)<script[^>]*th:if=\"\\$\\{screenId == 'FGC-UI-CONT-W01'\\}\"[^>]*"
+                        + "th:src=\"@\\{/js/features/contract/contract-list\\.js}\"[^>]*\\bdefer\\b[^>]*>");
+    }
+
+    /*
+     * FGC-UI-CONT-W02 보험계약 상세 (#283) — FGC-FUN-018·032·035·036·063, REG-08·12 (화면정의서 :1692).
+     * 인라인 <script> 321줄을 contract-detail.js 로 뺐다. layout 의 page(...) fragment 는
+     * ~{::main} 만 삽입하므로 <main> 밖 <script>는 사라진다 — 인라인이 되살아나면 안 된다.
+     */
+    @Test
+    void contractDetailMovesPageBehaviourOutOfTheTemplate() throws IOException {
+        assertThat(resource("templates/contract/detail.html"))
+                .doesNotContainPattern("(?i)<script[\\s>]")
+                .doesNotContain("style=\"")
+                .doesNotContain("publishing-page")
+                // 공통 탭 컴포넌트
+                .contains("class=\"tab-list contract-detail-tabs\" role=\"tablist\"")
+                .contains("class=\"tab-button contract-detail-tab\"")
+                .doesNotContain("contract-detail-tab-list")
+                // 탭 패널은 키보드로 도달 가능해야 하고, 헤더는 교체 대상 밖에 있어야 한다.
+                .contains("role=\"tabpanel\"")
+                .contains("data-tab-body")
+                .contains("data-tab-state")
+                // 화면정의서 CONT-W02 ① 요약 헤더 필수 항목
+                .contains("id=\"contract-summary-insurer\"")
+                .contains("id=\"contract-summary-agent\"")
+                .contains("id=\"contract-summary-organization\"")
+                // 기본정보 탭 계약상태·데이터 출처도 배지
+                .contains("<span id=\"contract-info-status\" class=\"status-badge")
+                .contains("<span id=\"contract-info-origin\" class=\"status-badge")
+                // REG-08 — 두 규제를 더하지 말라는 경고는 회색 소문단이 아니라 경고 톤이다.
+                .contains("class=\"guidance guidance-warning contract-tab-guidance\"")
+                .contains("두 규제를 더하지 마세요")
+                // 라벨은 서버 enum label() 하나만 쓴다.
+                .contains("data-label-group=\"contractStatus\"")
+                .contains("data-label-group=\"paymentCycle\"")
+                // 1,200% 와 차익거래 판정은 그룹을 나눈다. 둘 다 REVIEW_REQUIRED 를 쓰는데
+                // 라벨이 "검토필요"·"자료부족" 으로 달라, 합치면 labelMap() 이 뒤엣것으로 덮어써
+                // 1,200% 탭이 화면정의서 4-2 대조표(:277 검토필요)와 다른 라벨을 표시한다.
+                .contains("data-label-group=\"capResultStatus\"")
+                .contains("data-label-group=\"arbitrageResultStatus\"")
+                .doesNotContain("data-label-group=\"resultStatus\"")
+                // 구현이 끝난 탭에 "API 연동 대기" 를 남겨 두지 않는다.
+                .doesNotContain("API 연동 대기")
+                .doesNotContain("연동 대기 상태로 표시됩니다")
+                .contains("data-fgc-action=\"recheck\"")
+                .contains("data-fgc-action=\"regenerate\"")
+                .contains("data-fgc-action=\"edit\"");
+
+        assertThat(resource("static/js/features/contract/contract-detail.js"))
+                .contains("window.FgcUi.contractDetail")
+                .contains("STATUS_BADGE_CLASSES")
+                // className 통째 덮어쓰기는 병행 클래스를 잃는다 — exception-list.js 와 같은 방식이어야 한다.
+                .contains("classList.remove.apply(element.classList, STATUS_BADGE_CLASS_NAMES)")
+                .doesNotContain(".className = \"status-badge \"")
+                .contains("event.key === \"Home\"")
+                .contains("event.key === \"End\"")
+                .contains("aria-busy")
+                .contains("format.dateTime")
+                .doesNotContain("toLocaleString(\"ko-KR\")")
+                .doesNotContain("fetch(");
+
+        assertThat(resource("static/js/features/contract/contract-tabs.js"))
+                // 탭 제어를 두 파일이 각각 하지 않는다.
+                .doesNotContain("querySelectorAll(\".contract-detail-tab\")")
+                .contains("contract:tab-activate")
+                .contains("detail.contractId")
+                // 패널 전체가 아니라 본문만 교체해야 헤더가 남는다.
+                .doesNotContain("panel.replaceChildren(")
+                .contains("[data-tab-body]")
+                .contains("visually-hidden")
+                .contains("th.scope = \"col\"")
+                .contains("detail.badgeClass(status)")
+                .contains("format.won")
+                // 라벨 폴백은 판정 종류를 명시해서 읽는다 — 그룹을 안 주면 두 판정이 섞인다.
+                .contains("statusBadge(row.resultStatusLabel, row.resultStatus, \"capResultStatus\")")
+                .contains("statusBadge(row.resultStatusLabel, row.resultStatus, \"arbitrageResultStatus\")")
+                .doesNotContain("codeLabel(\"resultStatus\"")
+                .doesNotContain("fetch(");
+
+        assertThat(resource("templates/layout/default.html"))
+                .containsPattern("(?s)<script[^>]*th:if=\"\\$\\{screenId == 'FGC-UI-CONT-W02'\\}\"[^>]*"
+                        + "th:src=\"@\\{/js/features/contract/contract-detail\\.js}\"[^>]*\\bdefer\\b[^>]*>");
+        // contract-tabs.js 는 contract-detail.js 가 올려 둔 전역을 읽는다 — 순서가 바뀌면 탭이 죽는다.
+        String layout = resource("templates/layout/default.html");
+        assertThat(layout.indexOf("contract/contract-detail.js"))
+                .isLessThan(layout.indexOf("contract/contract-tabs.js"));
+    }
+
+    /*
+     * FGC-UI-CONT-W03 보험계약 등록·수정 (#283) — FGC-FUN-018·036·040 (화면정의서 :1693), IF-API-18·19.
+     * 인라인 동작을 contract-api.js · contract-form.js 로 분리한 상태를 고정한다.
+     */
     @Test
     void contractFormUsesSeparatedApiAndPageScriptsWithoutInlineBehavior() throws IOException {
         assertThat(resource("templates/contract/form.html"))
                 .contains("name=\"premiumPerCycleAmount\"")
                 .contains("cycle.name() != 'OTHER'")
                 .contains("data-field-error=\"organizationId\"")
+                .doesNotContain("page-description")
+                // 브리지 스코프를 뗐다 — 레거시 fgc-* 가 0건이라 재매핑이 필요 없다.
+                .doesNotContain("publishing-page")
+                // 설명 Guidance 는 지우되 규제 근거와 필수 입력 안내는 자리를 옮겨 유지한다 (가이드 §7.2).
+                .doesNotContain("contract-form-guidance")
+                .doesNotContain("contract-action-guidance")
+                .contains("id=\"organization-helper\"")
+                .contains("aria-describedby=\"contract-save-hint\"")
+                .contains("REG-07")
+                .contains("REG-08")
+                .contains("REG-12")
+                .contains("REG-19")
+                .contains("class=\"evidence\" data-evidence")
+                // 납입주기·계약상태 라벨은 서버 enum 하나만 쓴다.
+                .contains("T(com.susukkang.fgc.contract.domain.PaymentCycleCode).values()")
+                .contains("T(com.susukkang.fgc.contract.domain.ContractStatus).values()")
+                .doesNotContain("3개월납")
                 .doesNotContain("style=\"")
                 .doesNotContain("onclick=")
                 .doesNotContain("<script>");
@@ -759,6 +912,22 @@ class PublishingTemplateStructureTest {
         assertThat(resource("static/js/features/contract/contract-form.js"))
                 .contains("window.FgcUi.contractApi")
                 .contains("error.field")
+                /*
+                 * 주기 보험료는 입력 필드다 — 화면정의서 CONT-W03 항목표(:619)
+                 * "주기 보험료 | 입력 | 금액 | O | 0 이상", 그리고 :550 "premium_per_cycle_amount 와
+                 * monthly_equivalent_first_premium 은 다른 값입니다".
+                 * 자동 계산은 비어 있을 때 채우는 데까지만 하고 저장값·사용자 입력을 덮어쓰지 않는다.
+                 */
+                .doesNotContain("premiumPerCycleAmount.readOnly")
+                .contains("isPremiumPerCycleUserValue")
+                // 기준정보 로드 실패는 Toast, 필드 오류는 필드 옆 (가이드 §11).
+                .contains("function showLoadFailure(")
+                .contains("format.errorText")
+                // 저장 성공 안내는 상세 진입 후에 뜬다 — redirect 로 사라지면 안 된다.
+                .contains("fgc.contract.saveMessage")
+                .contains("scheduleHeaderIds")
+                .contains("format.today()")
+                .contains("aria-busy")
                 .doesNotContain("fetch(");
     }
 

--- a/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
+++ b/src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java
@@ -744,7 +744,7 @@ class PublishingTemplateStructureTest {
     }
 
     /*
-     * FGC-UI-CONT-W01 보험계약 목록 (#283) — FGC-FUN-018 (화면정의서 :1691).
+     * FGC-UI-CONT-W01 보험계약 목록 (#283) — FGC-FUN-018 (화면정의서 화면목록표 CONT-W01 행).
      * 자체 필터 카드·표 뷰포트를 공통 컴포넌트로 바꾸고, 계약상태·데이터 출처를 배지로 세웠다.
      */
     @Test
@@ -789,7 +789,7 @@ class PublishingTemplateStructureTest {
     }
 
     /*
-     * FGC-UI-CONT-W02 보험계약 상세 (#283) — FGC-FUN-018·032·035·036·063, REG-08·12 (화면정의서 :1692).
+     * FGC-UI-CONT-W02 보험계약 상세 (#283) — FGC-FUN-018·032·035·036·063, REG-08·12 (화면정의서 화면목록표 CONT-W02 행).
      * 인라인 <script> 321줄을 contract-detail.js 로 뺐다. layout 의 page(...) fragment 는
      * ~{::main} 만 삽입하므로 <main> 밖 <script>는 사라진다 — 인라인이 되살아나면 안 된다.
      */
@@ -874,7 +874,7 @@ class PublishingTemplateStructureTest {
     }
 
     /*
-     * FGC-UI-CONT-W03 보험계약 등록·수정 (#283) — FGC-FUN-018·036·040 (화면정의서 :1693), IF-API-18·19.
+     * FGC-UI-CONT-W03 보험계약 등록·수정 (#283) — FGC-FUN-018·036·040 (화면정의서 화면목록표 CONT-W03 행), IF-API-18·19.
      * 인라인 동작을 contract-api.js · contract-form.js 로 분리한 상태를 고정한다.
      */
     @Test
@@ -928,6 +928,12 @@ class PublishingTemplateStructureTest {
                 .contains("scheduleHeaderIds")
                 .contains("format.today()")
                 .contains("aria-busy")
+                /*
+                 * 등록(POST)·수정(PUT) 두 경로 모두 이동이 시작될 때까지 프라미스를 붙들어야 한다.
+                 * 반환하지 않으면 finally 가 먼저 돌아 저장 버튼이 다시 열리고 두 번째 요청이 나간다.
+                 */
+                .contains("function redirectAfter(")
+                .contains("if (isEditMode) return redirectAfter(0, redirect);")
                 .doesNotContain("fetch(");
     }
 


### PR DESCRIPTION
Refs #283, #138

#315 병합 이후 워킹트리에 남아 있던 후속 수정을 정리한 PR입니다.
정리하는 과정에서 **그 사이 다른 병합이 CONT 구조 테스트를 지운 것**을 발견해 함께 복구했습니다.

- 기준 커밋: `c55a7729` (`origin/develop`)
- 7 files changed, +222 / −15

---

## ⚠️ 먼저 봐 주세요 — 유실된 회귀 방어망

`806433ab [Refactor] VRUN-W01·W02 (#286) (#318)` 병합이 공유 파일
`PublishingTemplateStructureTest.java` 에서 CONT 검증을 되돌려 놓았습니다.
다른 화면 테스트는 무사하고, **CONT 쪽만** 다음이 사라졌습니다.

| 잃은 것 | 내용 |
|---|---|
| 테스트 2개 삭제 | `contractListUsesCommonFilterTableAndStatusBadges`<br>`contractDetailMovesPageBehaviourOutOfTheTemplate` |
| W03 테스트 약화 | REG-07/08/12/19 · `evidence` · `publishing-page` 부재 · `PaymentCycleCode` enum · `showLoadFailure` · `saveMessage` · `scheduleHeaderIds` · `aria-busy` 단언 전부 |
| `PUBLISHED_TEMPLATES` | `contract/list.html` · `contract/detail.html` 제외 |

그 결과 **CONT-W01/W02 에 인라인 `<script>` 가 되살아나거나, 탭 제어가 다시 2중화되거나,
`panel.replaceChildren` 이 패널 헤더를 지워도 아무도 잡지 못하는 상태**였습니다.
테스트는 계속 초록이었으므로 코드 스캔으로는 드러나지 않습니다.

확인 방법:

```bash
git show 7654eeb7:src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java \
  | grep -oE 'void [a-zA-Z]+\(' | sort > /tmp/before.txt
git show origin/develop:src/test/java/com/susukkang/fgc/ui/PublishingTemplateStructureTest.java \
  | grep -oE 'void [a-zA-Z]+\(' | sort > /tmp/after.txt
comm -23 /tmp/before.txt /tmp/after.txt      # 사라진 2건
```

이 PR 은 develop 판을 기준으로 두고 **잃은 것만 다시 얹었습니다.**
`#318`·`#321`·`#322` 가 새로 넣은 테스트 3개와 W03 의
`cycle.name() != 'OTHER'` 단언은 그대로 유지했습니다 (테스트 메서드 30개, 중복 0).

> 마이그레이션 가이드 §2 가 경고한 "공유 파일" 충돌이 실제로 일어난 사례입니다.
> 남은 화면 이슈들도 이 파일을 건드리므로, 병합 시 **테스트 메서드 목록을 diff** 해
> 사라진 것이 없는지 확인하는 절차를 두는 편이 좋겠습니다.

---

## 수정 내용

### 1. CONT-W03 저장 중복 요청 — `contract-form.js`

저장 성공 후 redirect 프라미스를 반환하지 않아 `finally` 가 먼저 돌았습니다.
버튼이 다시 열려 **두 번째 POST 가 실제로 나갑니다.**

API 를 스텁해 서버를 부르지 않고 A/B 로 확인했습니다.

| | 마이크로태스크 후 버튼 | `aria-busy` | `createContract` 호출 |
|---|---|---|---|
| 수정 전 | `disabled: false` | `false` | **2** |
| 수정 후 | `disabled: true` | `true` | **1** |

`uq_contract_no UNIQUE (insurer_id, contract_no)` 제약이 있어 **데이터 중복 생성은 없습니다.**
대신 서버가 스케줄 생성까지 하다가 롤백하고, 리다이렉트 순간 화면에
"저장 불가 — 이미 등록된 계약번호입니다" 가 스칩니다.

주기 보험료를 비운 즉시 다시 채우도록 함께 고쳤습니다 — 안내 문구
("비워 두면 … 채웁니다")와 동작이 어긋나 있었습니다.

### 2. CONT-W01 — `contract-list.js` · `list.html` · `contract.css`

- **CSV 파일명** 을 하드코딩(`contracts.csv`) 대신 `Content-Disposition` 에서 읽습니다.
  서버가 `ContentDisposition.attachment().filename(name, UTF_8)` 로 보내므로
  `filename*=UTF-8''보험계약목록_yyyyMMdd_HHmmss.csv` 를 우선 읽고,
  폴백에서 RFC 2047 인코딩워드(`=?UTF-8?Q?…?=`)를 걸러 파일명이 깨지지 않게 했습니다.
- **`URL.revokeObjectURL` 을 다음 태스크로** 미룹니다. 같은 태스크에서 해제하면
  다운로드를 비동기로 시작하는 브라우저에서 저장이 실패합니다.
- **[전체 보기] 패널에 링크를 복제하지 않습니다.** 계약번호 셀의 `<a>` 가 두 번
  들어가 스크린리더가 같은 목적지를 두 번 읽었습니다. 값 확인용이므로 텍스트만 넣습니다.
- **`document.fonts.ready`** 로 폰트 로드 후 잘림 여부를 다시 잽니다
  (`policy-list.js`·`exception-list.js` 와 같은 방식).
- **월납환산 초회보험료 설명을 근거 팝오버로** 옮겼습니다 (화면정의서 4장 규칙 5).
  `th` 의 `title` 은 키보드·터치에서 닿지 않습니다. 트리거가 들어갈 만큼 컬럼 폭을 넓혔습니다.
- **필터 필드 기본 폭 규칙을 미디어쿼리보다 앞으로** 옮겼습니다.
  셀렉터 특정성이 같아 뒤에 있으면 좁은 폭 규칙이 져서, **반응형이 아예 먹지 않았습니다.**

### 3. CONT-W02 — `contract-tabs.js`

`disclosureCell()` 이 `cell.className = "contract-disclosure-cell"` 로 덮어써
`cap-disclosure-cell` 을 잃고 `.table-cell-details` 규칙이 빠졌습니다.
`classList.add` 로 바꿨습니다.

*(#315 에서 배지에 대해 지적하고 고쳤던 `className` 통째 덮어쓰기 안티패턴을
같은 PR 안 다른 곳에서 저질렀던 건입니다.)*

### 4. 테스트

- 주기 보험료 인수조건 고정 — `premiumPerCycleAmount.readOnly` 부재 +
  `isPremiumPerCycleUserValue` 존재 (화면정의서 `:619` "주기 보험료 | 입력", `:550`)
- `ScreenViewControllerTest` 의 공백 취약 단언을 3개로 분리.
  `data-code="ACTIVE">정상</span>` 한 덩어리는 Thymeleaf 가 속성 사이에
  줄바꿈을 넣으면 깨집니다.
- 요구사항 추적 주석(FGC-FUN-018 등) 추가

---

## 검증

```
./gradlew test                                   전체 통과 (테스트 메서드 30개, 중복 0)
node --check contract-{list,tabs,form,api,detail}.js   전부 통과
```

**브라우저 QA** (`bootRun`, Chrome, 로그인 후 실제 조작)

| 화면 | 확인 |
|---|---|
| CONT-W01 | 필터 조회 → URL 보존 · 배지 3종 · 근거 팝오버 · **전체 보기 링크 0개**(preview 1개) · 잘린 셀 17/숨김 63 · CSV Toast |
| CONT-W02 | 요약 헤더 7항목 · 탭 전환 시 헤더 유지 · **`cap-disclosure-cell contract-disclosure-cell` 둘 다 유지** · caption·`th scope`·뷰포트 `tabindex/role/aria-label` |
| CONT-W03 수정 | 저장값 보존 · 편집 가능 · **월납→분기납 변경 시 안 밀림** · 직접 입력값 유지 · 비우면 재채움 |
| CONT-W03 등록 | 저장 성공 Toast + 스케줄 2건 안내 · 저장 중 `disabled`+`aria-busy` |

콘솔 오류 0건.

## 확인 부탁드립니다

1. **900px / 720px 육안 확인이 남았습니다.** 반응형 규칙 순서 수정은 CSSOM 으로
   확인했지만(base → 63.94rem → 47.94rem) 실제 화면은 못 봤습니다.
   세션 환경에서 브라우저 창 크기 조절이 막혀 있습니다.
2. **시연/QA 중 만든 계약이 로컬 dev DB 에 남아 있습니다** — `QA-283-0001`(25),
   `DEMO-283-DUP`(26), `DEMO-283-DUP2`(27). 27번은 테스트 방식 실패로 생긴 것이라
   지우셔도 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
