### PR TITLE
[Fix] 오류 메시지 치환 파라미터 미치환 해소 — {requestId} 기본 주입 · {id} 지점 보정

### DIFF
--- a/src/main/java/com/susukkang/fgc/arbitrage/service/ArbitrageService.java
+++ b/src/main/java/com/susukkang/fgc/arbitrage/service/ArbitrageService.java
@@ -222,7 +222,7 @@ public class ArbitrageService {
         ArbitrageCalculationSource source =
                 arbitrageMapper.selectCalculationSource(contractId, request.getAsOfDate());
         if (source == null)
-            throw new FgcBusinessException(FgcErrorCode.COMMON_004, Map.of("contractId", contractId));
+            throw new FgcBusinessException(FgcErrorCode.COMMON_004, Map.of("id", contractId));
 
         // 확정 지급·차감 순액과 활성 스케줄의 남은 지급예정액 조회
         ConfirmedCommissionSummary confirmedCommission = arbitrageMapper.sumConfirmedCommissionAmount(

--- a/src/main/java/com/susukkang/fgc/cap/service/CapCalculatorImpl.java
+++ b/src/main/java/com/susukkang/fgc/cap/service/CapCalculatorImpl.java
@@ -54,7 +54,7 @@ public class CapCalculatorImpl implements CapCalculator {
         CapContractView contract = capContractMapper.findById(command.contractId());
         if (contract == null) {
             throw new FgcBusinessException(FgcErrorCode.COMMON_500,
-                    Map.of("requestId", "contractId=" + command.contractId() + " not found"));
+                    null, Map.of(), "contractId=" + command.contractId() + " not found");
         }
 
         // "어떤 규칙을 적용할지"는 항상 계약 체결일 기준으로 찾음 (REG-19)

--- a/src/main/java/com/susukkang/fgc/cap/service/CapCheckServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/cap/service/CapCheckServiceImpl.java
@@ -216,7 +216,7 @@ public class CapCheckServiceImpl implements CapCheckService {
             // "{}"로 조용히 넘기면 근거(계산 스냅샷) 없는 cap_check가 성공한 것처럼 저장된다.
             // calculateAndSave는 @Transactional이라 여기서 던지면 INSERT까지 통째로 롤백된다.
             throw new FgcBusinessException(FgcErrorCode.COMMON_500,
-                    Map.of("requestId", "calculation_snapshot 직렬화 실패: " + e.getMessage()));
+                    null, Map.of(), "calculation_snapshot 직렬화 실패: " + e.getMessage());
         }
     }
 
@@ -231,7 +231,7 @@ public class CapCheckServiceImpl implements CapCheckService {
             // 빈 맵으로 감추면 저장된 판정이 근거 없이 조회되는 것처럼 보인다 — 데이터가 깨졌다는
             // 사실을 그대로 드러내야 원인 파악이 된다.
             throw new FgcBusinessException(FgcErrorCode.COMMON_500,
-                    Map.of("requestId", "calculation_snapshot 역직렬화 실패: " + e.getMessage()));
+                    null, Map.of(), "calculation_snapshot 역직렬화 실패: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/com/susukkang/fgc/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/susukkang/fgc/common/exception/GlobalExceptionHandler.java
@@ -83,20 +83,24 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.failure(apiError));
     }
 
+    /** {requestId} 를 쓰는 유일한 문구 — 이 키는 COMMON_500 과 AUDT_001 이 공유한다 (코드리뷰 2차 반영). */
+    private static final String INTERNAL_MESSAGE_KEY = "error.common.internal";
+
     /**
      * {requestId} 자리표시자를 쓰는 문구가 호출부의 파라미터 누락으로
      * "요청번호 {requestId}를…" 원문 그대로 노출되지 않게 기본값을 주입한다 (QA-07 · #259).
      *
-     * COMMON_500 에만 주입하는 이유(코드리뷰 반영) — error.params 는 문서상 "문구의
-     * 치환값"(인터페이스정의서 :157)이라, 문구가 쓰지 않는 키를 모든 오류에 얹으면
-     * 응답 계약이 문서 예시(:143~148)와 달라진다. 현재 {requestId} 를 쓰는 문구는
-     * error.common.internal(COMMON_500) 하나뿐이며, 이 전제는
-     * GlobalExceptionHandlerTest.requestIdPlaceholderIsOnlyUsedByCommon500 이 지킨다 —
-     * 새 문구가 {requestId} 를 쓰기 시작하면 그 테스트가 깨져 이 목록을 갱신하게 된다.
+     * 대상을 문구 키 기준으로 좁히는 이유(코드리뷰 반영, 2차) — error.params 는 문서상
+     * "문구의 치환값"(인터페이스정의서 :157)이라, 문구가 쓰지 않는 키를 모든 오류에 얹으면
+     * 응답 계약이 문서 예시(:143~148)와 달라진다. enum 동일성(COMMON_500)으로 좁히면
+     * 같은 문구 키를 공유하는 AUDT_001 이 빠진다(FgcErrorCode :197·:229) — 그래서
+     * messageKey 기준으로 판정한다. 이 전제는 GlobalExceptionHandlerTest 의
+     * requestIdPlaceholderIsOnlyUsedByInternalMessage(properties 스캔)와
+     * fillsRequestIdForEveryErrorCodeUsingTheInternalMessage(enum 전수)가 지킨다.
      * 호출부가 이미 requestId 를 넣었으면 그대로 둔다.
      */
     private Map<String, Object> withRequestId(FgcErrorCode errorCode, Map<String, Object> params) {
-        if (errorCode != FgcErrorCode.COMMON_500) {
+        if (!INTERNAL_MESSAGE_KEY.equals(errorCode.getMessageKey())) {
             return params;
         }
         if (params != null && params.containsKey("requestId")) {

--- a/src/main/java/com/susukkang/fgc/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/susukkang/fgc/common/exception/GlobalExceptionHandler.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @Slf4j
@@ -73,13 +74,28 @@ public class GlobalExceptionHandler {
         ApiError apiError = createApiError(
                 errorCode,
                 exception.getField(),
-                exception.getParams(),
+                withRequestId(exception.getParams()),
                 productionDetail(exception.getDetail())
         );
 
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ApiResponse.failure(apiError));
+    }
+
+    /**
+     * {requestId} 자리표시자를 쓰는 문구(COMMON_500 등)가 호출부의 파라미터 누락으로
+     * "요청번호 {requestId}를…" 원문 그대로 노출되지 않게 기본값을 주입한다 (QA-07 · #259).
+     * 호출부가 이미 requestId 를 넣었으면 그대로 둔다. {requestId} 가 없는 문구에는
+     * 남는 파라미터일 뿐이라 무해하다.
+     */
+    private Map<String, Object> withRequestId(Map<String, Object> params) {
+        if (params != null && params.containsKey("requestId")) {
+            return params;
+        }
+        Map<String, Object> merged = new LinkedHashMap<>(params == null ? Map.of() : params);
+        merged.put("requestId", RequestIdContext.current());
+        return merged;
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/susukkang/fgc/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/susukkang/fgc/common/exception/GlobalExceptionHandler.java
@@ -193,18 +193,12 @@ public class GlobalExceptionHandler {
                 exception
         );
 
-        Map<String, Object> params =
-                errorCode == FgcErrorCode.COMMON_500
-                        ? Map.of(
-                        "requestId",
-                        RequestIdContext.current()
-                )
-                        : Map.of();
-
+        // withRequestId 와 같은 messageKey 기준 판정을 재사용한다 (3차 리뷰 반영) —
+        // resolver 매핑이 AUDT_001 같은 internal 문구 공유 코드로 확장돼도 이 경로가 놓치지 않는다.
         ApiError apiError = createApiError(
                 errorCode,
                 null,
-                params,
+                withRequestId(errorCode, Map.of()),
                 productionDetail(exception.getMostSpecificCause().getMessage())
         );
 

--- a/src/main/java/com/susukkang/fgc/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/susukkang/fgc/common/exception/GlobalExceptionHandler.java
@@ -74,7 +74,7 @@ public class GlobalExceptionHandler {
         ApiError apiError = createApiError(
                 errorCode,
                 exception.getField(),
-                withRequestId(exception.getParams()),
+                withRequestId(errorCode, exception.getParams()),
                 productionDetail(exception.getDetail())
         );
 
@@ -84,12 +84,21 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * {requestId} 자리표시자를 쓰는 문구(COMMON_500 등)가 호출부의 파라미터 누락으로
+     * {requestId} 자리표시자를 쓰는 문구가 호출부의 파라미터 누락으로
      * "요청번호 {requestId}를…" 원문 그대로 노출되지 않게 기본값을 주입한다 (QA-07 · #259).
-     * 호출부가 이미 requestId 를 넣었으면 그대로 둔다. {requestId} 가 없는 문구에는
-     * 남는 파라미터일 뿐이라 무해하다.
+     *
+     * COMMON_500 에만 주입하는 이유(코드리뷰 반영) — error.params 는 문서상 "문구의
+     * 치환값"(인터페이스정의서 :157)이라, 문구가 쓰지 않는 키를 모든 오류에 얹으면
+     * 응답 계약이 문서 예시(:143~148)와 달라진다. 현재 {requestId} 를 쓰는 문구는
+     * error.common.internal(COMMON_500) 하나뿐이며, 이 전제는
+     * GlobalExceptionHandlerTest.requestIdPlaceholderIsOnlyUsedByCommon500 이 지킨다 —
+     * 새 문구가 {requestId} 를 쓰기 시작하면 그 테스트가 깨져 이 목록을 갱신하게 된다.
+     * 호출부가 이미 requestId 를 넣었으면 그대로 둔다.
      */
-    private Map<String, Object> withRequestId(Map<String, Object> params) {
+    private Map<String, Object> withRequestId(FgcErrorCode errorCode, Map<String, Object> params) {
+        if (errorCode != FgcErrorCode.COMMON_500) {
+            return params;
+        }
         if (params != null && params.containsKey("requestId")) {
             return params;
         }

--- a/src/main/java/com/susukkang/fgc/exceptioncase/service/ExceptionCaseService.java
+++ b/src/main/java/com/susukkang/fgc/exceptioncase/service/ExceptionCaseService.java
@@ -213,7 +213,7 @@ public class ExceptionCaseService {
             throw new FgcBusinessException(
                     FgcErrorCode.COMMON_004,
                     "exceptionCaseId",
-                    Map.of("field", "exceptionCaseId"),
+                    Map.of("field", "exceptionCaseId", "id", exceptionCaseId),
                     null
             );
         }

--- a/src/main/java/com/susukkang/fgc/exceptioncase/service/JournalCorrectionExceptionActionService.java
+++ b/src/main/java/com/susukkang/fgc/exceptioncase/service/JournalCorrectionExceptionActionService.java
@@ -49,7 +49,7 @@ public class JournalCorrectionExceptionActionService {
                 .findJournalCorrectionTargetForUpdate(exceptionCaseId);
         if (target == null) {
             throw new FgcBusinessException(FgcErrorCode.COMMON_004,
-                    "exceptionCaseId", Map.of("field", "exceptionCaseId"), null);
+                    "exceptionCaseId", Map.of("field", "exceptionCaseId", "id", exceptionCaseId), null);
         }
         validateTarget(target);
 

--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationRunDetailServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationRunDetailServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -32,7 +33,7 @@ public class ValidationRunDetailServiceImpl implements ValidationRunDetailServic
     public ValidationRunDetailResponse detail(Long validationRunId) {
         ValidationRunListRow header = validationRunDetailMapper.findHeaderById(validationRunId);
         if (header == null) {
-            throw new FgcBusinessException(FgcErrorCode.COMMON_004);
+            throw new FgcBusinessException(FgcErrorCode.COMMON_004, Map.of("id", validationRunId));
         }
 
         List<ValidationTargetItemResponse> targets =
@@ -81,7 +82,7 @@ public class ValidationRunDetailServiceImpl implements ValidationRunDetailServic
     public ValidationRunProgressResponse progress(Long validationRunId) {
         ValidationRunRow row = validationRunMapper.findById(validationRunId);
         if (row == null) {
-            throw new FgcBusinessException(FgcErrorCode.COMMON_004);
+            throw new FgcBusinessException(FgcErrorCode.COMMON_004, Map.of("id", validationRunId));
         }
         return ValidationRunProgressResponse.from(row);
     }

--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationRunExecuteServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationRunExecuteServiceImpl.java
@@ -27,7 +27,7 @@ public class ValidationRunExecuteServiceImpl implements ValidationRunExecuteServ
     public ValidationRunRow execute(Long validationRunId, Long executedBy, String requestId) {
         ValidationRunRow row = validationRunMapper.findById(validationRunId);
         if (row == null) {
-            throw new FgcBusinessException(FgcErrorCode.COMMON_004);
+            throw new FgcBusinessException(FgcErrorCode.COMMON_004, Map.of("id", validationRunId));
         }
         if (ValidationRunStatus.FINALIZED.name().equals(row.getStatus())) {
             // "수정 불가 — 확정된 검증 결과입니다. 새 실행을 만드세요." (§3-2)

--- a/src/test/java/com/susukkang/fgc/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/exception/GlobalExceptionHandlerTest.java
@@ -75,11 +75,11 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody().error().message()).contains("CALLER-SET");
     }
 
-    // 주입 범위를 COMMON_500 으로 좁힌 전제(리뷰 반영)를 지키는 가드 —
+    // 주입 범위를 문구 키(error.common.internal)로 좁힌 전제(리뷰 반영)를 지키는 가드 —
     // messages.properties 에서 {requestId} 를 쓰는 문구가 늘어나면 여기가 깨져
-    // withRequestId 의 대상 목록을 함께 갱신하게 된다.
+    // withRequestId 의 판정 기준을 함께 갱신하게 된다.
     @Test
-    void requestIdPlaceholderIsOnlyUsedByCommon500() throws Exception {
+    void requestIdPlaceholderIsOnlyUsedByInternalMessage() throws Exception {
         java.util.Properties messages = new java.util.Properties();
         try (java.io.InputStreamReader reader = new java.io.InputStreamReader(
                 getClass().getResourceAsStream("/messages.properties"),
@@ -91,6 +91,25 @@ class GlobalExceptionHandlerTest {
                 .sorted()
                 .toList();
         assertThat(usingRequestId).containsExactly("error.common.internal");
+    }
+
+    // 같은 문구 키를 공유하는 모든 코드(COMMON_500·AUDT_001)가 보호되는지 enum 전수로 검증 —
+    // enum 동일성 판정이 문구 키 공유를 놓친다는 2차 리뷰 지적의 재발 방지.
+    @Test
+    void fillsRequestIdForEveryErrorCodeUsingTheInternalMessage() {
+        RequestIdContext.set("20260821-test01");
+        java.util.List<FgcErrorCode> internalMessageCodes = java.util.Arrays.stream(FgcErrorCode.values())
+                .filter(code -> "error.common.internal".equals(code.getMessageKey()))
+                .toList();
+        assertThat(internalMessageCodes).contains(FgcErrorCode.COMMON_500, FgcErrorCode.AUDT_001);
+
+        for (FgcErrorCode code : internalMessageCodes) {
+            ResponseEntity<ApiResponse<Void>> response = handler()
+                    .handleBusinessException(new FgcBusinessException(code));
+            String message = response.getBody().error().message();
+            assertThat(message).doesNotContain("{requestId}");
+            assertThat(message).contains("20260821-test01");
+        }
     }
 
     @Test

--- a/src/test/java/com/susukkang/fgc/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,90 @@
+package com.susukkang.fgc.common.exception;
+
+import com.susukkang.fgc.common.web.ApiResponse;
+import com.susukkang.fgc.common.web.RequestIdContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.support.ResourceBundleMessageSource;
+import org.springframework.core.env.Environment;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 설명 : 공통 예외 핸들러의 메시지 치환 파라미터 회귀 테스트 (QA-07 · #259)
+ *
+ * COMMON_500 문구는 {requestId} 자리표시자를 갖는다. 호출부가 파라미터를 빠뜨리면
+ * 화면에 "요청번호 {requestId}를…" 원문이 그대로 노출됐다 — 핸들러가 기본값을
+ * 주입해 이 사고를 구조적으로 막는지 검증한다.
+ *
+ * @author yslee
+ * @version 1.0
+ * @since 2026-08-21
+ */
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerTest {
+
+    @Mock
+    private ConstraintErrorCodeResolver constraintResolver;
+    @Mock
+    private Environment environment;
+
+    private GlobalExceptionHandler handler() {
+        ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
+        messageSource.setBasename("messages");
+        messageSource.setDefaultEncoding("UTF-8");
+        return new GlobalExceptionHandler(
+                new FgcMessageResolver(messageSource),
+                constraintResolver,
+                environment
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestIdContext.clear();
+    }
+
+    @Test
+    void fillsRequestIdWhenCallerOmitsIt() {
+        RequestIdContext.set("20260821-test01");
+
+        ResponseEntity<ApiResponse<Void>> response = handler()
+                .handleBusinessException(new FgcBusinessException(FgcErrorCode.COMMON_500));
+
+        String message = response.getBody().error().message();
+        assertThat(message).doesNotContain("{requestId}");
+        assertThat(message).contains("20260821-test01");
+    }
+
+    @Test
+    void keepsCallerProvidedRequestId() {
+        RequestIdContext.set("20260821-test01");
+
+        ResponseEntity<ApiResponse<Void>> response = handler()
+                .handleBusinessException(new FgcBusinessException(
+                        FgcErrorCode.COMMON_500,
+                        Map.of("requestId", "CALLER-SET")
+                ));
+
+        assertThat(response.getBody().error().message()).contains("CALLER-SET");
+    }
+
+    @Test
+    void notFoundMessageResolvesIdPlaceholderWhenProvided() {
+        ResponseEntity<ApiResponse<Void>> response = handler()
+                .handleBusinessException(new FgcBusinessException(
+                        FgcErrorCode.COMMON_004,
+                        Map.of("id", 42L)
+                ));
+
+        String message = response.getBody().error().message();
+        assertThat(message).doesNotContain("{id}");
+        assertThat(message).contains("42");
+    }
+}

--- a/src/test/java/com/susukkang/fgc/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/exception/GlobalExceptionHandlerTest.java
@@ -75,6 +75,35 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody().error().message()).contains("CALLER-SET");
     }
 
+    // 주입 범위를 COMMON_500 으로 좁힌 전제(리뷰 반영)를 지키는 가드 —
+    // messages.properties 에서 {requestId} 를 쓰는 문구가 늘어나면 여기가 깨져
+    // withRequestId 의 대상 목록을 함께 갱신하게 된다.
+    @Test
+    void requestIdPlaceholderIsOnlyUsedByCommon500() throws Exception {
+        java.util.Properties messages = new java.util.Properties();
+        try (java.io.InputStreamReader reader = new java.io.InputStreamReader(
+                getClass().getResourceAsStream("/messages.properties"),
+                java.nio.charset.StandardCharsets.UTF_8)) {
+            messages.load(reader);
+        }
+        java.util.List<String> usingRequestId = messages.stringPropertyNames().stream()
+                .filter(key -> messages.getProperty(key).contains("{requestId}"))
+                .sorted()
+                .toList();
+        assertThat(usingRequestId).containsExactly("error.common.internal");
+    }
+
+    @Test
+    void doesNotInjectRequestIdIntoOtherErrorCodesParams() {
+        ResponseEntity<ApiResponse<Void>> response = handler()
+                .handleBusinessException(new FgcBusinessException(
+                        FgcErrorCode.COMMON_004,
+                        Map.of("id", 7L)
+                ));
+
+        assertThat(response.getBody().error().params()).doesNotContainKey("requestId");
+    }
+
     @Test
     void notFoundMessageResolvesIdPlaceholderWhenProvided() {
         ResponseEntity<ApiResponse<Void>> response = handler()

--- a/src/test/java/com/susukkang/fgc/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/susukkang/fgc/common/exception/GlobalExceptionHandlerTest.java
@@ -112,6 +112,23 @@ class GlobalExceptionHandlerTest {
         }
     }
 
+    // DataIntegrityViolation 폴백 경로도 같은 판정을 타는지 검증 (3차 리뷰 반영 —
+    // handleBusinessException 만 커버하던 기존 테스트의 사각지대).
+    @Test
+    void fillsRequestIdOnDataIntegrityFallbackPath() {
+        RequestIdContext.set("20260821-test01");
+        org.mockito.BDDMockito.given(constraintResolver.resolve(org.mockito.ArgumentMatchers.any()))
+                .willReturn(java.util.Optional.empty());
+
+        ResponseEntity<ApiResponse<Void>> response = handler().handleDataIntegrityViolation(
+                new org.springframework.dao.DataIntegrityViolationException("boom",
+                        new RuntimeException("root")));
+
+        String message = response.getBody().error().message();
+        assertThat(message).doesNotContain("{requestId}");
+        assertThat(message).contains("20260821-test01");
+    }
+
     @Test
     void doesNotInjectRequestIdIntoOtherErrorCodesParams() {
         ResponseEntity<ApiResponse<Void>> response = handler()


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- 시연·운영 중 화면에 **"요청번호 {requestId}를 담당자에게 알려주세요"** / **"요청한 데이터를 찾을 수 없습니다. ({id})"** 처럼 자리표시자 원문이 그대로 노출되던 문제를 해소합니다 (QA-07 전수 대조 발견 10·11, #259 코멘트).

## 🔗 2. 관련 이슈

- #259 (QA-07 오류코드 전수 검증) · #252

## 🛠 3. 구현 내용

- **근본 수정(1곳)**: `GlobalExceptionHandler.handleBusinessException`이 `requestId` 파라미터를 기본 주입 — 던지는 쪽이 빠뜨려도 원문 노출이 구조적으로 불가능. 호출부가 넣은 값은 유지, `{requestId}` 없는 문구에는 남는 파라미터일 뿐이라 무해
- **`{id}` 미치환 6곳 보정**: `ValidationRunExecuteServiceImpl` · `ValidationRunDetailServiceImpl`(2곳) · `ArbitrageService`(파라미터 키 오기 `contractId`→`id`) · `ExceptionCaseService` · `JournalCorrectionExceptionActionService`
- **`requestId` 오용 3곳 정리**: `CapCalculatorImpl`·`CapCheckServiceImpl`(직렬화/역직렬화)이 오류 설명 문자열을 requestId 자리에 넣어 "요청번호 calculation_snapshot 직렬화 실패…" 같은 왜곡 문장이 나가던 것을 `detail`로 이동 — **prod에서는 detail이 null 처리되므로(3-3 규칙 5) 내부 문자열 노출도 함께 해소**되고, 사용자에겐 진짜 요청번호가 표시됨

## 🧪 4. 테스트 방법

1. 신규 `GlobalExceptionHandlerTest` 3건 — 기본 주입 / 호출부 값 유지 / {id} 치환
2. `./gradlew test --tests "com.susukkang.fgc.{common,validation,arbitrage,exceptioncase,cap}.*"` — 전부 통과
3. 수동: 존재하지 않는 실행 조회(`GET /api/v1/validation-runs/999/progress`) → 메시지에 `{id}` 대신 999 표시 확인

## 🗄️ 5. DB / Flyway 변경

- [x] DB 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)