### PR TITLE
[Fix] sonarcloud blocker 4종 심각도 버그 수정

### DIFF
--- a/src/main/java/com/susukkang/fgc/journal/dto/JournalBalanceSummary.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/JournalBalanceSummary.java
@@ -17,14 +17,24 @@ public class JournalBalanceSummary {
     private BigDecimal debitTotal;
     private BigDecimal creditTotal;
 
-    /** 이슈 #98 균형 조건: 차변>0, 대변>0, 차변==대변을 모두 만족해야 한다. */
+    /**
+     * 이슈 #98 균형 조건: 차변>0, 대변>0, 차변==대변을 모두 만족해야 한다.
+     * debitTotal/creditTotal 중 하나라도 null이면(값을 안 채우고 호출한 경우) 0으로 취급한다 —
+     * summarize()의 null 헤더 처리와 동일하게 "미균형"으로만 판정하고 NPE는 내지 않는다.
+     */
     public boolean isBalanced() {
-        return debitTotal.compareTo(BigDecimal.ZERO) > 0
-                && creditTotal.compareTo(BigDecimal.ZERO) > 0
-                && debitTotal.compareTo(creditTotal) == 0;
+        BigDecimal debit = nullToZero(debitTotal);
+        BigDecimal credit = nullToZero(creditTotal);
+        return debit.compareTo(BigDecimal.ZERO) > 0
+                && credit.compareTo(BigDecimal.ZERO) > 0
+                && debit.compareTo(credit) == 0;
     }
 
     public BigDecimal differenceAmount() {
-        return debitTotal.subtract(creditTotal).abs();
+        return nullToZero(debitTotal).subtract(nullToZero(creditTotal)).abs();
+    }
+
+    private static BigDecimal nullToZero(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
     }
 }

--- a/src/main/resources/static/js/features/base/base-list.js
+++ b/src/main/resources/static/js/features/base/base-list.js
@@ -392,8 +392,7 @@
         return true;
       })
       .catch(function (error) {
-        if (requestId !== state.organizationOptionsRequestId) return false;
-        setError("agent", error);
+        if (requestId === state.organizationOptionsRequestId) setError("agent", error);
         return false;
       })
       .finally(function () {

--- a/src/test/java/com/susukkang/fgc/journal/dto/JournalBalanceSummaryTest.java
+++ b/src/test/java/com/susukkang/fgc/journal/dto/JournalBalanceSummaryTest.java
@@ -1,0 +1,32 @@
+package com.susukkang.fgc.journal.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * SonarQube javabugs:S2259 대응 — isBalanced()/differenceAmount()가 서비스 계층의
+ * null 가드 없이 직접 호출돼도(예: 다른 호출부가 debitTotal/creditTotal 중 하나만
+ * 채운 채 호출) NPE 없이 "미균형"으로 처리되는지 확인한다.
+ */
+class JournalBalanceSummaryTest {
+
+    @Test
+    void isBalancedIsFalseWithoutNpeWhenBothTotalsAreNull() {
+        JournalBalanceSummary summary = new JournalBalanceSummary();
+
+        assertThat(summary.isBalanced()).isFalse();
+        assertThat(summary.differenceAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    void isBalancedIsFalseWithoutNpeWhenOnlyOneTotalIsSet() {
+        JournalBalanceSummary summary = new JournalBalanceSummary();
+        summary.setDebitTotal(BigDecimal.valueOf(1000));
+
+        assertThat(summary.isBalanced()).isFalse();
+        assertThat(summary.differenceAmount()).isEqualByComparingTo(BigDecimal.valueOf(1000));
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

조사 결과 (파일 간 유기적 연결 + 업무 맥락)

1) SQL BLOCKER 2건 — V23_1__exception_work_item_occurrence.sql:90, 329 → 실제 버그 아님, 편집 금지

- 근거대장 확인: SRC-032(2026-08-18 결정, 활성) — "같은 검증월 안정 업무건 1건 + 실행별 검출이력(occurrence) 분리, 13종 상위 예외유형/상세원인 분리" 설계를 그대로 구현한 마이그레이션입니다. git log상 이미 코드리뷰 반영 커밋(37f64e4b)까지 거친 파일입니다.
- 90번 줄: exception_case 전체 행에 reason_code를 CASE로 일괄 백필 — 의도적으로 WHERE 없는 전수 갱신(구 실행별 예외를 새 13종 유형 체계로 이관).
- 329번 줄: exception_occurrence 전체를 is_new_case=false로 리셋한 뒤(331~342줄에서) "각 업무건의 최초 검출 1건만" 다시 true로 되돌리는 2단계 재계산 패턴 — 역시 의도적.
- 결정적 확인: 로컬 DB(fgc-db 컨테이너)에서 flyway_schema_history 조회 결과 23.1 버전이 이미 success=t로 적용됨을 확인했습니다. Flyway는 적용된 마이그레이션 파일의 체크섬을 검증하므로, 이 파일을 지금 고치면 이미 이 마이그레이션을 실행한 모든 환경(로컬/CI/개발 DB)에서 FlywayValidateException으로 기동이 깨집니다. 내일(8/24) 발표를 앞두고 가장 위험한 행동이 "이 파일을 고치는 것"입니다.
- → 코드 수정 대신 SonarQube 이슈를 "Won't Fix"로 처리하는 게 맞는 조치입니다. (아래 확인 필요)

2) JournalBalanceSummary.java:22 NPE — 진짜 방어 공백, 근본 수정 필요

- 호출 경로 추적: JournalImbalanceMapper.xml의 findBalanceSummary 쿼리는 COALESCE(SUM(...), 0)을 쓰고, 그룹 자체가 없을 때(라인 0건)만 매퍼가 null 객체를 반환합니다.
- JournalBalanceValidationServiceImpl.summarize()가 이 null 케이스를 이미 방어(0/0으로 채움) — 서비스 계층의 유일한 실제 호출 경로는 안전합니다. 관련 단위테스트도 이 시나리오를 정확히 커버 중(headerWithNoLinesIsTreatedAsImbalancedInsteadOfThrowingNpe).
- 하지만 JournalBalanceSummary는 @Getter @Setter가 열린 순수 DTO라서, 누구든 new JournalBalanceSummary() 후 debitTotal/creditTotal 중 하나만 세팅하고 isBalanced()를 직접 호출하면 그 자리에서 NPE입니다 — 지금은 안 그러지만 이 DTO에 의존하는 다음 코드(다른 서비스, 매퍼 확장, 테스트)가 그 가드를 다시 안 짤 거란 보장이 없습니다.
- 이건 원장 잔액 검증(이슈 #98, LEDG_001)이라는 돈 계산 경계라서, ponytail 기준으로도 "가볍게 넘길 안전장치"가 아니라 지금 막아두는 게 맞습니다. 호출부 한 곳(서비스)이 아니라 공유 클래스(DTO) 자체에서 막는 게 근본 수정입니다 — 지금 바로 고치겠습니다.

3) base-list.js:394 (S3516, "항상 같은 값 반환") — 의도된 동작, 사실상 오탐

- ensureOrganizationOptions()의 .catch()가 "요청이 이미 낡음(stale race)"과 "진짜 에러" 두 분기 모두 return false로 끝남 — 둘 다 "패널을 로드하면 안 됨"이라는 같은 의미라 실제로 옳은 로직입니다. 다만 stale 분기는 에러 표시(setError)를 건너뛰는 차이만 있고 반환값은 같아서 린터가 "항상 같은 값"으로 오해합니다.
- 원인/조치 없이 넘어가도 되지만, 조건문을 반환값이 아니라 setError 호출 여부에만 걸어 린터도 만족시키고 가독성도 나아지므로 같이 정리하겠습니다.
