### PR TITLE
[Refactor] 계약 컨트롤러 역할 분리 및 enum 패키지 구조 정리

### DIFF
--- a/src/main/java/com/susukkang/fgc/journal/dto/JournalBalanceSummary.java
+++ b/src/main/java/com/susukkang/fgc/journal/dto/JournalBalanceSummary.java
@@ -17,14 +17,24 @@ public class JournalBalanceSummary {
     private BigDecimal debitTotal;
     private BigDecimal creditTotal;
 
-    /** 이슈 #98 균형 조건: 차변>0, 대변>0, 차변==대변을 모두 만족해야 한다. */
+    /**
+     * 이슈 #98 균형 조건: 차변>0, 대변>0, 차변==대변을 모두 만족해야 한다.
+     * debitTotal/creditTotal 중 하나라도 null이면(값을 안 채우고 호출한 경우) 0으로 취급한다 —
+     * summarize()의 null 헤더 처리와 동일하게 "미균형"으로만 판정하고 NPE는 내지 않는다.
+     */
     public boolean isBalanced() {
-        return debitTotal.compareTo(BigDecimal.ZERO) > 0
-                && creditTotal.compareTo(BigDecimal.ZERO) > 0
-                && debitTotal.compareTo(creditTotal) == 0;
+        BigDecimal debit = nullToZero(debitTotal);
+        BigDecimal credit = nullToZero(creditTotal);
+        return debit.compareTo(BigDecimal.ZERO) > 0
+                && credit.compareTo(BigDecimal.ZERO) > 0
+                && debit.compareTo(credit) == 0;
     }
 
     public BigDecimal differenceAmount() {
-        return debitTotal.subtract(creditTotal).abs();
+        return nullToZero(debitTotal).subtract(nullToZero(creditTotal)).abs();
+    }
+
+    private static BigDecimal nullToZero(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
     }
 }

--- a/src/main/resources/static/js/features/base/base-list.js
+++ b/src/main/resources/static/js/features/base/base-list.js
@@ -392,8 +392,7 @@
         return true;
       })
       .catch(function (error) {
-        if (requestId !== state.organizationOptionsRequestId) return false;
-        setError("agent", error);
+        if (requestId === state.organizationOptionsRequestId) setError("agent", error);
         return false;
       })
       .finally(function () {

--- a/src/test/java/com/susukkang/fgc/journal/dto/JournalBalanceSummaryTest.java
+++ b/src/test/java/com/susukkang/fgc/journal/dto/JournalBalanceSummaryTest.java
@@ -1,0 +1,32 @@
+package com.susukkang.fgc.journal.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * SonarQube javabugs:S2259 대응 — isBalanced()/differenceAmount()가 서비스 계층의
+ * null 가드 없이 직접 호출돼도(예: 다른 호출부가 debitTotal/creditTotal 중 하나만
+ * 채운 채 호출) NPE 없이 "미균형"으로 처리되는지 확인한다.
+ */
+class JournalBalanceSummaryTest {
+
+    @Test
+    void isBalancedIsFalseWithoutNpeWhenBothTotalsAreNull() {
+        JournalBalanceSummary summary = new JournalBalanceSummary();
+
+        assertThat(summary.isBalanced()).isFalse();
+        assertThat(summary.differenceAmount()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    void isBalancedIsFalseWithoutNpeWhenOnlyOneTotalIsSet() {
+        JournalBalanceSummary summary = new JournalBalanceSummary();
+        summary.setDebitTotal(BigDecimal.valueOf(1000));
+
+        assertThat(summary.isBalanced()).isFalse();
+        assertThat(summary.differenceAmount()).isEqualByComparingTo(BigDecimal.valueOf(1000));
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

- 계약 관련 컨트롤러를 관리 API, 상세 API, 화면 라우팅의 세 가지 책임으로 분리했습니다.
- 계약 전용 enum을 `contract.domain`에서 `contract.code` 패키지로 이동했습니다.
- 기존 API URL과 응답 구조, 권한 정책은 유지했습니다.

## 🔗 2. 관련 이슈

- Closes #이슈번호

## 🛠 3. 구현 내용

- `ContractController`
  - 계약 목록 조회
  - 계약 목록 CSV 내보내기
  - 계약 등록
  - 계약 수정

- `ContractDetailController`
  - 계약 기본정보 조회
  - 계약 상태이력 조회
  - 운영 예상 스케줄 조회 및 재생성
  - 지급단계별 최신 한도 판정 조회 및 재검증
  - 차익거래 검증 결과 조회 및 수동 재검증
  - 계약 관련 검증원장 조회
  - 계약 관련 지급 및 대사 내역 조회

- `ContractViewController`
  - 계약 목록 화면
  - 계약 등록·수정 화면
  - 계약 상세 화면

- 기존 `ContractLedgerProjectionController`의 원장·지급 내역 조회 기능을 `ContractDetailController`로 통합했습니다.
- 계약 상세 화면 라우팅을 `ScreenViewController`에서 `ContractViewController`로 이동했습니다.
- 상세 API에서 사용하는 도메인 서비스는 기존 책임을 유지하고, `ContractDetailController`에서 조합하도록 정리했습니다.
- 다음 계약 전용 enum을 `contract.code` 패키지로 이동했습니다.
  - `ContractStatus`
  - `DataOrigin`
  - `PaymentCycleCode`
  - `PremiumConversionRuleCode`
- Java 메인·테스트 코드의 import와 Thymeleaf `T(...)` 타입 참조를 변경했습니다.
- 컨트롤러 테스트를 책임별로 분리하고 상세 API 및 화면 라우팅 테스트를 보강했습니다.

## 🧪 4. 테스트 방법

1. 메인 코드와 테스트 코드를 컴파일합니다.

   ```bash
   ./gradlew compileJava compileTestJava
   ```

2. 계약 관련 테스트와 템플릿 구조 테스트를 실행합니다.

   ```bash
   ./gradlew test \
     --tests 'com.susukkang.fgc.contract.*' \
     --tests 'com.susukkang.fgc.ui.PublishingTemplateStructureTest'
   ```

3. 다음 항목을 확인합니다.
    - 계약 목록·등록·수정·상세 화면 접근
    - 계약 상세 API 응답
    - 처리 권한별 수동 재검증 접근 제어
    - 계약 enum을 사용하는 폼 및 상세 화면 렌더링

테스트 결과:

- `compileJava` 성공
- `compileTestJava` 성공
- 계약 관련 테스트 성공
- 템플릿 구조 테스트 성공

## 🗄️ 5. DB / Flyway 변경

- [x] DB 변경 없음
- [ ] 새로운 Flyway 마이그레이션 파일 추가
- [ ] 시드 데이터 변경
- [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

- 없음

## 📋 6. 리뷰 요구사항

- 계약 관리 API와 상세 API의 컨트롤러 책임 구분이 적절한지 확인 부탁드립니다.
- 계약 상세 API를 `ContractDetailController`에서 통합 제공하는 구조가 적절한지 확인 부탁드립니다.
- 계약 전용 enum을 `contract.code`에 배치한 패키지 구조가 프로젝트 컨벤션에 부합하는지 확인 부탁드립니다.
- 기존 API URL과 권한 정책이 그대로 유지되는지 확인 부탁드립니다.

## ✅ 7. 체크리스트

- [ ] `develop` 최신 내용을 반영했습니다.
- [x] 로컬 빌드에 성공했습니다.
- [ ] 애플리케이션 실행을 확인했습니다.
- [x] 관련 기능을 직접 테스트했습니다.
- [x] 테스트 코드가 필요한 경우 작성했습니다.
- [x] 기존 기능에 영향이 없는지 확인했습니다.
- [ ] 커밋 메시지 컨벤션을 준수했습니다.
- [x] 민감정보를 커밋하지 않았습니다.
- [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
- [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

- 화면 UI 변경 없음
- 계약 상세 화면의 URL과 렌더링 결과는 유지하고 라우팅 담당 컨트롤러만 변경

## 💬 9. 참고 사항

- 기존 API URL과 DTO 응답 구조는 변경하지 않았습니다.
- 서비스 계층의 비즈니스 로직은 변경하지 않았습니다.
- 애플리케이션 실행 확인 항목은 별도로 확인 후 체크가 필요합니다.
- `Closes #이슈번호`의 번호는 생성한 이슈 번호로 변경해야 합니다.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 차변·대변 합계가 누락된 경우에도 예외 없이 잔액 상태와 차액을 올바르게 표시합니다.
  * 이전 요청에서 발생한 오류가 최신 요청 결과를 덮어쓰지 않도록 개선했습니다.

* **테스트**
  * 합계가 모두 없거나 한쪽만 있는 경우의 잔액 계산 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->