### PR TITLE
fix(validation): 확정 게이트 예외 조건을 검증월 기준으로 교정 — 실시간 CRITICAL 누락 차단 (#330)

### DIFF
--- a/src/main/java/com/susukkang/fgc/validation/service/ValidationRunFinalizationServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/validation/service/ValidationRunFinalizationServiceImpl.java
@@ -140,12 +140,15 @@ public class ValidationRunFinalizationServiceImpl implements ValidationRunFinali
                 condition(2, "원장 불균형(차변≠대변)이 0건인가",
                         counts.getJournalImbalanceCount(),
                         "/api/v1/journals/imbalances?validationRunId=" + id),
+                // 조건 3·4는 집계 쿼리와 같은 월(validation_month) 기준으로 조회해야
+                // 미충족 건수와 바로가기 목록이 일치한다(#330). 파라미터는 ISO 날짜(월 1일)다.
                 condition(3, "심각도 긴급(CRITICAL) 미처리 예외가 0건인가",
                         counts.getUnresolvedCriticalExceptionCount(),
-                        "/exceptions?validationRunId=" + id + "&severity=CRITICAL&status=OPEN"),
+                        "/exceptions?validationMonth=" + counts.getValidationMonth()
+                                + "&severity=CRITICAL&status=OPEN"),
                 condition(4, "정책 없음 · 정책 중복이 0건인가",
                         counts.getUnresolvedPolicyExceptionCount(),
-                        "/exceptions?validationRunId=" + id
+                        "/exceptions?validationMonth=" + counts.getValidationMonth()
                                 + "&types=POLICY_MISSING&types=POLICY_DUPLICATE&status=OPEN"),
                 condition(5, "귀속합계 오류가 0건인가",
                         counts.getAttributionImbalanceCount(),

--- a/src/main/resources/db/migration/V41__backfill_exception_case_validation_month.sql
+++ b/src/main/resources/db/migration/V41__backfill_exception_case_validation_month.sql
@@ -1,0 +1,11 @@
+-- #330: 실시간 확정 경로(validation_run_id NULL)로 생성된 예외는 validation_month 가
+-- 비어 있어 월 통합검증 확정 게이트(제44조)가 세지 못했다.
+-- 이후 생성분은 CapExceptionMapper·CommissionPaymentMapper INSERT 가 지급 건의
+-- 정산월을 함께 남기므로, 여기서는 기존 행만 지급 건(source_entity)으로 역추적해 채운다.
+-- source_entity_id 가 varchar 라 숫자 캐스팅 오류가 없도록 텍스트 쪽으로 조인한다.
+UPDATE fgc.exception_case ec
+   SET validation_month = ct.settlement_month
+  FROM fgc.commission_transaction ct
+ WHERE ec.validation_month IS NULL
+   AND ec.source_entity_type = 'COMMISSION_TRANSACTION'
+   AND ec.source_entity_id = CAST(ct.commission_transaction_id AS varchar);

--- a/src/main/resources/mapper/cap/CapExceptionMapper.xml
+++ b/src/main/resources/mapper/cap/CapExceptionMapper.xml
@@ -21,6 +21,7 @@
             source_entity_type,
             source_entity_id,
             cap_check_id,
+            validation_month,
             title,
             description
         )
@@ -47,6 +48,12 @@
             <!-- 계산근거로 가는 포인터. 목록 두 곳이 거절된 후보를 제외하므로
                  IF-API-31(findById, 제외 조건 없음)로 여는 경로가 여기서만 열린다. -->
             #{capCheckId},
+            <!-- 실시간 경로는 validation_run_id 가 NULL 이라 확정 게이트(제44조)가 월 기준으로
+                 세도록 지급 건의 정산월을 검출 검증월로 남긴다(#330). settlement_month 는
+                 DDL CHECK 로 항상 월 1일이라 ck_exception_case_validation_month 를 충족한다. -->
+            (SELECT ct.settlement_month
+               FROM commission_transaction ct
+              WHERE ct.commission_transaction_id = #{paymentId}),
             #{title},
             #{description}
             )
@@ -62,6 +69,7 @@
             agent_id = EXCLUDED.agent_id,
             <!-- 재확정 시도 시 최신 판정의 계산근거를 가리키게 한다(#331). -->
             cap_check_id = EXCLUDED.cap_check_id,
+            validation_month = COALESCE(EXCLUDED.validation_month, existing.validation_month),
             title = EXCLUDED.title,
             description = EXCLUDED.description,
             updated_at = clock_timestamp()

--- a/src/main/resources/mapper/transaction/CommissionPaymentMapper.xml
+++ b/src/main/resources/mapper/transaction/CommissionPaymentMapper.xml
@@ -736,6 +736,7 @@
             policy_version_id,
             source_entity_type,
             source_entity_id,
+            validation_month,
             title,
             description
         ) VALUES (
@@ -749,12 +750,19 @@
             #{policyVersionId},
             'COMMISSION_TRANSACTION',
             COALESCE(CAST(#{paymentId} AS varchar), #{sourceEntityId}),
+            <!-- 실시간 확정 경로(run_id NULL)의 POLICY_MISSING 등도 확정 게이트(제44조)가
+                 월 기준으로 세도록 지급 건의 정산월을 검출 검증월로 남긴다(#330).
+                 paymentId 가 NULL 이면 서브쿼리도 NULL — 현행과 동일하게 비워 둔다. -->
+            (SELECT ct.settlement_month
+               FROM fgc.commission_transaction ct
+              WHERE ct.commission_transaction_id = #{paymentId}),
             #{title},
             #{description}
         )
         ON CONFLICT (exception_key) DO UPDATE
            SET status = 'NEW',
                reason_code = EXCLUDED.reason_code,
+               validation_month = COALESCE(EXCLUDED.validation_month, existing.validation_month),
                title = EXCLUDED.title,
                description = EXCLUDED.description,
                updated_at = clock_timestamp()

--- a/src/main/resources/mapper/validation/ValidationRunMapper.xml
+++ b/src/main/resources/mapper/validation/ValidationRunMapper.xml
@@ -46,7 +46,9 @@
     <!--
       IF-API-50 / FUN-044-01
       한 SELECT의 MVCC 스냅샷에서 6개 실패 건수를 함께 읽어 조건별 조회 시점 차이를 없앤다.
-      전표·예외·한도는 validation_run_id 범위, 귀속합계는 문서 정의대로 validation_month 범위다.
+      전표·한도는 validation_run_id 범위, 예외·귀속합계는 문서 정의대로 validation_month 범위다.
+      예외를 실행 범위로 좁히면 실시간 경로(run_id NULL)의 CRITICAL·POLICY_* 가 빠진 채
+      확정되므로(제44조 위반, #330) 상세 화면 KPI(ValidationRunDetailMapper)와 같은 월 기준을 쓴다.
       서비스는 이 집계값을 0건 여부로만 판정하고 화면 문구와 이동 링크를 조립한다.
     -->
     <select id="findFinalizeChecklistCounts"
@@ -63,13 +65,13 @@
                    AS journalImbalanceCount,
                (SELECT COUNT(*)
                   FROM fgc.exception_case exception
-                 WHERE exception.validation_run_id = vr.validation_run_id
+                 WHERE exception.validation_month = vr.validation_month
                    AND exception.severity = 'CRITICAL'
                    AND exception.status IN ('NEW', 'IN_REVIEW'))
                    AS unresolvedCriticalExceptionCount,
                (SELECT COUNT(*)
                   FROM fgc.exception_case exception
-                 WHERE exception.validation_run_id = vr.validation_run_id
+                 WHERE exception.validation_month = vr.validation_month
                    AND exception.exception_type IN ('POLICY_MISSING', 'POLICY_DUPLICATE')
                    AND exception.status IN ('NEW', 'IN_REVIEW'))
                    AS unresolvedPolicyExceptionCount,

--- a/src/test/java/com/susukkang/fgc/cap/mapper/CapExceptionMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/cap/mapper/CapExceptionMapperIntegrationTest.java
@@ -50,7 +50,7 @@ class CapExceptionMapperIntegrationTest {
                 exceptionKey, paymentId, reference, ExceptionType.CAP_VIOLATION, ExceptionSeverity.CRITICAL));
 
         Map<String, Object> stored = jdbcTemplate.queryForMap("""
-                SELECT exception_case_id, exception_type, severity, status
+                SELECT exception_case_id, exception_type, severity, status, validation_month
                   FROM fgc.exception_case
                  WHERE exception_key = ?
                 """, exceptionKey);
@@ -64,7 +64,10 @@ class CapExceptionMapperIntegrationTest {
         assertThat(stored)
                 .containsEntry("exception_type", "CAP_VIOLATION")
                 .containsEntry("severity", "CRITICAL")
-                .containsEntry("status", "NEW");
+                .containsEntry("status", "NEW")
+                // #330: 실시간 예외도 지급 건의 정산월을 검출 검증월로 남겨
+                //       월 통합검증 확정 게이트(제44조)가 셀 수 있어야 한다
+                .containsEntry("validation_month", java.sql.Date.valueOf("2026-08-01"));
         assertThat(capExceptionService.hasUnresolvedViolation(paymentId)).isTrue();
 
         capExceptionService.resolve(CapExceptionResolveCommand.builder()

--- a/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunFinalizeChecklistMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/mapper/ValidationRunFinalizeChecklistMapperIntegrationTest.java
@@ -34,8 +34,12 @@ class ValidationRunFinalizeChecklistMapperIntegrationTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    // 2026-08-23 yslee - #330 확정 게이트 예외 조건을 실행 범위 → 검증월 범위로 교정
+    // 기존 코드: 조건 3·4가 validation_run_id 범위라 실시간 경로(run_id NULL)의
+    //           CRITICAL·POLICY_* 미처리 예외가 있어도 6/6 통과로 FINALIZED 될 수 있었음
+    // 개선: 같은 검증월이면 실행이 달라도, 실행이 없어도(실시간) 확정을 막는지 검증
     @Test
-    void countsOnlyFailuresInTheDocumentedRunAndMonthScopes() {
+    void countsFailuresInTheDocumentedScopesIncludingRealtimeExceptions() {
         Long currentRunId = createCompletedRun(TEST_MONTH);
         Long otherRunId = createCompletedRun(TEST_MONTH);
         Long contractId = jdbcTemplate.queryForObject(
@@ -44,11 +48,17 @@ class ValidationRunFinalizeChecklistMapperIntegrationTest {
         insertJournalImbalance(currentRunId, contractId, "current");
         insertJournalImbalance(otherRunId, contractId, "other");
 
-        insertException(currentRunId, "CRITICAL", "OTHER", "NEW", "critical-open");
-        insertException(currentRunId, "CRITICAL", "OTHER", "RESOLVED", "critical-resolved");
-        insertException(otherRunId, "CRITICAL", "OTHER", "NEW", "critical-other-run");
-        insertException(currentRunId, "WARNING", "POLICY_MISSING", "IN_REVIEW", "policy-open");
-        insertException(currentRunId, "WARNING", "POLICY_DUPLICATE", "REJECTED", "policy-rejected");
+        insertException(currentRunId, TEST_MONTH, "CRITICAL", "OTHER", "NEW", "critical-open");
+        insertException(currentRunId, TEST_MONTH, "CRITICAL", "OTHER", "RESOLVED", "critical-resolved");
+        insertException(otherRunId, TEST_MONTH, "CRITICAL", "OTHER", "NEW", "critical-other-run");
+        // #330 핵심 회귀: 실시간 확정 경로(FUN-034)는 validation_run_id 가 NULL 이다
+        insertException(null, TEST_MONTH, "CRITICAL", "CAP_VIOLATION", "NEW", "critical-realtime");
+        insertException(null, TEST_MONTH.plusMonths(1), "CRITICAL", "CAP_VIOLATION", "NEW",
+                "critical-other-month");
+        insertException(currentRunId, TEST_MONTH, "WARNING", "POLICY_MISSING", "IN_REVIEW", "policy-open");
+        insertException(currentRunId, TEST_MONTH, "WARNING", "POLICY_DUPLICATE", "REJECTED",
+                "policy-rejected");
+        insertException(null, TEST_MONTH, "HIGH", "POLICY_MISSING", "NEW", "policy-realtime");
 
         insertAttributionImbalancedTransaction(TEST_MONTH, "current-month");
         insertAttributionImbalancedTransaction(TEST_MONTH.plusMonths(1), "other-month");
@@ -60,8 +70,11 @@ class ValidationRunFinalizeChecklistMapperIntegrationTest {
 
         assertThat(counts.getIncompleteRunCount()).isZero();
         assertThat(counts.getJournalImbalanceCount()).isEqualTo(1);
-        assertThat(counts.getUnresolvedCriticalExceptionCount()).isEqualTo(1);
-        assertThat(counts.getUnresolvedPolicyExceptionCount()).isEqualTo(1);
+        // 같은 검증월의 미처리 CRITICAL 3건: 현재 실행 1 + 다른 실행 1 + 실시간(run_id NULL) 1.
+        // 다른 검증월·해결(RESOLVED) 건은 세지 않는다.
+        assertThat(counts.getUnresolvedCriticalExceptionCount()).isEqualTo(3);
+        // 같은 검증월의 미처리 정책 예외 2건: 배치 IN_REVIEW 1 + 실시간 NEW 1. 종결(REJECTED) 제외.
+        assertThat(counts.getUnresolvedPolicyExceptionCount()).isEqualTo(2);
         assertThat(counts.getAttributionImbalanceCount()).isEqualTo(1);
         assertThat(counts.getCapDetailMismatchCount()).isEqualTo(1);
     }
@@ -140,14 +153,16 @@ class ValidationRunFinalizeChecklistMapperIntegrationTest {
                 """, headerId, accounts.get(0), headerId, accounts.get(1));
     }
 
-    private void insertException(Long runId, String severity, String type, String status, String suffix) {
+    /** runId 가 NULL 이면 실시간 확정 경로, 아니면 배치 검출 경로를 흉내 낸다. 월은 두 경로 모두 남긴다(#330). */
+    private void insertException(Long runId, LocalDate month, String severity, String type,
+                                 String status, String suffix) {
         jdbcTemplate.update("""
                 INSERT INTO fgc.exception_case (
                     exception_key, exception_type, severity, status, validation_run_id,
-                    source_entity_type, source_entity_id, title
-                ) VALUES (?, ?, ?, ?, ?, 'VALIDATION_RUN', ?, 'FUN-044 checklist test')
+                    validation_month, source_entity_type, source_entity_id, title
+                ) VALUES (?, ?, ?, ?, ?, ?, 'VALIDATION_RUN', ?, 'FUN-044 checklist test')
                 """, "FUN044-EX-" + suffix + "-" + UUID.randomUUID(), type, severity, status,
-                runId, runId + "-" + suffix);
+                runId, month, runId + "-" + suffix);
     }
 
     private void insertAttributionImbalancedTransaction(LocalDate month, String suffix) {

--- a/src/test/java/com/susukkang/fgc/validation/service/ValidationRunFinalizationServiceImplTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ValidationRunFinalizationServiceImplTest.java
@@ -72,8 +72,9 @@ class ValidationRunFinalizationServiceImplTest {
         assertThat(response.conditions()).extracting("linkUrl").containsExactly(
                 "/validation-runs/44",
                 "/api/v1/journals/imbalances?validationRunId=44",
-                "/exceptions?validationRunId=44&severity=CRITICAL&status=OPEN",
-                "/exceptions?validationRunId=44&types=POLICY_MISSING&types=POLICY_DUPLICATE&status=OPEN",
+                // #330: 조건 3·4는 집계와 같은 월 기준으로 이동해야 건수와 목록이 일치한다
+                "/exceptions?validationMonth=2026-08-01&severity=CRITICAL&status=OPEN",
+                "/exceptions?validationMonth=2026-08-01&types=POLICY_MISSING&types=POLICY_DUPLICATE&status=OPEN",
                 "/transactions?settlementMonth=2026-08&attributionImbalanceOnly=true",
                 "/validation-runs/44");
     }

--- a/src/test/java/com/susukkang/fgc/validation/service/ValidationRunFinalizationServiceIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/service/ValidationRunFinalizationServiceIntegrationTest.java
@@ -65,13 +65,16 @@ class ValidationRunFinalizationServiceIntegrationTest {
     @Test
     @WithMockUser(username = "admin", roles = "SYSTEM_ADMIN")
     void leavesRunCompletedWhenChecklistHasAnUnresolvedCriticalException() {
-        Long runId = createCompletedRun(LocalDate.of(2087, 2, 1));
+        LocalDate month = LocalDate.of(2087, 2, 1);
+        Long runId = createCompletedRun(month);
+        // #330: 배치 검출 경로(record_exception_detection)는 항상 validation_month 를 남기고,
+        // 확정 게이트 조건 3도 그 월 기준으로 센다 — 픽스처도 실제 검출 행과 같게 월을 채운다.
         jdbcTemplate.update("""
                 INSERT INTO fgc.exception_case (
                     exception_key, exception_type, severity, status, validation_run_id,
-                    source_entity_type, source_entity_id, title
-                ) VALUES (?, 'OTHER', 'CRITICAL', 'NEW', ?, 'VALIDATION_RUN', ?, '확정 차단 예외')
-                """, "FUN044-BLOCK-" + UUID.randomUUID(), runId, String.valueOf(runId));
+                    validation_month, source_entity_type, source_entity_id, title
+                ) VALUES (?, 'OTHER', 'CRITICAL', 'NEW', ?, ?, 'VALIDATION_RUN', ?, '확정 차단 예외')
+                """, "FUN044-BLOCK-" + UUID.randomUUID(), runId, month, String.valueOf(runId));
 
         assertThatThrownBy(() -> validationRunFinalizationService.finalizeRun(
                 runId, systemAdminUserId(), "FUN044-BLOCK-KEY-" + UUID.randomUUID()))


### PR DESCRIPTION
Closes #330

> 기준 커밋: origin/develop `9f79925b` · 상위 #252 · QA-05(#257) E2E 실측 발견

## 무엇이 문제였나

실시간 확정 경로(FUN-034, `CapExceptionServiceImpl.createIfNecessary`)가 만드는 예외는 `validation_run_id` 가 **NULL** 이라(FGC-FUN-052 중복 방지를 위한 설계), 확정 체크리스트의

- 조건 3 `CRITICAL 미처리 예외 0건`
- 조건 4 `정책 없음·중복 0건`

이 쓰던 `exception.validation_run_id = vr.validation_run_id` 조건에 **구조적으로 걸리지 않았습니다.** 그 결과 `CAP_VIOLATION`/`CRITICAL` 미해결 예외가 실재해도 6/6 통과 → `FINALIZED`(불변) 될 수 있었습니다 (#257 E2E 실측 재현).

조사 중 확인한 추가 사실: `CommissionPaymentMapper.insertExceptionCase` 도 실시간으로 `POLICY_MISSING` 을 만들어 **조건 4에도 같은 구멍**이 있었습니다.

## 어떻게 고쳤나 (월 기준 통일)

제44조(`운영정책서 :1059`)는 범위 한정 문언이 없고, 같은 화면의 KPI(`ValidationRunDetailMapper.xml` 미처리 업무건)는 이미 `validation_month` 기준입니다. 이슈의 선택지 (b)를 뿌리 쪽에서 구현했습니다.

1. **실시간 INSERT 2곳이 검출 검증월을 남김** — `CapExceptionMapper`·`CommissionPaymentMapper` 가 지급 건의 `settlement_month`(DDL CHECK 로 항상 월 1일)를 `validation_month` 로 기록. ON CONFLICT 시 기존 값 보존(COALESCE).
2. **V41 백필 마이그레이션** — 기존 실시간 예외 행을 `source_entity`(지급 건)로 역추적해 월을 채움. varchar 쪽으로 조인해 캐스팅 오류 없음.
3. **확정 조건 3·4를 `validation_month = vr.validation_month` 로 통일** — 부수 발견(한 체크리스트 안에서 실행/월 범위 혼재)도 함께 해소. 같은 검증월이면 실행이 달라도, 실행이 없어도(실시간) 확정을 막습니다.
4. **바로가기 링크를 월 기준으로 변경** — `/exceptions?validationMonth=YYYY-MM-01&…` (예외함이 이미 지원하는 필터). 미충족 건수와 바로가기 목록이 일치합니다.

## 시연 영향 (중요)

- 컷⑤에서 만든 한도 위반(CRITICAL)이 **해결되기 전에는 컷⑩ 확정이 422(VRUN_002)로 차단**됩니다. 이것이 제44조의 올바른 동작입니다. 시연 대본은 확정 전에 예외함에서 해당 예외를 해결(예: 감액 조치)하는 단계를 거쳐야 합니다.
- 확정 화면의 조건 3 배지가 KPI 카드 "미처리 업무건" 과 같은 기준으로 움직여 화면 내 모순이 사라집니다.

## 검증

- `ValidationRunFinalizeChecklistMapperIntegrationTest` — run_id NULL 실시간 CRITICAL/POLICY_MISSING 이 집계되고, 다른 검증월·종결 상태는 제외되는 회귀 픽스처 추가. ✅ 통과
- `CapExceptionMapperIntegrationTest` — 실시간 INSERT 후 `validation_month = 지급 정산월` 검증 추가. ✅ 통과
- `ValidationRunFinalizationServiceImplTest`·`CommissionPaymentIntegrationTest`·`ExceptionCaseQueryMapperIntegrationTest`·`CapExceptionServiceImplTest`·`CommissionPaymentServiceImplTest` ✅ 전부 통과 (Testcontainers, V41 포함 Flyway 실행 확인)

## 알려진 잔여 한계 (의도적 제외)

`ScheduleMapper.upsertPolicyReviewCase` 의 계약 단위 POLICY_* 예외(스케줄 생성 실패)는 귀속 월 개념이 없어 여전히 게이트 밖입니다 — 현행과 동일하며, 월이 없는 예외를 특정 월 확정에 귀속시킬 수 없어 제외했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)