### PR TITLE
fix(seed): STD-SAV-A 예상 해약환급률표 시드 추가 — 시연 컷③→⑧ 이음매 복구 (#332)

### DIFF
--- a/docs/FGC_정규화_입력데이터_시드데이터_명세서_v1_0.md
+++ b/docs/FGC_정규화_입력데이터_시드데이터_명세서_v1_0.md
@@ -562,6 +562,13 @@ approved_basis_ref = SYNTHETIC:COMMON-COST-POLICY-2026-001
 | STD-LIFE-B | 240개월 | FACE_TO_FACE | true |
 | STD-TERM-A | 120개월 | FACE_TO_FACE | true |
 | STD-NL-A | 240개월 | FACE_TO_FACE | false |
+| STD-SAV-A | 120개월 | FACE_TO_FACE | false |
+
+> STD-SAV-A 행은 #332 로 추가되었다(근거: REG-23 — 36개월 표·상품코드 일치).
+> §11 경계시험용 판매버전(V4) 중 CONT-W03 에서 선택 가능한 상품이 환급률표 없이
+> 남으면 등록 계약이 월 통합검증 선별에서 검토필요로 빠지기 때문이다.
+> STD-TERM-A 의 TM 채널은 §11 이 `REVIEW_REQUIRED` 를 기대값으로 명시하므로
+> 의도적으로 표를 두지 않는다.
 
 환급률은 합성값이지만 다음 조건을 만족해야 한다.
 

--- a/src/main/resources/db/demo/V42__seed_refund_rate_std_sav_a.sql
+++ b/src/main/resources/db/demo/V42__seed_refund_rate_std_sav_a.sql
@@ -1,0 +1,83 @@
+-- ============================================================================
+-- V42: STD-SAV-A 예상 해약환급률표 시드 (#332)
+--
+-- 왜: V4 가 만든 STD-SAV-A(가상 연금저축보험, FGL04) 판매버전은 CONT-W03 에서
+--     선택 가능하지만 환급률표가 없어, 등록한 계약이 월 통합검증 대상 선별에서
+--     "예상 해약환급률표 없음 → 검토필요" 로 빠진다. 발표 시연 컷③→⑧ 이음매가
+--     이 상품을 고르면 끊어진다. 경고 토스트도 없다(저해지형이 아니라서).
+--
+-- 범위: STD-SAV-A(FACE_TO_FACE)만 보강한다.
+--     STD-TERM-A 의 TM 채널은 시드데이터 명세서 §11 이 REVIEW_REQUIRED 를
+--     경계시험 기대값으로 명시하므로 **의도적으로 추가하지 않는다.**
+--
+-- 방법: 기존 INS-REFUND-2026-V1 은 ACTIVE 라 guard_policy_child_mutation 트리거가
+--     자식 행 INSERT 를 거부한다. 명세 §17 "변경본은 새 정책버전과 새 헤더로 적재"
+--     에 따라 새 정책버전을 DRAFT 로 만들어 적재 후 두 단계로 승격한다 (V3 §13 선례).
+--     환급률표 해석은 표별 policy_version_id 로 ACTIVE 를 확인하므로(uq_refund_table_scope,
+--     ProductMapper·ValidationTargetSelectionMapper) 기존 4개 표에는 영향이 없다.
+-- ============================================================================
+
+-- ① 새 정책버전 DRAFT 생성 (REG-23: 36개월 표·상품코드 일치)
+INSERT INTO policy_version(policy_code, policy_name, policy_type, source_class,
+                           version_no, effective_from, effective_to, status,
+                           regulation_refs, source_refs, approval_evidence_ref, created_by)
+SELECT 'INS-REFUND-2026-SAV-V1','예상 해약환급률표(연금저축 보강)','REFUND_RATE','INSURER_RULE',
+       1, DATE '2026-01-01', NULL,'DRAFT',
+       ARRAY['REG-23'],
+       ARRAY['원수사 예상 해약환급률표 2026'],
+       'PROJECT_ASSUMPTION — 합성값, #332 시연 커버리지 보강',
+       (SELECT user_id FROM app_user WHERE login_id='settle01')
+ WHERE NOT EXISTS (SELECT 1 FROM policy_version
+                    WHERE policy_code='INS-REFUND-2026-SAV-V1' AND version_no=1);
+
+-- ② 정책 파라미터 — V3 §12 의 INS-REFUND-2026-V1 과 같은 기준 금액 정의 (COR-004)
+INSERT INTO policy_parameter(policy_version_id, parameter_key, parameter_value, description)
+SELECT pv.policy_version_id,'REFUND_RATE_BASIS',
+       '"MONTHLY_EQUIVALENT_FIRST_PREMIUM_X12"'::jsonb,
+       '환급률(%)을 곱할 기준 금액. 월납환산 초회보험료 × 12 에 환급률을 곱해 예상 해약환급금을 구한다'
+  FROM policy_version pv
+ WHERE pv.policy_code='INS-REFUND-2026-SAV-V1' AND pv.status='DRAFT'
+ON CONFLICT DO NOTHING;
+
+-- ③ 환급률표 헤더 — 범위는 (보험사·상품·납입기간·채널·적용시작일)이다.
+--    product_offering_id 는 참고 표시일 뿐 조회 키가 아니다 (V3 §11 경고 참조).
+INSERT INTO refund_rate_table(policy_version_id, insurer_id, product_id, product_offering_id,
+                              payment_term_months, channel_code, effective_from,
+                              standard_deduction_80_yn, source_product_code, source_document_ref)
+SELECT pv.policy_version_id, p.insurer_id, p.product_id, po.product_offering_id,
+       120, po.channel_code, DATE '2026-01-01',
+       po.standard_deduction_80_yn,               -- STD-SAV-A 는 false (V4 §0)
+       p.standard_product_code, '원수사 예상 해약환급률표 2026 (합성값·#332 보강)'
+  FROM product p
+  JOIN product_offering po ON po.product_id = p.product_id
+                          AND po.offering_version = '2026-CURRENT-A'
+                          AND po.channel_code = 'FACE_TO_FACE'
+  CROSS JOIN policy_version pv
+ WHERE p.standard_product_code = 'STD-SAV-A'
+   AND pv.policy_code='INS-REFUND-2026-SAV-V1' AND pv.status='DRAFT'
+ON CONFLICT DO NOTHING;
+
+-- ④ 상세 36행 — V3 §11 과 같은 합성 곡선(일반형 m×2.9, 12차월 34.8%).
+--    0 이상 · 1~36차월 누락 없음 · 12차월 존재 (§17 조건).
+INSERT INTO refund_rate_line(refund_rate_table_id, contract_month_no, refund_rate_pct)
+SELECT rrt.refund_rate_table_id, m, (m * 2.9)::numeric(9,6)
+  FROM refund_rate_table rrt
+  JOIN policy_version pvr ON pvr.policy_version_id = rrt.policy_version_id
+  CROSS JOIN generate_series(1, 36) AS m
+ WHERE pvr.policy_code='INS-REFUND-2026-SAV-V1' AND pvr.status='DRAFT'
+ON CONFLICT DO NOTHING;
+
+-- ⑤ 승격 — DRAFT → APPROVED → ACTIVE (직행은 트리거가 막는다. 작성자/승인자 분리, REG-22)
+--    재실행 시 status 조건에 걸리는 행이 없어 아무 것도 하지 않는다.
+UPDATE policy_version pv
+   SET status='APPROVED',
+       approved_at = TIMESTAMPTZ '2026-06-30 09:00:00+09',
+       approved_by = (SELECT user_id FROM app_user WHERE login_id='gaadmin'),
+       approval_evidence_ref = '시드 승인 (GOLDEN 프로파일·#332)'
+ WHERE pv.status='DRAFT'
+   AND pv.policy_code='INS-REFUND-2026-SAV-V1';
+
+UPDATE policy_version pv
+   SET status='ACTIVE'
+ WHERE pv.status='APPROVED'
+   AND pv.policy_code='INS-REFUND-2026-SAV-V1';

--- a/src/test/java/com/susukkang/fgc/validation/mapper/ValidationTargetSelectionMapperIntegrationTest.java
+++ b/src/test/java/com/susukkang/fgc/validation/mapper/ValidationTargetSelectionMapperIntegrationTest.java
@@ -73,6 +73,49 @@ class ValidationTargetSelectionMapperIntegrationTest {
         assertThat(withoutStandardCodeEvidence).isZero();
     }
 
+    /**
+     * #332 회귀 — CONT-W03 에서 선택 가능한 STD-SAV-A(V4 경계시험 판매버전)에
+     * 환급률표 시드(V42)가 없으면 등록 계약이 "예상 해약환급률표 없음" REVIEW_REQUIRED 로
+     * 빠져 시연 컷③→⑧ 이음매가 끊어진다. 시드 추가 후 SELECTED 로 선정되는지 고정한다.
+     */
+    @Test
+    void fgc332SavContractIsSelectedWithSeededRefundRateTable() {
+        Long contractId = insertSavContract();
+        Long runId = insertValidationRun(LocalDate.of(2098, 3, 1));
+
+        mapper.insertTargets(runId, LocalDate.of(2098, 3, 1), LocalDate.of(2098, 3, 31));
+
+        var target = jdbcTemplate.queryForMap("""
+                SELECT selection_status, selection_reason, refund_rate_table_id
+                  FROM fgc.validation_target
+                 WHERE validation_run_id = ? AND contract_id = ?
+                """, runId, contractId);
+        assertThat(target.get("selection_status")).isEqualTo("SELECTED");
+        assertThat(target.get("selection_reason")).isEqualTo("월 통합검증 대상");
+        assertThat(target.get("refund_rate_table_id")).isNotNull();
+    }
+
+    private Long insertSavContract() {
+        return jdbcTemplate.queryForObject("""
+                INSERT INTO fgc.insurance_contract (
+                    insurer_id, product_offering_id, contract_no, contract_date,
+                    agent_id, organization_id, premium_per_cycle_amount,
+                    first_premium_amount, monthly_equivalent_first_premium, payment_term_months
+                )
+                SELECT p.insurer_id, po.product_offering_id, 'IT-332-SAV-0001', DATE '2098-02-15',
+                       a.agent_id, a.organization_id, 200000, 200000, 200000, 120
+                  FROM fgc.product p
+                  JOIN fgc.product_offering po ON po.product_id = p.product_id
+                                              AND po.offering_version = '2026-CURRENT-A'
+                                              AND po.channel_code = 'FACE_TO_FACE'
+                  CROSS JOIN LATERAL (
+                       SELECT agent_id, organization_id FROM fgc.agent ORDER BY agent_id LIMIT 1
+                  ) a
+                 WHERE p.standard_product_code = 'STD-SAV-A'
+                RETURNING contract_id
+                """, Long.class);
+    }
+
     @Test
     void selectsOnlySelectedContractsFromRequestedRunInContractOrder() {
         Long requestedRunId = insertValidationRun(LocalDate.of(2097, 1, 1));


### PR DESCRIPTION
Closes #332

> 기준 커밋: origin/develop `9f79925b` · 상위 #252 · QA-05(#257) E2E 실측 · QA-09(#261) 시드 분석 연계

## 원인 재진단 (이슈 본문과 다른 점)

이슈는 "시드가 일부 상품 **판매버전**에만 존재"로 적었지만, 환급률표의 스코프는 판매버전이 아니라 **(보험사·상품·납입기간·채널·적용시작일)** 입니다 (`uq_refund_table_scope`, V3 시드 주석도 동일 경고). 실측 결과 실제 누락은 2건뿐입니다.

| 판매버전 | 상태 | 판단 |
|---|---|---|
| **STD-SAV-A** × FACE_TO_FACE (V4) | 표 자체가 없음. 저해지형이 아니라 **경고 토스트도 없이** 조용히 검토필요로 빠짐 | **이번 PR 로 시드 보강** |
| STD-TERM-A × **TM** (V4) | FACE_TO_FACE 표만 있어 채널 불일치 | **의도적으로 유지** — 시드데이터 명세서 §11 이 TM 특례 채널의 `REVIEW_REQUIRED` 를 경계시험 기대값으로 명시. 선택 시 경고 토스트는 기존대로 표시됨 |

따라서 이슈 (b)안을 "전 판매버전"이 아니라 **STD-SAV-A 1건으로 좁혀** 구현했습니다.

## 변경 내용

1. **`db/demo/V42__seed_refund_rate_std_sav_a.sql`**
   - 기존 `INS-REFUND-2026-V1` 은 ACTIVE 라 `guard_policy_child_mutation` 트리거가 자식 행 추가를 거부 → 명세 §17 *"변경본은 새 정책버전과 새 헤더로 적재"* 에 따라 새 정책버전 `INS-REFUND-2026-SAV-V1` 을 DRAFT 로 만들어 헤더 1건 + 36차월 라인 적재 후 DRAFT→APPROVED→ACTIVE 두 단계 승격 (V3 §13 선례, 작성자/승인자 분리 REG-22)
   - 환급률 곡선은 V3 일반형과 동일(m×2.9, 12차월 34.8%), `REFUND_RATE_BASIS` 파라미터 동반. 전 구문 멱등(재실행 안전)
   - 기존 4개 표는 표별 `policy_version_id` 로 ACTIVE 를 확인하므로 영향 없음
2. **시드데이터 명세서 §17** — 필수 조합 표에 `STD-SAV-A · 120개월 · FACE_TO_FACE · false` 행 추가, TM 미추가 사유 각주 (근거: REG-23 — 36개월 표·상품코드 일치)
3. **선별 회귀 테스트** — STD-SAV-A 계약 등록 → `insertTargets` → `SELECTED`·`월 통합검증 대상`·환급률표 배정 검증

## 시연 영향

- 컷③에서 STD-SAV-A(가상 연금저축보험, FGL04)를 골라도 납입기간 120개월이 자동채움·잠금되고, 컷⑧ 선별에 **SELECTED** 로 포함되어 ⑨ 원장·대사까지 이어집니다.
- 기존에 검토필요였던 QA 계약 중 STD-SAV-A 상품 건은 다음 검증 실행부터 선정으로 바뀌어 선정 건수가 늘 수 있습니다(정상).
- 컷③에서 TM 판매버전은 여전히 피해야 합니다 — 명세 §11 의도이며 선택 시 경고가 표시됩니다.

## 검증 (Testcontainers, V42 포함 Flyway 실행)

- `ValidationTargetSelectionMapperIntegrationTest` — 신규 SAV 회귀 + 기존 시드 6건 선정 회귀 ✅
- `ProductMapperIntegrationTest` · `ContractMapperIntegrationTest` · `PolicyControllerTest` ✅ (드롭다운·정책 화면 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)