### PR TITLE
[Fix] 발표 전일 리허설 실측 발견 2건 — 컷⑥ 딥링크 무동작·대사 이력 UTC 표시

### DIFF
--- a/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImpl.java
+++ b/src/main/java/com/susukkang/fgc/reconciliation/service/ReconciliationRunHistoryServiceImpl.java
@@ -4,6 +4,7 @@ import com.susukkang.fgc.common.code.PaymentStage;
 import com.susukkang.fgc.common.code.ValidationRunStatus;
 import com.susukkang.fgc.common.exception.FgcBusinessException;
 import com.susukkang.fgc.common.exception.FgcErrorCode;
+import com.susukkang.fgc.common.util.DateUtil;
 import com.susukkang.fgc.common.web.PageResponse;
 import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryResponse;
 import com.susukkang.fgc.reconciliation.dto.ReconciliationRunHistoryRow;
@@ -92,9 +93,9 @@ public class ReconciliationRunHistoryServiceImpl implements ReconciliationRunHis
                 row.getInsurerId(), row.getInsurerName(),
                 row.getStatus(), status.label(),
                 row.getTolerancePolicyVersionId(),
-                row.getCreatedBy(), row.getCreatedAt(),
-                row.getStartedAt(), row.getCompletedAt(),
-                row.getFinalizedAt(), row.getFinalizedBy(),
+                row.getCreatedBy(), DateUtil.toSeoul(row.getCreatedAt()),
+                DateUtil.toSeoul(row.getStartedAt()), DateUtil.toSeoul(row.getCompletedAt()),
+                DateUtil.toSeoul(row.getFinalizedAt()), row.getFinalizedBy(),
                 row.getTargetCount(), row.getMatchedCount(), row.getExceptionCount(),
                 row.getExpectedTotal(), row.getActualTotal(), row.getDifferenceTotal(),
                 matchRatePct);

--- a/src/main/resources/static/js/features/cap/cap-list.js
+++ b/src/main/resources/static/js/features/cap/cap-list.js
@@ -135,10 +135,13 @@
    * 그 판정은 목록(latestScopedCapChecks)에서 candidate_transaction_id 조건으로 제외되므로
    * 표에서 찾아 누를 수 없다. IF-API-31(findById)은 제외 조건이 없어 팝업은 정상 동작하므로
    * 목록과 무관하게 바로 연다 — 목록이 0건이어도 계산근거는 보인다.
+   * 값은 스크립트 로드 시점에 읽어 둔다 — load()의 replaceLocation()이
+   * capCheckId 없는 URL로 재작성한 뒤에 실행되기 때문이다.
    */
+  var deepLinkCapCheckId = new URLSearchParams(window.location.search).get("capCheckId");
+
   function openDetailFromLocation() {
-    var capCheckId = new URLSearchParams(window.location.search).get("capCheckId");
-    if (capCheckId) openDetail(capCheckId);
+    if (deepLinkCapCheckId) openDetail(deepLinkCapCheckId);
   }
 
   function currentParams() {


### PR DESCRIPTION
## 배경

발표(2026-08-24) 전일 최종 리허설 — 빈 DB 리셋 → 시연 10컷 + ⑨-b + ⑩ 재실행 전 구간 실클릭 재실측(develop `f12a2ddf` 기준) — 에서 발견한 2건의 수정입니다. 상세 근거: 로컬 `qa-findings/rehearsal-2026-08-23.md`.

## 수정 1 — 컷⑥ 계산근거 딥링크가 절대 열리지 않음 (#331 후속, 시연 차단급)

- **증상**: 예외 상세 [1,200% 계산근거 열기] → `/cap-checks?capCheckId=N` 이동 후 CAP-W02 팝업 무동작. 네트워크에 `/details` 요청 자체가 없음.
- **원인**: `cap-list.js` 초기화 체인 `loadReferenceData().then(load).then(openDetailFromLocation)`에서 `load()`가 `replaceLocation()`으로 URL을 `?month=…&page=…`로 재작성해 **capCheckId를 먼저 지운 뒤** `openDetailFromLocation()`이 URL을 읽음 — 간헐 레이스가 아닌 결정적 순서 버그(#331/#333 머지 시점부터 항상 무동작).
- **수정**: 스크립트 로드 시점에 `deepLinkCapCheckId`를 캡처해 사용 (2줄).
- **실측**: 수정 후 목록 0건 상태에서도 팝업 정상 — 4단 구조, 항목별 산입 내역 8건(#335), 합계 1,250,000원 일치·경고 없음, REG-06A·06C·REG-20 근거 표기.

## 수정 2 — RECO-W01 실행 이력 시각 UTC 표시 (SIR-008)

- **증상**: 대사 실행 이력의 시작·완료가 05:52로 표시(실제 14:52 KST). DB는 `+09`로 정상 저장.
- **원인**: `ReconciliationRunHistoryServiceImpl`만 `DateUtil.toSeoul()` 변환 누락 — exception(`ExceptionCaseResponseDTO`)·validation(`ValidationRunItemResponse`) 응답은 모두 변환 적용 중.
- **수정**: createdAt·startedAt·completedAt·finalizedAt 4필드에 기존 패턴 그대로 `DateUtil.toSeoul()` 적용.
- **실측**: 수정 후 15:02·14:52 KST 정상 표시.

## 검증

- 전체 테스트 스위트 **BUILD SUCCESSFUL** (수정 적용 후 재실행, 2m53s)
- 리셋 → 10컷 리허설에서 두 수정 모두 실클릭 실측 확인, 콘솔 에러 0건

## 시연 영향

**발표 전 머지 필수** — 미머지 빌드로 시연 시 컷⑥ 팝업이 열리지 않고, 컷⑨ 대사 이력 시각이 9시간 이르게 표시됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)