### PR TITLE
[Fix] 계약 생성시 상태변경이력 동기화 안되는 버그 수정

### DIFF
--- a/src/main/java/com/susukkang/fgc/contract/mapper/ContractStatusEventMapper.java
+++ b/src/main/java/com/susukkang/fgc/contract/mapper/ContractStatusEventMapper.java
@@ -2,10 +2,12 @@ package com.susukkang.fgc.contract.mapper;
 
 import com.susukkang.fgc.contract.dto.ContractStatusEventProcessingRow;
 import com.susukkang.fgc.contract.dto.ContractStatusEventRow;
+import com.susukkang.fgc.contract.code.ContractStatus;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
+import java.time.OffsetDateTime;
 
 /**
  * 설명 : 계약 상태 사건 Mapper
@@ -16,6 +18,13 @@ import java.util.List;
  */
 @Mapper
 public interface ContractStatusEventMapper {
+
+    int insertInitialEvent(
+            @Param("contractId") Long contractId,
+            @Param("newStatus") ContractStatus newStatus,
+            @Param("effectiveAt") OffsetDateTime effectiveAt,
+            @Param("receivedAt") OffsetDateTime receivedAt
+    );
 
     List<ContractStatusEventRow> selectByContractId(@Param("contractId") Long contractId);
 

--- a/src/main/java/com/susukkang/fgc/contract/service/ContractService.java
+++ b/src/main/java/com/susukkang/fgc/contract/service/ContractService.java
@@ -25,6 +25,7 @@ import org.springframework.validation.annotation.Validated;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -201,7 +202,21 @@ public class ContractService {
             calculateCapCheckOrRegisterReview(contractId, paymentStage, command);
         }
 
-        // TODO(FUN-026, 2차): 계약 생성 상태 사건 이력을 등록한다.
+        // 계약 상세의 상태 변경 이력에서 생성 당시의 최초 상태도 확인할 수 있도록
+        // 계약일을 효력일로 하는 event_seq=1 사건을 같은 트랜잭션에 남긴다.
+        OffsetDateTime receivedAt = DateUtil.nowSeoul();
+        OffsetDateTime effectiveAt = request.getContractDate()
+                .atStartOfDay(DateUtil.SEOUL_ZONE)
+                .toOffsetDateTime();
+        int insertedStatusEvents = contractStatusEventMapper.insertInitialEvent(
+                contractId,
+                request.getContractStatus(),
+                effectiveAt,
+                receivedAt
+        );
+        if (insertedStatusEvents != 1) {
+            throw new FgcBusinessException(FgcErrorCode.COMMON_500);
+        }
 
         auditLogService.record(AuditLogService.AuditEvent.builder()
                 .actionCode(AUDIT_CONTRACT_CREATED)

--- a/src/main/resources/mapper/contract/ContractStatusEventMapper.xml
+++ b/src/main/resources/mapper/contract/ContractStatusEventMapper.xml
@@ -5,6 +5,17 @@
 
 <mapper namespace="com.susukkang.fgc.contract.mapper.ContractStatusEventMapper">
 
+    <insert id="insertInitialEvent">
+        INSERT INTO fgc.contract_status_event
+            (contract_id, event_seq, previous_status, new_status,
+             effective_at, received_at, reason_code,
+             source_system, source_event_key, data_origin)
+        VALUES
+            (#{contractId}, 1, NULL, #{newStatus},
+             #{effectiveAt}, #{receivedAt}, 'NEW_CONTRACT',
+             'FGC_MANUAL', CONCAT('CONTRACT_CREATED:', #{contractId}), 'MANUAL')
+    </insert>
+
     <select id="selectByContractId"
             resultType="com.susukkang.fgc.contract.dto.ContractStatusEventRow">
         SELECT contract_status_event_id,

--- a/src/test/java/com/susukkang/fgc/contract/service/ContractServiceTest.java
+++ b/src/test/java/com/susukkang/fgc/contract/service/ContractServiceTest.java
@@ -226,6 +226,7 @@ class ContractServiceTest {
                 .willReturn(new ScheduleGenerationResult(List.of(100L, 101L), 3));
         given(scheduleService.hasActiveOperationalSchedule(21L, PaymentStage.INSURER_TO_GA)).willReturn(true);
         given(scheduleService.hasActiveOperationalSchedule(21L, PaymentStage.GA_TO_FC)).willReturn(true);
+        given(contractStatusEventMapper.insertInitialEvent(any(), any(), any(), any())).willReturn(1);
 
         ContractCreateResponse response = contractService.createContract(request);
 
@@ -239,6 +240,17 @@ class ContractServiceTest {
         assertThat(saved.getDataOrigin()).isEqualTo(DataOrigin.MANUAL);
         assertThat(response.contractId()).isEqualTo(21L);
         assertThat(response.scheduleHeaderIds()).containsExactly(100L, 101L);
+        ArgumentCaptor<OffsetDateTime> effectiveAtCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+        verify(contractStatusEventMapper).insertInitialEvent(
+                org.mockito.ArgumentMatchers.eq(21L),
+                org.mockito.ArgumentMatchers.eq(ACTIVE),
+                effectiveAtCaptor.capture(),
+                any(OffsetDateTime.class)
+        );
+        assertThat(effectiveAtCaptor.getValue())
+                .isEqualTo(request.getContractDate()
+                        .atStartOfDay(com.susukkang.fgc.common.util.DateUtil.SEOUL_ZONE)
+                        .toOffsetDateTime());
         verify(scheduleService).generateSchedules(saved);
         ArgumentCaptor<CapCalculationCommand> capCaptor =
                 ArgumentCaptor.forClass(CapCalculationCommand.class);


### PR DESCRIPTION
# 📌 Pull Request

## 📖 1. 변경 사항 요약

* 계약 생성 시 최초 계약 상태가 상태 변경 이력에 기록되도록 개선했습니다.

## 🔗 2. 관련 이슈

* Closes #이슈번호

## 🛠 3. 구현 내용

* 계약 생성 시 `contract_status_event`에 최초 상태 이력을 함께 저장합니다.
* 최초 이력은 `event_seq=1`, `previous_status=NULL`, `reason_code=NEW_CONTRACT`로 기록합니다.
* 효력 일시는 계약일 00시, 수신 일시는 계약 생성 시각을 서울 시간 기준으로 저장합니다.
* 계약과 상태 이력을 동일한 트랜잭션에서 저장하여 이력 저장 실패 시 계약 생성도 롤백합니다.
* 서비스 테스트에서 최초 상태와 효력 일시가 정상 전달되는지 검증합니다.

## 🧪 4. 테스트 방법

1. 신규 계약을 생성합니다.
2. 생성한 계약의 상세보기로 이동합니다.
3. 우측 패널의 계약 상태 변경 이력에 최초 계약 상태가 표시되는지 확인합니다.
4. 아래 테스트를 실행해 정상 통과하는지 확인합니다.

```bash
./gradlew test \
  --tests "com.susukkang.fgc.contract.service.ContractServiceTest" \
  --tests "com.susukkang.fgc.contract.mapper.ContractStatusEventMapperIntegrationTest"
```

## 🗄️ 5. DB / Flyway 변경

* [x] DB 변경 없음
* [ ] 새로운 Flyway 마이그레이션 파일 추가
* [ ] 시드 데이터 변경
* [ ] 기존 데이터에 영향을 줄 수 있음

### 추가된 마이그레이션 파일

* 없음

## 📋 6. 리뷰 요구사항

* 계약 생성과 최초 상태 이력 저장이 동일한 트랜잭션에서 처리되는지 확인 부탁드립니다.
* 최초 이력의 효력 일시와 `source_system`, `source_event_key` 설정이 적절한지 확인 부탁드립니다.

## ✅ 7. 체크리스트

* [ ] `develop` 최신 내용을 반영했습니다.
* [x] 로컬 빌드에 성공했습니다.
* [ ] 애플리케이션 실행을 확인했습니다.
* [ ] 관련 기능을 직접 테스트했습니다.
* [x] 테스트 코드가 필요한 경우 작성했습니다.
* [x] 기존 기능에 영향이 없는지 확인했습니다.
* [ ] 커밋 메시지 컨벤션을 준수했습니다.
* [x] 민감정보를 커밋하지 않았습니다.
* [x] 기존 Flyway 마이그레이션 파일을 수정하지 않았습니다.
* [x] 불필요한 주석과 디버깅 코드를 제거했습니다.

## 🖼️ 8. 화면 변경

* 없음

## 💬 9. 참고 사항

* 기존 계약에는 최초 상태 이력이 소급 생성되지 않으며, 변경 이후 새로 생성되는 계약부터 적용됩니다.
* 관련 단위 및 매퍼 테스트 20개가 모두 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 계약 생성 시 최초 계약 상태 이벤트가 자동으로 기록됩니다.
  * 초기 이벤트에 계약 상태, 계약일 기준 효력 시각, 접수 시각이 반영됩니다.
  * 계약 생성과 초기 상태 이벤트 기록이 함께 처리되어 일관성이 보장됩니다.

* **버그 수정**
  * 초기 상태 이벤트가 누락되던 문제를 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->