### PR TITLE
[Fix] 대시보드 최근 목록·감사로그 시각 UTC 표시 — Asia/Seoul 변환 누락 3개 DTO (SIR-008)

### DIFF
--- a/src/main/java/com/susukkang/fgc/audit/dto/AuditLogResponse.java
+++ b/src/main/java/com/susukkang/fgc/audit/dto/AuditLogResponse.java
@@ -1,5 +1,6 @@
 package com.susukkang.fgc.audit.dto;
 
+import com.susukkang.fgc.common.util.DateUtil;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.OffsetDateTime;
@@ -40,7 +41,7 @@ public record AuditLogResponse(
     public static AuditLogResponse from(AuditLogRow row) {
         return new AuditLogResponse(
                 row.auditLogId(),
-                row.occurredAt(),
+                DateUtil.toSeoul(row.occurredAt()),
                 row.userId(),
                 row.userLoginId(),
                 row.actionCode(),

--- a/src/main/java/com/susukkang/fgc/dashboard/dto/RecentExceptionResponse.java
+++ b/src/main/java/com/susukkang/fgc/dashboard/dto/RecentExceptionResponse.java
@@ -3,6 +3,7 @@ package com.susukkang.fgc.dashboard.dto;
 import com.susukkang.fgc.common.code.ExceptionSeverity;
 import com.susukkang.fgc.common.code.ExceptionStatus;
 import com.susukkang.fgc.common.code.ExceptionType;
+import com.susukkang.fgc.common.util.DateUtil;
 
 import java.time.OffsetDateTime;
 
@@ -35,7 +36,7 @@ public record RecentExceptionResponse(
                 row.title(),
                 row.status(),
                 ExceptionStatus.valueOf(row.status()).label(),
-                row.createdAt()
+                DateUtil.toSeoul(row.createdAt())
         );
     }
 }

--- a/src/main/java/com/susukkang/fgc/dashboard/dto/RecentValidationRunResponse.java
+++ b/src/main/java/com/susukkang/fgc/dashboard/dto/RecentValidationRunResponse.java
@@ -1,6 +1,7 @@
 package com.susukkang.fgc.dashboard.dto;
 
 import com.susukkang.fgc.common.code.ValidationRunStatus;
+import com.susukkang.fgc.common.util.DateUtil;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -35,9 +36,9 @@ public record RecentValidationRunResponse(
                 ValidationRunStatus.valueOf(row.status()).label(),
                 row.currentStep(),
                 row.triggeredBy(),
-                row.startedAt(),
-                row.completedAt(),
-                row.finalizedAt(),
+                DateUtil.toSeoul(row.startedAt()),
+                DateUtil.toSeoul(row.completedAt()),
+                DateUtil.toSeoul(row.finalizedAt()),
                 row.finalizedBy(),
                 row.failureMessage()
         );


### PR DESCRIPTION
## 배경

예외함 심층 QA(2026-08-23, develop `96c543c2` 기준 리허설 2회차)에서 발견한 **#346(RECO-W01)과 같은 계열**의 시간대 표시 결함 수정입니다.

## 증상

서버 렌더(Thymeleaf `#temporals.format`) 템플릿에 시간대 미변환 `OffsetDateTime`이 내려가 **9시간 이른 시각(UTC)** 으로 표시:

| 화면 | 필드 | 실측 |
|---|---|---|
| DASH-W01 최근 예외 | `RecentExceptionResponse.createdAt` | 06:59 표시 (실제 15:59 KST) |
| DASH-W01 최근 통합검증 실행 | `RecentValidationRunResponse.startedAt·completedAt·finalizedAt` | 동일 계열 |
| AUDT-W01 감사로그 | `AuditLogResponse.occurredAt` | 06:5x 표시 — **감사 증적 시각 직결** |

DB는 `+09`로 정상 저장되어 있고, 표시 계층만의 문제입니다.

## 수정

exception·validation 응답 DTO와 동일한 기존 패턴(`DateUtil.toSeoul()`)을 3개 DTO의 `from()` 조립부에 적용 (8줄).

## 계열 전수 스윕

시간(HH:mm)을 서버 렌더하는 템플릿 전수(6곳: audit·dashboard·exception·reco·vrun list/detail)를 DTO 변환 여부와 대조 — exception 계열·vrun 계열은 변환 기존 적용, reco는 #346에서 수정, dashboard·audit은 본 PR로 수정. **잔여 누락 0건.**

## 검증

- 전체 테스트 스위트 BUILD SUCCESSFUL (1m38s)
- 수정 후 실측: 대시보드 15:59/15:55/15:54 · 감사로그 16:03 등 KST 정상 표시

## 시연 영향

리셋 직후 대시보드는 빈 목록이라 컷②에는 직접 노출되지 않지만, 워밍업 실행 후 또는 시연 중 대시보드 재방문 시 노출됩니다. 감사로그 화면은 준법·감사 역할 시연 시 직결.

🤖 Generated with [Claude Code](https://claude.com/claude-code)